### PR TITLE
Fix port for prometheus actuator service monitor (STB-1320)

### DIFF
--- a/deployments/templates/servicemonitor.yml
+++ b/deployments/templates/servicemonitor.yml
@@ -11,6 +11,6 @@ spec:
     matchNames:
       - ${NAMESPACE}
   endpoints:
-    - port: http
+    - port: https
       path: /actuator/prometheus
       interval: 15s


### PR DESCRIPTION
Fix to instruct Prometheus to access the actuator endpoint on the correct port, to be able to collect metrics.

https://dsdmoj.atlassian.net/browse/STB-1320 