### PR TITLE
Fix: adding USER to Dockerfile to prevent root access vuln

### DIFF
--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -2,6 +2,8 @@ FROM postgres:14.3-alpine
 
 COPY init-db.sh /docker-entrypoint-initdb.d
 
+USER postgres
+
 HEALTHCHECK --interval=10s --timeout=10s --retries=10 CMD psql -c 'select 1' -d idam -U ${DB_USERNAME}
 
 EXPOSE 5432


### PR DESCRIPTION
Running containers with 'root' user can lead to a container escape situation. (High level vuln raised by Snyk)