### PR TITLE
Fix: make root filesystem immutable

### DIFF
--- a/deployments/templates/deployment.yml
+++ b/deployments/templates/deployment.yml
@@ -22,6 +22,7 @@ spec:
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsNonRoot: true
+            readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]


### PR DESCRIPTION
Snyk Vulnerability message: Container 'laa-landing-page' of Deployment 'laa-landing-page' should set 'securityContext.readOnlyRootFilesystem' to true