### PR TITLE
STB-1306 - ZAP Scan support for laa-landing-page

### DIFF
--- a/.github/workflows/zap_dast_daily_dev.yml
+++ b/.github/workflows/zap_dast_daily_dev.yml
@@ -20,14 +20,6 @@ jobs:
           cmd_options: '-a -j'
           fail_action: false
 
-      - name: Slack notification
-        uses: slackapi/slack-github-action@v1.23.0
-        with:
-            channel-id: 'laa-zap-scan-notifications'
-            slack-message: "Zap daily baseline scan has been run, please review the results here: https://github.com/ministryofjustice/laa-landing-page/issues"
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.HMPPS_SLACK_BOT_TOKEN }}
-
       - name: Upload ZAP Daily Baseline Run Report
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/zap_dast_daily_dev.yml
+++ b/.github/workflows/zap_dast_daily_dev.yml
@@ -1,0 +1,37 @@
+name: ZAP DAST Daily Baseline Scan
+
+on:
+  workflow_dispatch:
+  push :
+  schedule:
+    - cron: '0 8 * * 1-5'
+
+jobs:
+  zap_scan:
+    name: Run ZAP DAST Daily Baseline Scan Against Live App
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Run ZAP Daily Baseline Scan
+        id: baseline_run
+        uses: zaproxy/action-baseline@v0.14.0
+        with:
+          target: 'https://laa-landing-page-dev.apps.live.cloud-platform.service.justice.gov.uk/'
+          cmd_options: '-a -j'
+          fail_action: false
+
+      - name: Slack notification
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+            channel-id: 'laa-zap-scan-notifications'
+            slack-message: "Zap daily baseline scan has been run, please review the results here: https://github.com/ministryofjustice/laa-landing-page/issues"
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.HMPPS_SLACK_BOT_TOKEN }}
+
+      - name: Upload ZAP Daily Baseline Run Report
+        uses: actions/upload-artifact@v4
+        with:
+          name: daily-zap-report
+          path: |
+            daily_report_html.html
+            daily_report_json.json

--- a/.github/workflows/zap_dast_weekly_test.yml
+++ b/.github/workflows/zap_dast_weekly_test.yml
@@ -1,0 +1,35 @@
+name: ZAP DAST Weeky Full Scan
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 8 * * SUN'
+
+jobs:
+  zap_scan:
+    name: Run Full ZAP DAST Scan Against Live App
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Run ZAP Weekly Full Scan
+        uses: zaproxy/action-full-scan@v0.12.0
+        with:
+          target: 'https://laa-landing-page-dev.apps.live.cloud-platform.service.justice.gov.uk/'
+          cmd_options: '-a -j -m 120'
+          fail_action: false
+
+      - name: Slack notification
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+            channel-id: 'laa-zap-scan-notifications'
+            slack-message: "Zap Weekly Full scan has been run, please review the results here: https://github.com/ministryofjustice/laa-landing-page/issues"
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.HMPPS_SLACK_BOT_TOKEN }}
+
+      - name: Upload Weekly Scan ZAP Report
+        uses: actions/upload-artifact@v4
+        with:
+          name: weekly-zap-report
+          path: |
+            weekly_report_html.html
+            weekly_report_json.json

--- a/.github/workflows/zap_dast_weekly_test.yml
+++ b/.github/workflows/zap_dast_weekly_test.yml
@@ -18,14 +18,6 @@ jobs:
           cmd_options: '-a -j -m 120'
           fail_action: false
 
-      - name: Slack notification
-        uses: slackapi/slack-github-action@v1.23.0
-        with:
-            channel-id: 'laa-zap-scan-notifications'
-            slack-message: "Zap Weekly Full scan has been run, please review the results here: https://github.com/ministryofjustice/laa-landing-page/issues"
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.HMPPS_SLACK_BOT_TOKEN }}
-
       - name: Upload Weekly Scan ZAP Report
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
ZAP Scan support has been added. Two git workflows added to run a daily baseline scan and a weekly full scan. A report will be generated if there are any issues and corresponding Github issue gets created. A slack notification is sent to notify the channel subscribers.

All these changes are created from zap-dast-test branch. Below is the screenshot of Slack notificaiton


<img width="965" alt="Screenshot 2025-05-06 at 16 46 12" src="https://github.com/user-attachments/assets/91bd5e05-aa12-4f3f-afc4-7798e6a0adbe" />
