### PR TITLE
STB-1536 - Removed redundant dependency declaration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '3.4.5'
-    id 'io.spring.dependency-management' version '1.1.7'
-    id 'java'
-    id 'uk.gov.laa.ccms.springboot.laa-ccms-spring-boot-gradle-plugin' version '0.0.25'
+    id 'uk.gov.laa.ccms.springboot.laa-ccms-spring-boot-gradle-plugin' version '0.0.32'
     id "io.sentry.jvm.gradle" version "5.5.0"
 }
 
@@ -29,7 +26,6 @@ sentry {
 }
 
 dependencies {
-    implementation 'org.springframework.security:spring-security-crypto:6.3.9'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'


### PR DESCRIPTION
Removed redundant dependency declaration. The dependant library version numbers are now pulled from common location.