### PR TITLE
STB-1688: Fixed user pagination

### DIFF
--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
@@ -54,21 +54,16 @@ public class UserController {
     public String displayAllUsers(
             @RequestParam(defaultValue = "10") int size,
             @RequestParam(defaultValue = "1") int page,
-            @RequestParam(required = false) String nextPageLink,
-            Model model, HttpSession session) {
+            Model model) {
 
-        Stack<String> pageHistory = userService.getPageHistory(session);
-
-        PaginatedUsers paginatedUsers = userService.getPaginatedUsersWithHistory(pageHistory, size, nextPageLink);
+        PaginatedUsers paginatedUsers = userService.getPaginatedUsers(page, size);
 
         model.addAttribute("users", paginatedUsers.getUsers());
-        model.addAttribute("nextPageLink", paginatedUsers.getNextPageLink());
-        model.addAttribute("previousPageLink", paginatedUsers.getPreviousPageLink());
-        model.addAttribute("pageSize", size);
-        model.addAttribute("pageHistory", pageHistory);
+        model.addAttribute("requestedPageSize", size);
+        model.addAttribute("actualPageSize", paginatedUsers.getUsers().size());
         model.addAttribute("page", page);
         model.addAttribute("totalUsers", paginatedUsers.getTotalUsers());
-        model.addAttribute("totalPages", paginatedUsers.getTotalPages());
+        model.addAttribute("totalPages", paginatedUsers.getTotalPages(size));
 
         return "users";
     }

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/model/PaginatedUsers.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/model/PaginatedUsers.java
@@ -11,5 +11,13 @@ public class PaginatedUsers {
     private String previousPageLink;
     private String nextPageLink;
     private int totalUsers;
-    private int totalPages;
+
+    public int getTotalPages(int size) {
+        int totalPages = (int) Math.ceil((double) this.totalUsers / size);
+        if (totalPages > 0) {
+            return totalPages;
+        } else {
+            return 1;
+        }
+    }
 }

--- a/src/main/resources/templates/users.html
+++ b/src/main/resources/templates/users.html
@@ -118,28 +118,21 @@
                 </form>
                 <nav class="moj-pagination" aria-label="Pagination navigation">
                     <ul class="moj-pagination__list">
-                        <li class="moj-pagination__item  moj-pagination__item--prev" th:if="${previousPageLink}">
+                        <li class="moj-pagination__item  moj-pagination__item--prev" th:if="${page > 1}">
                             <a class="moj-pagination__link"
-                                th:href="@{/users(size=${pageSize}, page=${page - 1}, previousPageLink=${previousPageLink})}">Previous<span
+                                th:href="@{/users(size=${requestedPageSize}, page=${page - 1})}">Previous<span
                                     class="govuk-visually-hidden">
                                     page</span></a>
                         </li>
-                        <th:block th:each="i: ${#numbers.sequence(1, totalPages ?: 1)}">
-                            <!-- <li class="moj-pagination__item moj-pagination__item--active"> -->
-                            <li class="moj-pagination__item">
-                                <a class="moj-pagination__link" th:href="@{/users(size=${pageSize}, page=${i})}"
-                                    aria-label="Page ${i} of 5" aria-current="page" th:text="${i}"></a>
-                            </li>
-                        </th:block>
-                        <li class="moj-pagination__item  moj-pagination__item--next" th:if="${nextPageLink}">
+                        <li class="moj-pagination__item  moj-pagination__item--next" th:if="${page < totalPages}">
                             <a class="moj-pagination__link"
-                                th:href="@{/users(size=${pageSize}, page=${page + 1}, nextPageLink=${nextPageLink})}">Next<span
+                                th:href="@{/users(size=${requestedPageSize}, page=${page + 1})}">Next<span
                                     class="govuk-visually-hidden">
                                     page</span></a>
                         </li>
                     </ul>
-                    <p class="moj-pagination__results">Showing <b th:text="${(pageSize ?: 10) * ((page ?: 1) - 1)}"></b>
-                        to <b th:text="${(pageSize ?: 10)  * (page ?: 1) }"></b> of <b>
+                    <p class="moj-pagination__results">Showing <b th:text="${((requestedPageSize ?: 10) * ((page ?: 1) - 1)) + 1}"></b>
+                        to <b th:text="${((requestedPageSize ?: 10) * ((page ?: 1) - 1)) + (actualPageSize ?: 10)}"></b> of <b>
                             <b th:text="${totalUsers}"></b>
                         </b> results</p>
                 </nav>

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/UserControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/UserControllerTest.java
@@ -69,20 +69,15 @@ class UserControllerTest {
         paginatedUsers.setNextPageLink("nextPageLink");
         paginatedUsers.setPreviousPageLink("previousPageLink");
         paginatedUsers.setTotalUsers(100);
-        paginatedUsers.setTotalPages(10);
 
         Stack<String> pageHistory = new Stack<>();
-        when(userService.getPageHistory(session)).thenReturn(pageHistory);
-        when(userService.getPaginatedUsersWithHistory(any(), anyInt(), anyString())).thenReturn(paginatedUsers);
+        when(userService.getPaginatedUsers(anyInt(), anyInt())).thenReturn(paginatedUsers);
 
-        String view = userController.displayAllUsers(10, 1, "nextPageLink", model, session);
+        String view = userController.displayAllUsers(10, 1, model);
 
         assertThat(view).isEqualTo("users");
         assertThat(model.getAttribute("users")).isEqualTo(paginatedUsers.getUsers());
-        assertThat(model.getAttribute("nextPageLink")).isEqualTo("nextPageLink");
-        assertThat(model.getAttribute("previousPageLink")).isEqualTo("previousPageLink");
-        assertThat(model.getAttribute("pageSize")).isEqualTo(10);
-        assertThat(model.getAttribute("pageHistory")).isEqualTo(pageHistory);
+        assertThat(model.getAttribute("requestedPageSize")).isEqualTo(10);
         assertThat(model.getAttribute("page")).isEqualTo(1);
         assertThat(model.getAttribute("totalUsers")).isEqualTo(100);
         assertThat(model.getAttribute("totalPages")).isEqualTo(10);
@@ -104,49 +99,20 @@ class UserControllerTest {
     @Test
     void givenUsersExist_whenDisplayAllUsers_thenPopulatesModelAndReturnsUsersView() {
         // Arrange
-        Stack<String> history = new Stack<>();
-        history.push("prevLink456");
         PaginatedUsers mockPaginatedUsers = new PaginatedUsers();
         mockPaginatedUsers.setUsers(List.of(new UserModel(), new UserModel()));
         mockPaginatedUsers.setNextPageLink("nextLink123");
         mockPaginatedUsers.setPreviousPageLink("prevLink456");
-        when(userService.getPageHistory(session)).thenReturn(history);
-        when(userService.getPaginatedUsersWithHistory(eq(history), eq(10), isNull())).thenReturn(mockPaginatedUsers);
+        when(userService.getPaginatedUsers(eq(1), eq(10))).thenReturn(mockPaginatedUsers);
 
         // Act
-        String viewName = userController.displayAllUsers(10, 1, null, model, session);
+        String viewName = userController.displayAllUsers(10, 1, model);
 
         // Assert
         assertThat(viewName).isEqualTo("users");
         assertThat(model.getAttribute("users")).isEqualTo(mockPaginatedUsers.getUsers());
-        assertThat(model.getAttribute("nextPageLink")).isEqualTo("nextLink123");
-        assertThat(model.getAttribute("previousPageLink")).isEqualTo("prevLink456");
-        assertThat(model.getAttribute("pageSize")).isEqualTo(10);
-        assertThat(model.getAttribute("pageHistory")).isEqualTo(history);
-        verify(userService).getPageHistory(session);
-        verify(userService).getPaginatedUsersWithHistory(history, 10, null);
-    }
-
-    @Test
-    void givenNextPageLink_whenDisplayAllUsers_thenUsesLinkAndUpdatesHistory() {
-        // Arrange
-        PaginatedUsers mockPaginatedUsers = new PaginatedUsers();
-        mockPaginatedUsers.setUsers(List.of(new UserModel()));
-        mockPaginatedUsers.setNextPageLink("nextPageLinkFromServer");
-        mockPaginatedUsers.setPreviousPageLink("somePrevLink");
-        Stack<String> history = new Stack<>();
-        when(userService.getPageHistory(session)).thenReturn(history);
-        when(userService.getPaginatedUsersWithHistory(eq(history), eq(10), eq("pageLink")))
-                .thenReturn(mockPaginatedUsers);
-
-        // Act
-        String viewName = userController.displayAllUsers(10, 1, "pageLink", model, session);
-
-        // Assert
-        assertThat(viewName).isEqualTo("users");
-        assertThat(model.getAttribute("nextPageLink")).isEqualTo("nextPageLinkFromServer");
-        verify(userService).getPageHistory(session);
-        verify(userService).getPaginatedUsersWithHistory(history, 10, "pageLink");
+        assertThat(model.getAttribute("requestedPageSize")).isEqualTo(10);
+        verify(userService).getPaginatedUsers(1, 10);
     }
 
     @Test
@@ -156,20 +122,16 @@ class UserControllerTest {
         mockPaginatedUsers.setUsers(new ArrayList<>());
         mockPaginatedUsers.setNextPageLink(null);
         mockPaginatedUsers.setPreviousPageLink(null);
-        Stack<String> history = new Stack<>();
-
-        when(userService.getPageHistory(session)).thenReturn(history);
-        when(userService.getPaginatedUsersWithHistory(any(), anyInt(), isNull()))
+        when(userService.getPaginatedUsers(anyInt(), anyInt()))
                 .thenReturn(mockPaginatedUsers);
 
         // Act
-        String viewName = userController.displayAllUsers(10, 1, null, model, session);
+        String viewName = userController.displayAllUsers(10, 1, model);
 
         // Assert
         assertThat(viewName).isEqualTo("users");
         assertThat(model.getAttribute("users")).isEqualTo(new ArrayList<>());
-        assertThat(model.getAttribute("nextPageLink")).isNull();
-        verify(userService).getPaginatedUsersWithHistory(history, 10, null);
+        verify(userService).getPaginatedUsers(1, 10);
     }
 
     @Test

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/service/UserServiceTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/service/UserServiceTest.java
@@ -637,19 +637,6 @@ class UserServiceTest {
     }
 
     @Test
-    void getPageHistoryWhenNoHistoryInSessionInitialisesAndReturnsEmptyStack() {
-        // Arrange
-        when(session.getAttribute("pageHistory")).thenReturn(null);
-
-        // Act
-        Stack<String> history = userService.getPageHistory(session);
-
-        // Assert
-        assertThat(history).isNotNull().isEmpty();
-        verify(session).setAttribute(eq("pageHistory"), any(Stack.class));
-    }
-
-    @Test
     void existingUserRetrievalById() {
         // Arrange
         String userId = "existing-user-id";
@@ -753,23 +740,6 @@ class UserServiceTest {
         }
 
         @Test
-        void firstPage_returnsNextLink_noPrev() {
-            // Arrange
-            when(mockGraph.users().get(any()))
-                    .thenReturn(buildPage(List.of(graphUser("1", "Alice")), "https://next"));
-            when(mockGraph.users().count().get(any())).thenReturn(1);
-
-            // Act
-            PaginatedUsers result = paginationSvc.getPaginatedUsersWithHistory(new Stack<>(), 10, null);
-
-            // Assert
-            assertThat(result.getUsers()).hasSize(1);
-            assertThat(result.getNextPageLink()).isEqualTo("https://next");
-            assertThat(result.getPreviousPageLink()).isNull();
-            assertThat(result.getTotalPages()).isEqualTo(1);
-        }
-
-        @Test
         void zeroUsers_setsTotalPagesToOne() {
             // Arrange
             when(mockGraph.users().get(any()))
@@ -777,11 +747,68 @@ class UserServiceTest {
             when(mockGraph.users().count().get(any())).thenReturn(0);
 
             // Act
-            PaginatedUsers result = paginationSvc.getPaginatedUsersWithHistory(new Stack<>(), 5, null);
+            PaginatedUsers result = paginationSvc.getPaginatedUsers(5, 10);
 
             // Assert
             assertThat(result.getTotalUsers()).isZero();
-            assertThat(result.getTotalPages()).isEqualTo(1);
+            assertThat(result.getTotalPages(10)).isEqualTo(1);
+        }
+
+        @Test
+        void requestingPage2ReturnsSecondPageOfUsers() {
+            List<User> firstPageOfUsers = List.of(graphUser("first-page-user-1", "FirstPageUser1"));
+            List<User> secondPageOfUsers = List.of(graphUser("second-page-user-1", "SecondPageUser1"));
+            // Arrange
+            when(mockGraph.users().get(any()))
+                    .thenReturn(buildPage(firstPageOfUsers, "secondPageLink"));
+            when(mockGraph.users().count().get(any())).thenReturn(3);
+            when(mockGraph.users().withUrl("secondPageLink").get())
+                    .thenReturn(buildPage(secondPageOfUsers, "thirdPageLink"));
+
+            // Act
+            PaginatedUsers result = paginationSvc.getPaginatedUsers(2, 1);
+
+            // Assert
+            assertThat(result.getTotalUsers()).isEqualTo(3);
+            assertThat(result.getTotalPages(1)).isEqualTo(3);
+            assertThat(result.getUsers().size()).isEqualTo(1);
+            assertThat(result.getUsers().get(0).getFullName()).isEqualTo("SecondPageUser1");
+        }
+
+        @Test
+        void requestingPage5ReturnsNothingWhenOnly2PagesAreAvailable() {
+            List<User> firstPageOfUsers = List.of(graphUser("first-page-user-1", "FirstPageUser1"));
+            List<User> secondPageOfUsers = List.of(graphUser("second-page-user-1", "SecondPageUser1"));
+            // Arrange
+            when(mockGraph.users().get(any()))
+                    .thenReturn(buildPage(firstPageOfUsers, "secondPageLink"));
+            when(mockGraph.users().count().get(any())).thenReturn(3);
+            when(mockGraph.users().withUrl("secondPageLink").get())
+                    .thenReturn(buildPage(secondPageOfUsers, "thirdPageLink"));
+
+            // Act
+            PaginatedUsers result = paginationSvc.getPaginatedUsers(5, 1);
+
+            // Assert
+            assertThat(result.getTotalUsers()).isEqualTo(3);
+            assertThat(result.getTotalPages(1)).isEqualTo(3);
+            assertThat(result.getUsers().size()).isEqualTo(0);
+        }
+
+        @Test
+        void requestingPageReturnsNothingWhenUserResponseIsNull() {
+            // Arrange
+            when(mockGraph.users().get(any()))
+                    .thenReturn(null);
+            when(mockGraph.users().count().get(any())).thenReturn(null);
+
+            // Act
+            PaginatedUsers result = paginationSvc.getPaginatedUsers(1, 10);
+
+            // Assert
+            assertThat(result.getTotalUsers()).isEqualTo(0);
+            assertThat(result.getTotalPages(10)).isEqualTo(1);
+            assertThat(result.getUsers().size()).isEqualTo(0);
         }
     }
 


### PR DESCRIPTION
Re-worked pagination to use GraphQL's cursor-based pagination
Added new fields to pagination model to allow us to correctly display number of users on page.
Updated old tests and added new tests.