### PR TITLE
Add missing app label to service (STB-1320)

### DIFF
--- a/deployments/templates/service.yml
+++ b/deployments/templates/service.yml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: laa-landing-page
+  labels:
+    app: laa-landing-page
 spec:
   selector:
     app: laa-landing-page # this should match the pod label in deployment.yml


### PR DESCRIPTION
The service monitor has a selector that needs to match an app label on a service:

https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/application-metrics.html#add-service-endpoint-and-servicemonitor

This app label was missing in our service configuration, adding it in to attempt to resolve Prometheus being unable to scrape our application metrics.

https://dsdmoj.atlassian.net/browse/STB-1320