### PR TITLE
STB-1685: Update attribute name so the roles list is displayed on UI

### DIFF
--- a/src/main/resources/templates/add-user-roles.html
+++ b/src/main/resources/templates/add-user-roles.html
@@ -21,7 +21,7 @@
                     Select the roles required within the
                 </p>
                 <div class="govuk-checkboxes" data-module="govuk-checkboxes">
-                    <div class="govuk-checkboxes__item" th:each="role : ${userAppRoles}"
+                    <div class="govuk-checkboxes__item" th:each="role : ${roles}"
                         th:id="'role-' + ${role.appRoleId}">
                         <input class="govuk-checkboxes__input" id="selectedRoles" name="selectedRoles"
                             th:checked="${role.selected}" th:value="${role.appRoleId}" type="checkbox">


### PR DESCRIPTION
The user role assignment page is not showing any roles because a different attribute is set compared to what is being used on template. Fixed it by adjusting the attribute name.