### PR TITLE
STB-1452-Implement-dynamic-apps-using-app-roles

### DIFF
--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/config/GraphClientConfig.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/config/GraphClientConfig.java
@@ -3,8 +3,12 @@ package uk.gov.justice.laa.portal.landingpage.config;
 import com.azure.identity.ClientSecretCredential;
 import com.azure.identity.ClientSecretCredentialBuilder;
 import com.microsoft.graph.serviceclient.GraphServiceClient;
+import com.microsoft.kiota.authentication.AuthenticationProvider;
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Scope;
 
 /**
  * Config file for graph client api
@@ -22,6 +26,7 @@ public class GraphClientConfig {
      * @return Usable and authenticated Graph Client
      */
     @Bean
+    @Primary
     public static GraphServiceClient getGraphClient() {
 
         // Create secret
@@ -32,5 +37,20 @@ public class GraphClientConfig {
 
         return new GraphServiceClient(credential, scopes);
     }
+
+    /**
+     * Get the GraphApiClient using access token
+     * @param accessToken the access token
+     * @return the Graph service client
+     */
+    @Bean(name = "graphicServiceClientByAccessToken")
+    @Scope(BeanDefinition.SCOPE_PROTOTYPE)
+    public static GraphServiceClient getGraphClientByAccessToken(String accessToken) {
+
+        AuthenticationProvider authProvider = new TokenAuthAccessProvider(accessToken);
+
+        return new GraphServiceClient(authProvider);
+    }
+
 }
 

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/config/TokenAuthAccessProvider.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/config/TokenAuthAccessProvider.java
@@ -1,0 +1,33 @@
+package uk.gov.justice.laa.portal.landingpage.config;
+
+import com.microsoft.kiota.RequestInformation;
+import com.microsoft.kiota.authentication.AuthenticationProvider;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Map;
+
+/**
+ * Auth provider (using access token) class for creating graph api client.
+ */
+public class TokenAuthAccessProvider implements AuthenticationProvider {
+
+    private static final String AUTHORIZATION_HEADER_NAME = "Authorization";
+    private static final String OAUTH_BEARER_PREFIX = "Bearer ";
+    private final String accessToken;
+
+    public TokenAuthAccessProvider(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    @Override
+    public void authenticateRequest(@NotNull RequestInformation request, @Nullable Map<String, Object> additionalAuthenticationContext) {
+
+        if (request.headers.containsKey(AUTHORIZATION_HEADER_NAME)) {
+            // Found an existing authorization header so don't add another
+            return;
+        }
+
+        request.headers.add(AUTHORIZATION_HEADER_NAME, OAUTH_BEARER_PREFIX + accessToken);
+    }
+}

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/LoginController.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/LoginController.java
@@ -77,6 +77,7 @@ public class LoginController {
                 model.addAttribute("user", userSessionData.getUser());
                 model.addAttribute("lastLogin", userSessionData.getLastLogin());
                 model.addAttribute("laaApplications", userSessionData.getLaaApplications());
+                model.addAttribute("userAppsAndRoles", userSessionData.getUserAppsAndRoles());
             } else {
                 logger.info("No access token found");
             }

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/model/LaaApplication.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/model/LaaApplication.java
@@ -1,10 +1,13 @@
 package uk.gov.justice.laa.portal.landingpage.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.microsoft.graph.models.AppRole;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import java.util.Set;
 
 /**
  * Model class representing Laa Applications
@@ -24,4 +27,6 @@ public class LaaApplication {
     private String description;
     @JsonProperty(index = 4)
     private String url;
+    @JsonProperty(index = 5)
+    private Set<AppRole> role;
 }

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/model/UserSessionData.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/model/UserSessionData.java
@@ -23,4 +23,5 @@ public class UserSessionData {
     private User user;
     private String lastLogin;
     private List<LaaApplication> laaApplications;
+    private List<LaaApplication> userAppsAndRoles;
 }

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/service/LaaAppDetailsStore.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/service/LaaAppDetailsStore.java
@@ -1,9 +1,9 @@
 package uk.gov.justice.laa.portal.landingpage.service;
 
-import com.microsoft.graph.models.Application;
 import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.fasterxml.jackson.dataformat.csv.CsvSchema;
+import com.microsoft.graph.models.Application;
 import org.springframework.stereotype.Component;
 import uk.gov.justice.laa.portal.landingpage.model.LaaApplication;
 import uk.gov.justice.laa.portal.landingpage.utils.HashUtil;
@@ -30,6 +30,14 @@ public class LaaAppDetailsStore {
         return laaApplications.stream().filter(app -> registeredApps.stream()
                         .map(Application::getAppId).anyMatch(resId -> HashUtil.sha256(resId).equals(app.getId())))
                 .collect(Collectors.toList());
+    }
+
+    public static void populateAppDetails(LaaApplication application) {
+        LaaApplication laaMeta = laaApplications.stream().filter(app -> app.getId().equals(HashUtil.sha256(application.getId()))).findFirst().orElse(application);
+        application.setDescription(laaMeta.getDescription());
+        application.setUrl(laaMeta.getUrl());
+        application.setTitle(laaMeta.getTitle());
+        application.setOidGroupName(laaMeta.getOidGroupName());
     }
 
     @PostConstruct

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/service/LoginService.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/service/LoginService.java
@@ -105,8 +105,9 @@ public class LoginService {
         }
 
         List<LaaApplication> managedAppRegistrations = userService.getManagedAppRegistrations();
+        List<LaaApplication> userAppsAndRoles = graphApiService.getUserAppsAndRoles(tokenValue);
 
         return new UserSessionData(name, tokenValue, appRoleAssignments,
-                userAppRoleAssignments, user, formattedLastLogin, managedAppRegistrations);
+                userAppRoleAssignments, user, formattedLastLogin, managedAppRegistrations, userAppsAndRoles);
     }
 }

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/utils/RestUtils.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/utils/RestUtils.java
@@ -1,0 +1,31 @@
+package uk.gov.justice.laa.portal.landingpage.utils;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Optional;
+
+/**
+ * Utility class for making rest calls
+ */
+public class RestUtils {
+
+    public static final String EMPTY_STRING = "";
+
+    public static String callGraphApi(String accessToken, String url) {
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + accessToken);
+        headers.set("Accept", "application/json");
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+        ResponseEntity<String> response = restTemplate.exchange(
+                url, HttpMethod.GET, entity, String.class);
+
+        return Optional.ofNullable(response.getBody()).orElse(EMPTY_STRING);
+    }
+
+}

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/service/GraphApiServiceTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/service/GraphApiServiceTest.java
@@ -130,7 +130,7 @@ public class GraphApiServiceTest {
             List<LaaApplication> results = service.getUserAppsAndRoles("token");
             assertThat(results).isNotEmpty();
             assertThat(results.size()).isEqualTo(1);
-            LaaApplication result = results.get(0);
+            LaaApplication result = results.getFirst();
             assertThat(result.getId()).isEqualTo("870c4f2e-85b6-4d43-bdda-6ed9a579b725");
             assertThat(result.getTitle()).isEqualTo("App One");
 

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/service/GraphApiServiceTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/service/GraphApiServiceTest.java
@@ -1,0 +1,143 @@
+package uk.gov.justice.laa.portal.landingpage.service;
+
+import com.microsoft.graph.models.AppRole;
+import com.microsoft.graph.models.ServicePrincipal;
+import com.microsoft.graph.serviceclient.GraphServiceClient;
+import com.microsoft.graph.serviceprincipals.ServicePrincipalsRequestBuilder;
+import com.microsoft.graph.serviceprincipals.getbyids.GetByIdsPostRequestBody;
+import com.microsoft.graph.serviceprincipals.getbyids.GetByIdsPostResponse;
+import com.microsoft.graph.serviceprincipals.getbyids.GetByIdsRequestBuilder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.util.ReflectionTestUtils;
+import uk.gov.justice.laa.portal.landingpage.model.LaaApplication;
+import uk.gov.justice.laa.portal.landingpage.utils.RestUtils;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test class for exercising Graph Api Service Client
+ */
+@ExtendWith(MockitoExtension.class)
+public class GraphApiServiceTest {
+
+    private static final String APP_ROLE_ASSIGNMENT =
+            "{\"@odata.context\": \"https://graph.microsoft.com/v1.0/$metadata#appRoleAssignments\","
+            + "\"value\": [ {"
+            + "\"id\": \"hxjTSK1fc02p9Tw1bmigOH5fJdqoSSNInDHAF7MOyaA\","
+            + "\"deletedDateTime\": null,"
+            + "\"appRoleId\": \"8b2071cd-015a-4025-8052-1c0dba2d3f64\","
+            + "\"createdDateTime\": \"2017-07-31T17:45:18.9559566Z\","
+            + "\"principalDisplayName\": \"Megan Bowen\","
+            + "\"principalId\": \"48d31887-5fad-4d73-a9f5-3c356e68a038\","
+            + "\"principalType\": \"User\","
+            + "\"resourceDisplayName\": \"MOD Demo Platform UnifiedApiConsumer\","
+            + "\"resourceId\": \"b7dc5c41-68a7-4416-ad5d-14a887f1c665\" }]}";
+    @Mock
+    private GraphServiceClient client;
+    @Mock
+    private ServicePrincipalsRequestBuilder servicePrincipalsRequestBuilder;
+    @Mock
+    private GetByIdsPostResponse getByIdsPostResponse;
+    @Mock
+    private GetByIdsRequestBuilder getByIdsRequestBuilder;
+    @Mock
+    private ApplicationContext context;
+    @InjectMocks
+    private GraphApiService service;
+
+    @BeforeAll
+    public static void init() {
+        // Test data for app registrations in local store
+        LaaApplication laaApp1 = LaaApplication.builder().id("a36da3a3bfb6ba026c255cc64a68f87f527bf11dbfc9e4b94730f78e977c0a4f").title("App One").build();
+        LaaApplication laaApp2 = LaaApplication.builder().id("b21b9c1a0611a09a0158d831b765ffe6ded9103a1ecdbc87c706c4ce44d07be7").title("App Two").build();
+        LaaApplication laaApp3 = LaaApplication.builder().id("a32d05f19e64840bf256a7128483db941410e4f86bae5c1d4a03c9514c2266a4").title("App Two").build();
+        List<LaaApplication> laaApplications = List.of(laaApp1, laaApp2, laaApp3);
+        ReflectionTestUtils.setField(LaaAppDetailsStore.class, "laaApplications", laaApplications);
+    }
+
+    @AfterAll
+    public static void tearDown() {
+        ReflectionTestUtils.setField(LaaAppDetailsStore.class, "laaApplications", null);
+    }
+
+    @Test
+    public void testGetUserAppsAndRolesNoAppRoleAssignments() {
+        try (MockedStatic<RestUtils> mockedStatic = mockStatic(RestUtils.class)) {
+            mockedStatic.when(() -> RestUtils.callGraphApi(anyString(), anyString())).thenReturn("");
+
+            assertThat(service.getUserAppsAndRoles("")).isEmpty();
+        }
+    }
+
+    @Test
+    public void testGetUserAppsAndRolesNoServicePrinciples() {
+        try (MockedStatic<RestUtils> mockedStatic = mockStatic(RestUtils.class)) {
+            mockedStatic.when(() -> RestUtils.callGraphApi(anyString(), anyString()))
+                    .thenReturn(APP_ROLE_ASSIGNMENT)
+                    .thenReturn("");
+            when(client.servicePrincipals()).thenReturn(servicePrincipalsRequestBuilder);
+            when(servicePrincipalsRequestBuilder.getByIds()).thenReturn(getByIdsRequestBuilder);
+            when(getByIdsRequestBuilder.post(any(GetByIdsPostRequestBody.class))).thenReturn(getByIdsPostResponse);
+            when(getByIdsPostResponse.getValue()).thenReturn(null);
+            Mockito.mock(GraphServiceClient.class, RETURNS_DEEP_STUBS);
+            when(context.getBean(anyString(), anyString())).thenReturn(client);
+
+
+            assertThat(service.getUserAppsAndRoles("")).isEmpty();
+        }
+    }
+
+    @Test
+    public void testGetUserAppsAndRole() {
+
+        ServicePrincipal servicePrincipal = new ServicePrincipal();
+        servicePrincipal.setId("b7dc5c41-68a7-4416-ad5d-14a887f1c665");
+        servicePrincipal.setAppId("870c4f2e-85b6-4d43-bdda-6ed9a579b725");
+        AppRole appRole = new AppRole();
+        appRole.setId(UUID.fromString("8b2071cd-015a-4025-8052-1c0dba2d3f64"));
+        servicePrincipal.setAppRoles(List.of(appRole));
+
+        try (MockedStatic<RestUtils> mockedStatic = mockStatic(RestUtils.class)) {
+            mockedStatic.when(() -> RestUtils.callGraphApi(anyString(), anyString()))
+                    .thenReturn(APP_ROLE_ASSIGNMENT)
+                    .thenReturn("");
+            when(client.servicePrincipals()).thenReturn(servicePrincipalsRequestBuilder);
+            when(servicePrincipalsRequestBuilder.getByIds()).thenReturn(getByIdsRequestBuilder);
+            when(getByIdsRequestBuilder.post(any(GetByIdsPostRequestBody.class))).thenReturn(getByIdsPostResponse);
+            when(getByIdsPostResponse.getValue()).thenReturn(List.of(servicePrincipal));
+            Mockito.mock(GraphServiceClient.class, RETURNS_DEEP_STUBS);
+            when(context.getBean(anyString(), anyString())).thenReturn(client);
+
+
+            List<LaaApplication> results = service.getUserAppsAndRoles("token");
+            assertThat(results).isNotEmpty();
+            assertThat(results.size()).isEqualTo(1);
+            LaaApplication result = results.get(0);
+            assertThat(result.getId()).isEqualTo("870c4f2e-85b6-4d43-bdda-6ed9a579b725");
+            assertThat(result.getTitle()).isEqualTo("App One");
+
+            Set<AppRole> appRoles = result.getRole();
+            assertThat(appRoles).isNotEmpty();
+            AppRole role = appRoles.iterator().next();
+            assertThat(role.getId()).isEqualTo(appRole.getId());
+        }
+    }
+}


### PR DESCRIPTION
This PR will provide the ability to load the user applications and the corresponding user specific roles and render them on landing page. As not many of us configured for user role access, it may not show many apps on the landing page when run locally. So the application list is stored in user session for now and not implemented the rendering. It can be easily done near future once we get the apps setup with user roles for most of us.