### PR TITLE
Add RDS alerts and metrics, and refine existing monitoring (STB-1714)

### DIFF
--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -44,6 +44,17 @@ jobs:
       - uses: aws-actions/amazon-ecr-login@v2
         id: login-ecr
 
+      - name: Configure kubectl
+        run: |
+          echo "${{ secrets.KUBE_CERT }}" > ca.crt
+          kubectl config set-cluster ${KUBE_CLUSTER} --certificate-authority=./ca.crt --server=https://${KUBE_CLUSTER}
+          kubectl config set-credentials deploy-user --token=${{ secrets.KUBE_TOKEN }}
+          kubectl config set-context ${KUBE_CLUSTER} --cluster=${KUBE_CLUSTER} --user=deploy-user --namespace=${KUBE_NAMESPACE}
+          kubectl config use-context ${KUBE_CLUSTER}
+        env:
+          KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
+          KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
+
       - name: Build and Push Docker Image to the container repository
         run: |
           docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG .
@@ -59,27 +70,41 @@ jobs:
           cat deployments/templates/ingress.yml | envsubst > deployments/ingress.yml
           cat deployments/templates/service.yml | envsubst > deployments/service.yml
           cat deployments/templates/servicemonitor.yml | envsubst > deployments/servicemonitor.yml
-          cat deployments/templates/prometheus.yml | envsubst '$NAMESPACE,$ALERT_SEVERITY' > deployments/prometheus.yml
-          cat deployments/templates/grafanadashboard.yml | envsubst '$NAMESPACE,$ENV_NAME'> deployments/grafanadashboard.yml
         env:
           IMAGE_TAG: ${{ github.sha }}
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: ${{ vars.ECR_REPOSITORY }}
           NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
-          ALERT_SEVERITY: ${{ secrets.KUBE_NAMESPACE }}
-          ENV_NAME: ${{ vars.ENV_NAME }}
-          INGRESS_CLASS_NAME: ${{ vars.INGRESS_CLASS_NAME }}
-
 
       - name: Deploy to Cloud Platform
         run: |
-          echo "${{ secrets.KUBE_CERT }}" > ca.crt
-          kubectl config set-cluster ${KUBE_CLUSTER} --certificate-authority=./ca.crt --server=https://${KUBE_CLUSTER}
-          kubectl config set-credentials deploy-user --token=${{ secrets.KUBE_TOKEN }}
-          kubectl config set-context ${KUBE_CLUSTER} --cluster=${KUBE_CLUSTER} --user=deploy-user --namespace=${KUBE_NAMESPACE}
-          kubectl config use-context ${KUBE_CLUSTER}
           kubectl -n ${KUBE_NAMESPACE} apply -f deployments/
         env:
           KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
-          KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
-          SECURITY_OAUTH2_CLIENT_REGISTRATION_AZURE_REDIRECT_URI: ${{ secrets.AZURE_REDIRECT_URI }}
+
+      # Get DB identifier to use for Prometheus alerts & Grafana configuration
+      - name: Get DB identifier
+        run: |
+          #!/bin/bash
+          RDS_DB_IDENTIFIER=$(kubectl get secret rds-postgresql-instance-output -o jsonpath='{.data.rds_instance_endpoint}' | base64 -d | cut -d. -f1 | xargs printf "%s")
+          echo "RDS_DB_IDENTIFIER=${RDS_DB_IDENTIFIER}" >> "$GITHUB_ENV"
+          
+      # Prometheus alerts & Grafana configuration - after application deployment to avoid chicken/egg scenarios
+      # Note: first rm command removes the previously generated files and doesn't remove the templates/ directory
+      - name: Generate Monitoring Deployment Files
+        run: |
+          rm deployments/* 2> /dev/null
+          cat deployments/templates/prometheus.yml | envsubst '$NAMESPACE,$ALERT_SEVERITY,$ENV_NAME,$RDS_DB_IDENTIFIER' > deployments/prometheus.yml
+          cat deployments/templates/grafanadashboard.yml | envsubst '$NAMESPACE,$ENV_NAME,$RDS_DB_IDENTIFIER' > deployments/grafanadashboard.yml
+        env:
+          NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
+          ALERT_SEVERITY: ${{ secrets.KUBE_NAMESPACE }}
+          ENV_NAME: ${{ vars.ENV_NAME }}
+          INGRESS_CLASS_NAME: ${{ vars.INGRESS_CLASS_NAME }}
+      
+      # Prometheus alerts & Grafana deployment
+      - name: Deploy Monitoring to Cloud Platform
+        run: |
+          kubectl -n ${KUBE_NAMESPACE} apply -f deployments/
+        env:
+          KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -75,6 +75,7 @@ jobs:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: ${{ vars.ECR_REPOSITORY }}
           NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
+          INGRESS_CLASS_NAME: ${{ vars.INGRESS_CLASS_NAME }}
 
       - name: Deploy to Cloud Platform
         run: |
@@ -94,13 +95,14 @@ jobs:
       - name: Generate Monitoring Deployment Files
         run: |
           rm deployments/* 2> /dev/null
-          cat deployments/templates/prometheus.yml | envsubst '$NAMESPACE,$ALERT_SEVERITY,$ENV_NAME,$RDS_DB_IDENTIFIER' > deployments/prometheus.yml
+          cat deployments/templates/prometheus.yml | envsubst '$NAMESPACE,$ALERT_SEVERITY,$ENV_NAME,$RDS_DB_IDENTIFIER,$RDS_LOW_FREEABLE_MEMORY_TRIGGER' > deployments/prometheus.yml
           cat deployments/templates/grafanadashboard.yml | envsubst '$NAMESPACE,$ENV_NAME,$RDS_DB_IDENTIFIER' > deployments/grafanadashboard.yml
         env:
           NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
           ALERT_SEVERITY: ${{ secrets.KUBE_NAMESPACE }}
           ENV_NAME: ${{ vars.ENV_NAME }}
-          INGRESS_CLASS_NAME: ${{ vars.INGRESS_CLASS_NAME }}
+          # Alert trigger for remaining freeable memory on RDS instance, currently set in MB, below value is 85% of total memory
+          RDS_LOW_FREEABLE_MEMORY_TRIGGER: "150"
       
       # Prometheus alerts & Grafana deployment
       - name: Deploy Monitoring to Cloud Platform

--- a/.github/workflows/deploy_test.yml
+++ b/.github/workflows/deploy_test.yml
@@ -76,6 +76,7 @@ jobs:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: ${{ vars.ECR_REPOSITORY }}
           NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
+          INGRESS_CLASS_NAME: ${{ vars.INGRESS_CLASS_NAME }}
 
       - name: Deploy to Cloud Platform
         run: |
@@ -95,13 +96,14 @@ jobs:
       - name: Generate Monitoring Deployment Files
         run: |
           rm deployments/* 2> /dev/null
-          cat deployments/templates/prometheus.yml | envsubst '$NAMESPACE,$ALERT_SEVERITY,$ENV_NAME,$RDS_DB_IDENTIFIER' > deployments/prometheus.yml
+          cat deployments/templates/prometheus.yml | envsubst '$NAMESPACE,$ALERT_SEVERITY,$ENV_NAME,$RDS_DB_IDENTIFIER,$RDS_LOW_FREEABLE_MEMORY_TRIGGER' > deployments/prometheus.yml
           cat deployments/templates/grafanadashboard.yml | envsubst '$NAMESPACE,$ENV_NAME,$RDS_DB_IDENTIFIER' > deployments/grafanadashboard.yml
         env:
           NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
           ALERT_SEVERITY: ${{ secrets.KUBE_NAMESPACE }}
           ENV_NAME: ${{ vars.ENV_NAME }}
-          INGRESS_CLASS_NAME: ${{ vars.INGRESS_CLASS_NAME }}
+          # Alert trigger for remaining freeable memory on RDS instance, currently set in MB, below value is 85% of total memory
+          RDS_LOW_FREEABLE_MEMORY_TRIGGER: "150"
       
       # Prometheus alerts & Grafana deployment
       - name: Deploy Monitoring to Cloud Platform

--- a/.github/workflows/deploy_test.yml
+++ b/.github/workflows/deploy_test.yml
@@ -45,6 +45,17 @@ jobs:
       - uses: aws-actions/amazon-ecr-login@v2
         id: login-ecr
 
+      - name: Configure kubectl
+        run: |
+          echo "${{ secrets.KUBE_CERT }}" > ca.crt
+          kubectl config set-cluster ${KUBE_CLUSTER} --certificate-authority=./ca.crt --server=https://${KUBE_CLUSTER}
+          kubectl config set-credentials deploy-user --token=${{ secrets.KUBE_TOKEN }}
+          kubectl config set-context ${KUBE_CLUSTER} --cluster=${KUBE_CLUSTER} --user=deploy-user --namespace=${KUBE_NAMESPACE}
+          kubectl config use-context ${KUBE_CLUSTER}
+        env:
+          KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
+          KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
+
       - name: Build and Push Docker Image to the container repository
         run: |
           docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG .
@@ -60,26 +71,41 @@ jobs:
           cat deployments/templates/ingress.yml | envsubst > deployments/ingress.yml
           cat deployments/templates/service.yml | envsubst > deployments/service.yml
           cat deployments/templates/servicemonitor.yml | envsubst > deployments/servicemonitor.yml
-          cat deployments/templates/prometheus.yml | envsubst '$NAMESPACE,$ALERT_SEVERITY' > deployments/prometheus.yml
-          cat deployments/templates/grafanadashboard.yml | envsubst '$NAMESPACE,$ENV_NAME'> deployments/grafanadashboard.yml
         env:
           IMAGE_TAG: ${{ github.sha }}
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: ${{ vars.ECR_REPOSITORY }}
           NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
-          ALERT_SEVERITY: ${{ secrets.KUBE_NAMESPACE }}
-          ENV_NAME: ${{ vars.ENV_NAME }}
-          INGRESS_CLASS_NAME: ${{ vars.INGRESS_CLASS_NAME }}
 
       - name: Deploy to Cloud Platform
         run: |
-          echo "${{ secrets.KUBE_CERT }}" > ca.crt
-          kubectl config set-cluster ${KUBE_CLUSTER} --certificate-authority=./ca.crt --server=https://${KUBE_CLUSTER}
-          kubectl config set-credentials deploy-user --token=${{ secrets.KUBE_TOKEN }}
-          kubectl config set-context ${KUBE_CLUSTER} --cluster=${KUBE_CLUSTER} --user=deploy-user --namespace=${KUBE_NAMESPACE}
-          kubectl config use-context ${KUBE_CLUSTER}
           kubectl -n ${KUBE_NAMESPACE} apply -f deployments/
         env:
           KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
-          KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
-          SECURITY_OAUTH2_CLIENT_REGISTRATION_AZURE_REDIRECT_URI: ${{ secrets.AZURE_REDIRECT_URI }}
+
+      # Get DB identifier to use for Prometheus alerts & Grafana configuration
+      - name: Get DB identifier
+        run: |
+          #!/bin/bash
+          RDS_DB_IDENTIFIER=$(kubectl get secret rds-postgresql-instance-output -o jsonpath='{.data.rds_instance_endpoint}' | base64 -d | cut -d. -f1 | xargs printf "%s")
+          echo "RDS_DB_IDENTIFIER=${RDS_DB_IDENTIFIER}" >> "$GITHUB_ENV"
+          
+      # Prometheus alerts & Grafana config generation - after application deployment to avoid chicken/egg scenarios
+      # Note: first rm command removes the previously generated files and doesn't remove the templates/ directory
+      - name: Generate Monitoring Deployment Files
+        run: |
+          rm deployments/* 2> /dev/null
+          cat deployments/templates/prometheus.yml | envsubst '$NAMESPACE,$ALERT_SEVERITY,$ENV_NAME,$RDS_DB_IDENTIFIER' > deployments/prometheus.yml
+          cat deployments/templates/grafanadashboard.yml | envsubst '$NAMESPACE,$ENV_NAME,$RDS_DB_IDENTIFIER' > deployments/grafanadashboard.yml
+        env:
+          NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
+          ALERT_SEVERITY: ${{ secrets.KUBE_NAMESPACE }}
+          ENV_NAME: ${{ vars.ENV_NAME }}
+          INGRESS_CLASS_NAME: ${{ vars.INGRESS_CLASS_NAME }}
+      
+      # Prometheus alerts & Grafana deployment
+      - name: Deploy Monitoring to Cloud Platform
+        run: |
+          kubectl -n ${KUBE_NAMESPACE} apply -f deployments/
+        env:
+          KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}

--- a/deployments/templates/grafanadashboard.yml
+++ b/deployments/templates/grafanadashboard.yml
@@ -136,7 +136,7 @@ data:
             {
               "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "sum by(instance) (increase(http_server_requests_seconds_count{namespace='${NAMESPACE}'}[$__rate_interval])) ",
+              "expr": "sum by(instance) (increase(http_server_requests_seconds_count{namespace='${cpnamespace}'}[$__rate_interval])) ",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "legendFormat": "__auto",
@@ -235,7 +235,7 @@ data:
                 "uid": "prometheus"
               },
               "editorMode": "code",
-              "expr": "sum by(instance) (increase(http_server_requests_seconds_count{namespace='${NAMESPACE}',status='200'}[$__rate_interval])) ",
+              "expr": "sum by(instance) (increase(http_server_requests_seconds_count{namespace='${cpnamespace}',status='200'}[$__rate_interval])) ",
               "legendFormat": "__auto",
               "range": true,
               "refId": "A"
@@ -331,7 +331,7 @@ data:
                 "uid": "prometheus"
               },
               "editorMode": "code",
-              "expr": "sum by(uri) (increase(http_server_requests_seconds_count{namespace='${NAMESPACE}', uri!~'.*swagger.*|.*health.*', status='200'}[$__rate_interval])) ",
+              "expr": "sum by(uri) (increase(http_server_requests_seconds_count{namespace='${cpnamespace}', uri!~'.*health.*', status='200'}[$__rate_interval])) ",
               "legendFormat": "{{uri}}",
               "range": true,
               "refId": "A"
@@ -437,7 +437,7 @@ data:
             {
               "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "sum(rate(nginx_ingress_controller_requests{exported_namespace = \"${NAMESPACE}\",status=~\"4.*\"}[5m])) by (status)",
+              "expr": "sum(rate(nginx_ingress_controller_requests{exported_namespace = \"${cpnamespace}\",status=~\"4.*\"}[5m])) by (status)",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "legendFormat": "__auto",
@@ -533,7 +533,7 @@ data:
             {
               "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "sum(rate(nginx_ingress_controller_requests{exported_namespace = \"${NAMESPACE}\",status=~\"5.*\"}[5m])) by (status)",
+              "expr": "sum(rate(nginx_ingress_controller_requests{exported_namespace = \"${cpnamespace}\",status=~\"5.*\"}[5m])) by (status)",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "legendFormat": "__auto",
@@ -646,7 +646,7 @@ data:
                 "uid": "prometheus"
               },
               "editorMode": "code",
-              "expr": "sum by(uri) (rate(http_server_requests_seconds_sum{namespace='${NAMESPACE}', uri!~'.*swagger.*|.*health.*', status='200'}[1m])) / sum by(uri) (rate(http_server_requests_seconds_count{namespace='${NAMESPACE}', uri!~'.*swagger.*|.*health.*', status='200'}[$__rate_interval]))",
+              "expr": "sum by(uri) (rate(http_server_requests_seconds_sum{namespace='${cpnamespace}', uri!~'.*health.*', status='200'}[1m])) / sum by(uri) (rate(http_server_requests_seconds_count{namespace='${cpnamespace}', uri!~'.*health.*', status='200'}[$__rate_interval]))",
               "legendFormat": "__auto",
               "range": true,
               "refId": "A"
@@ -743,7 +743,7 @@ data:
                 "uid": "prometheus"
               },
               "editorMode": "code",
-              "expr": "max by(uri) (http_server_requests_seconds_max{namespace='${NAMESPACE}', uri!~'.*swagger.*|.*health.*', status='200'}) ",
+              "expr": "max by(uri) (http_server_requests_seconds_max{namespace='${cpnamespace}', uri!~'.*health.*', status='200'}) ",
               "legendFormat": "__auto",
               "range": true,
               "refId": "A"
@@ -822,7 +822,7 @@ data:
                 "uid": "prometheus"
               },
               "editorMode": "builder",
-              "expr": "sum(kube_pod_container_info{namespace='${NAMESPACE}',pod=~'.*laa-landing-page.*'})",
+              "expr": "sum(kube_pod_container_info{namespace='${cpnamespace}',pod=~'.*laa-landing-page.*'})",
               "legendFormat": "Total",
               "range": true,
               "refId": "A"
@@ -833,7 +833,7 @@ data:
                 "uid": "prometheus"
               },
               "editorMode": "code",
-              "expr": "sum({namespace='${NAMESPACE}',phase='Running',pod=~'.*laa-landing-page.*'} + 0)",
+              "expr": "sum({namespace='${cpnamespace}',phase='Running',pod=~'.*laa-landing-page.*'} + 0)",
               "hide": false,
               "legendFormat": "Running",
               "range": true,
@@ -845,7 +845,7 @@ data:
                 "uid": "prometheus"
               },
               "editorMode": "builder",
-              "expr": "sum({namespace='${NAMESPACE}',phase='Pending',pod=~'.*laa-landing-page.*'} + 0)",
+              "expr": "sum({namespace='${cpnamespace}',phase='Pending',pod=~'.*laa-landing-page.*'} + 0)",
               "hide": false,
               "legendFormat": "Pending",
               "range": true,
@@ -857,7 +857,7 @@ data:
                 "uid": "prometheus"
               },
               "editorMode": "code",
-              "expr": "sum({namespace='${NAMESPACE}',phase='Failed',pod=~'.*laa-landing-page.*'} + 0)",
+              "expr": "sum({namespace='${cpnamespace}',phase='Failed',pod=~'.*laa-landing-page.*'} + 0)",
               "hide": false,
               "legendFormat": "Failed",
               "range": true,
@@ -951,7 +951,7 @@ data:
             {
               "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "sort_desc(avg(sum by (pod_name) (rate(container_network_receive_bytes_total{namespace='${NAMESPACE}'}[5m]))))",
+              "expr": "sort_desc(avg(sum by (pod_name) (rate(container_network_receive_bytes_total{namespace='${cpnamespace}'}[5m]))))",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "legendFormat": "Average Bytes Received",
@@ -966,7 +966,7 @@ data:
               },
               "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "sort_desc(avg(sum by (pod_name) (rate(container_network_transmit_bytes_total{namespace='${NAMESPACE}'}[5m]))))",
+              "expr": "sort_desc(avg(sum by (pod_name) (rate(container_network_transmit_bytes_total{namespace='${cpnamespace}'}[5m]))))",
               "fullMetaSearch": false,
               "hide": false,
               "includeNullMetadata": true,
@@ -1066,7 +1066,7 @@ data:
               "disableTextWrap": false,
               "editorMode": "code",
               "exemplar": false,
-              "expr": "100 * kube_resourcequota{job=\"kube-state-metrics\", type=\"used\", namespace=\"${NAMESPACE}\"}\n/ ignoring(instance, job, type)\n(kube_resourcequota{job=\"kube-state-metrics\", type=\"hard\", namespace=\"${NAMESPACE}\"} > 0)",
+              "expr": "100 * kube_resourcequota{job=\"kube-state-metrics\", type=\"used\", namespace=\"${cpnamespace}\"}\n/ ignoring(instance, job, type)\n(kube_resourcequota{job=\"kube-state-metrics\", type=\"hard\", namespace=\"${cpnamespace}\"} > 0)",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "instant": false,
@@ -1189,7 +1189,7 @@ data:
             {
               "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "sum(aws_ecr_repository_image_count{repository_name=~'laa-portal-stabilisation-tech/${NAMESPACE}'}) by (repository_name)",
+              "expr": "sum(aws_ecr_repository_image_count{repository_name=~'laa-portal-stabilisation-tech/${cpnamespace}'}) by (repository_name)",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "legendFormat": "ECR Image Count",
@@ -1299,7 +1299,7 @@ data:
             {
               "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "round(\n  100 *\n    sum(container_memory_working_set_bytes{image!='',namespace='${NAMESPACE}',pod=~\"laa-landing-page.*\"}) by (container, pod)\n      /\n    sum(kube_pod_container_resource_requests{resource='memory', namespace='${NAMESPACE}',pod=~\"laa-landing-page.*\"} > 0) by (container, pod)\n)",
+              "expr": "round(\n  100 *\n    sum(container_memory_working_set_bytes{image!='',namespace='${cpnamespace}',pod=~\"laa-landing-page.*\"}) by (container, pod)\n      /\n    sum(kube_pod_container_resource_requests{resource='memory', namespace='${cpnamespace}',pod=~\"laa-landing-page.*\"} > 0) by (container, pod)\n)",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "legendFormat": "{{pod}}",
@@ -1396,7 +1396,7 @@ data:
             {
               "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "round(\n  100 *\n    sum(container_memory_working_set_bytes{image!=\"\", namespace='${NAMESPACE}', container_name!=\"laa-landing-page.*\"}) by (container, pod)\n      /\n    sum(kube_pod_container_resource_limits{namespace='${NAMESPACE}', container_name!=\"laa-landing-page.*\",resource=\"memory\"} > 0) by (container, pod)\n)",
+              "expr": "round(\n  100 *\n    sum(container_memory_working_set_bytes{image!=\"\", namespace='${cpnamespace}', container_name!=\"laa-landing-page.*\"}) by (container, pod)\n      /\n    sum(kube_pod_container_resource_limits{namespace='${cpnamespace}', container_name!=\"laa-landing-page.*\",resource=\"memory\"} > 0) by (container, pod)\n)",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "legendFormat": "{{pod}}",
@@ -1492,7 +1492,7 @@ data:
             {
               "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "container_memory_usage_bytes{namespace=\"${NAMESPACE}\", pod=~'laa-landing-page.*'}",
+              "expr": "container_memory_usage_bytes{namespace=\"${cpnamespace}\", pod=~'laa-landing-page.*'}",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "legendFormat": "{{pod}}",
@@ -1507,7 +1507,7 @@ data:
               },
               "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "container_memory_max_usage_bytes{namespace=\"${NAMESPACE}\", pod=~'laa-landing-page.*'}",
+              "expr": "container_memory_max_usage_bytes{namespace=\"${cpnamespace}\", pod=~'laa-landing-page.*'}",
               "fullMetaSearch": false,
               "hide": false,
               "includeNullMetadata": true,
@@ -1635,7 +1635,7 @@ data:
             {
               "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "round(\n  100 *\n    sum(\n      rate(container_cpu_usage_seconds_total{namespace='${NAMESPACE}', container_name!=\"laa-landing-page.*\"}[5m])\n    ) by (pod, container_name, namespace)\n      /\n    sum(\n      kube_pod_container_resource_limits{namespace='${NAMESPACE}', container_name!='laa-landing-page.*', resource='cpu'}\n    ) by (pod, container_name, namespace)\n)",
+              "expr": "round(\n  100 *\n    sum(\n      rate(container_cpu_usage_seconds_total{namespace='${cpnamespace}', container_name!=\"laa-landing-page.*\"}[5m])\n    ) by (pod, container_name, namespace)\n      /\n    sum(\n      kube_pod_container_resource_limits{namespace='${cpnamespace}', container_name!='laa-landing-page.*', resource='cpu'}\n    ) by (pod, container_name, namespace)\n)",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "legendFormat": "__auto",
@@ -1736,7 +1736,7 @@ data:
               },
               "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "round(\n  100 *\n    sum(\n      rate(container_cpu_usage_seconds_total{namespace='${NAMESPACE}', container_name!=\"laa-landing-page.*\"}[5m])\n    ) by (pod_name, container_name, namespace)\n      /\n    sum(\n      kube_pod_container_resource_limits{namespace='${NAMESPACE}', container_name!=\"laa-landing-page.*\",resource='cpu'}\n    ) by (pod_name, container_name, namespace)\n)",
+              "expr": "round(\n  100 *\n    sum(\n      rate(container_cpu_usage_seconds_total{namespace='${cpnamespace}', container_name!=\"laa-landing-page.*\"}[5m])\n    ) by (pod_name, container_name, namespace)\n      /\n    sum(\n      kube_pod_container_resource_limits{namespace='${cpnamespace}', container_name!=\"laa-landing-page.*\",resource='cpu'}\n    ) by (pod_name, container_name, namespace)\n)",
               "fullMetaSearch": false,
               "hide": false,
               "includeNullMetadata": true,
@@ -1835,7 +1835,7 @@ data:
             {
               "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "topk(3, max by (pod, container)(rate(container_cpu_usage_seconds_total{image!='', namespace='${NAMESPACE}',pod=~\"laa-landing-page.*\"}[$__rate_interval]))) / 10",
+              "expr": "topk(3, max by (pod, container)(rate(container_cpu_usage_seconds_total{image!='', namespace='${cpnamespace}',pod=~\"laa-landing-page.*\"}[$__rate_interval]))) / 10",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "legendFormat": "__auto",
@@ -1932,7 +1932,7 @@ data:
             {
               "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "sum(executor_active_threads{namespace=\"${NAMESPACE}\"})",
+              "expr": "sum(executor_active_threads{namespace=\"${cpnamespace}\"})",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "legendFormat": "Number of threads actively executing tasks",
@@ -1947,7 +1947,7 @@ data:
               },
               "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "sum(executor_pool_max_threads{namespace=\"${NAMESPACE}\"})",
+              "expr": "sum(executor_pool_max_threads{namespace=\"${cpnamespace}\"})",
               "fullMetaSearch": false,
               "hide": false,
               "includeNullMetadata": true,
@@ -2028,7 +2028,7 @@ data:
                 "uid": "prometheus"
               },
               "editorMode": "code",
-              "expr": "jvm_memory_max_bytes{namespace='${NAMESPACE}',area='heap',id='Survivor Space'} / 1000000",
+              "expr": "jvm_memory_max_bytes{namespace='${cpnamespace}',area='heap',id='Survivor Space'} / 1000000",
               "legendFormat": "{{instance}}",
               "range": true,
               "refId": "A"
@@ -2124,7 +2124,7 @@ data:
                 "uid": "prometheus"
               },
               "editorMode": "code",
-              "expr": "jvm_memory_used_bytes{namespace='${NAMESPACE}',area='heap',id='Survivor Space'}/1000000",
+              "expr": "jvm_memory_used_bytes{namespace='${cpnamespace}',area='heap',id='Survivor Space'}/1000000",
               "legendFormat": "{{instance}}",
               "range": true,
               "refId": "A"
@@ -2186,7 +2186,7 @@ data:
                 "uid": "prometheus"
               },
               "editorMode": "code",
-              "expr": "jvm_memory_max_bytes{namespace='${NAMESPACE}',area='heap',id='Eden Space'}/1000000",
+              "expr": "jvm_memory_max_bytes{namespace='${cpnamespace}',area='heap',id='Eden Space'}/1000000",
               "legendFormat": "{{instance}}",
               "range": true,
               "refId": "A"
@@ -2282,7 +2282,7 @@ data:
                 "uid": "prometheus"
               },
               "editorMode": "code",
-              "expr": "jvm_memory_used_bytes{namespace='${NAMESPACE}',area='heap',id='Eden Space'}/1000000",
+              "expr": "jvm_memory_used_bytes{namespace='${cpnamespace}',area='heap',id='Eden Space'}/1000000",
               "legendFormat": "{{instance}}",
               "range": true,
               "refId": "A"
@@ -2344,7 +2344,7 @@ data:
                 "uid": "prometheus"
               },
               "editorMode": "code",
-              "expr": "jvm_memory_max_bytes{namespace='${NAMESPACE}',area='heap',id='Tenured Gen'} /1000000",
+              "expr": "jvm_memory_max_bytes{namespace='${cpnamespace}',area='heap',id='Tenured Gen'} /1000000",
               "legendFormat": "{{instance}}",
               "range": true,
               "refId": "A"
@@ -2440,7 +2440,7 @@ data:
                 "uid": "prometheus"
               },
               "editorMode": "code",
-              "expr": "jvm_memory_used_bytes{namespace='${NAMESPACE}',area='heap',id='Tenured Gen'} /1000000",
+              "expr": "jvm_memory_used_bytes{namespace='${cpnamespace}',area='heap',id='Tenured Gen'} /1000000",
               "legendFormat": "{{instance}}",
               "range": true,
               "refId": "A"
@@ -2448,18 +2448,2365 @@ data:
           ],
           "title": "Used Tenured Gen (MB)",
           "type": "timeseries"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 82
+          },
+          "id": 65,
+          "panels": [],
+          "title": "PostgreSQL database (RDS)",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "$cwdatasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "FailedSQLServerAgentJobsCount"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#E0B400",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 83
+          },
+          "id": 16,
+          "options": {
+            "dataLinks": [],
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.3.1",
+          "targets": [
+            {
+              "alias": "",
+              "application": {
+                "filter": ""
+              },
+              "datasource": {
+                "type": "cloudwatch",
+                "uid": "$cwdatasource"
+              },
+              "dimensions": {
+                "DBInstanceIdentifier": "$dbinstanceidentifier"
+              },
+              "expression": "",
+              "functions": [],
+              "group": {
+                "filter": ""
+              },
+              "host": {
+                "filter": ""
+              },
+              "id": "",
+              "item": {
+                "filter": ""
+              },
+              "label": "",
+              "matchExact": true,
+              "metricEditorMode": 0,
+              "metricName": "CPUUtilization",
+              "metricQueryType": 0,
+              "mode": 0,
+              "namespace": "AWS/RDS",
+              "options": {
+                "showDisabledItems": false
+              },
+              "period": "",
+              "refId": "A",
+              "region": "$region",
+              "statistic": "Average"
+            },
+            {
+              "alias": "",
+              "application": {
+                "filter": ""
+              },
+              "datasource": {
+                "uid": "$cwdatasource"
+              },
+              "dimensions": {
+                "DBInstanceIdentifier": "$dbinstanceidentifier"
+              },
+              "expression": "",
+              "functions": [],
+              "group": {
+                "filter": ""
+              },
+              "host": {
+                "filter": ""
+              },
+              "id": "",
+              "item": {
+                "filter": ""
+              },
+              "label": "",
+              "matchExact": true,
+              "metricEditorMode": 0,
+              "metricName": "FailedSQLServerAgentJobsCount",
+              "metricQueryType": 0,
+              "mode": 0,
+              "namespace": "AWS/RDS",
+              "options": {
+                "showDisabledItems": false
+              },
+              "period": "",
+              "refId": "B",
+              "region": "$region",
+              "statistic": "Average"
+            }
+          ],
+          "title": "CPUUtilization/FailedSQLServerAgentJobsCount",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "$cwdatasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "DiskQueueDepth"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "semi-dark-yellow",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 83
+          },
+          "id": 18,
+          "options": {
+            "dataLinks": [],
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.3.1",
+          "targets": [
+            {
+              "alias": "",
+              "application": {
+                "filter": ""
+              },
+              "datasource": {
+                "uid": "$cwdatasource"
+              },
+              "dimensions": {
+                "DBInstanceIdentifier": "$dbinstanceidentifier"
+              },
+              "expression": "",
+              "functions": [],
+              "group": {
+                "filter": ""
+              },
+              "host": {
+                "filter": ""
+              },
+              "id": "",
+              "item": {
+                "filter": ""
+              },
+              "label": "",
+              "matchExact": true,
+              "metricEditorMode": 0,
+              "metricName": "DatabaseConnections",
+              "metricQueryType": 0,
+              "mode": 0,
+              "namespace": "AWS/RDS",
+              "options": {
+                "showDisabledItems": false
+              },
+              "period": "",
+              "refId": "A",
+              "region": "$region",
+              "statistic": "Maximum"
+            },
+            {
+              "alias": "",
+              "application": {
+                "filter": ""
+              },
+              "datasource": {
+                "type": "cloudwatch",
+                "uid": "$cwdatasource"
+              },
+              "dimensions": {
+                "DBInstanceIdentifier": "$dbinstanceidentifier"
+              },
+              "expression": "",
+              "functions": [],
+              "group": {
+                "filter": ""
+              },
+              "host": {
+                "filter": ""
+              },
+              "id": "",
+              "item": {
+                "filter": ""
+              },
+              "label": "",
+              "matchExact": true,
+              "metricEditorMode": 0,
+              "metricName": "DiskQueueDepth",
+              "metricQueryType": 0,
+              "mode": 0,
+              "namespace": "AWS/RDS",
+              "options": {
+                "showDisabledItems": false
+              },
+              "period": "",
+              "refId": "B",
+              "region": "$region",
+              "statistic": "Average"
+            }
+          ],
+          "title": "DatabaseConnections/DiskQueueDepth",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "$cwdatasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "bits"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "FreeStorageSpace"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "semi-dark-yellow",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 91
+          },
+          "id": 17,
+          "options": {
+            "dataLinks": [],
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.3.1",
+          "targets": [
+            {
+              "alias": "",
+              "application": {
+                "filter": ""
+              },
+              "datasource": {
+                "type": "cloudwatch",
+                "uid": "$cwdatasource"
+              },
+              "dimensions": {
+                "DBInstanceIdentifier": "$dbinstanceidentifier"
+              },
+              "functions": [],
+              "group": {
+                "filter": ""
+              },
+              "host": {
+                "filter": ""
+              },
+              "item": {
+                "filter": ""
+              },
+              "label": "",
+              "metricEditorMode": 0,
+              "metricName": "FreeableMemory",
+              "metricQueryType": 0,
+              "mode": 0,
+              "namespace": "AWS/RDS",
+              "options": {
+                "showDisabledItems": false
+              },
+              "period": "",
+              "refId": "A",
+              "region": "$region",
+              "statistic": "Average"
+            },
+            {
+              "alias": "",
+              "application": {
+                "filter": ""
+              },
+              "datasource": {
+                "uid": "$cwdatasource"
+              },
+              "dimensions": {
+                "DBInstanceIdentifier": "$dbinstanceidentifier"
+              },
+              "functions": [],
+              "group": {
+                "filter": ""
+              },
+              "host": {
+                "filter": ""
+              },
+              "item": {
+                "filter": ""
+              },
+              "label": "",
+              "metricEditorMode": 0,
+              "metricName": "FreeStorageSpace",
+              "metricQueryType": 0,
+              "mode": 0,
+              "namespace": "AWS/RDS",
+              "options": {
+                "showDisabledItems": false
+              },
+              "period": "",
+              "refId": "B",
+              "region": "$region",
+              "statistic": "Average"
+            }
+          ],
+          "title": "FreeableMemory/FreeStorageSpace",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "$cwdatasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "iops"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "BurstBalance"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "blue",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  },
+                  {
+                    "id": "unit",
+                    "value": "none"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 91
+          },
+          "id": 19,
+          "options": {
+            "dataLinks": [],
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.3.1",
+          "targets": [
+            {
+              "alias": "",
+              "application": {
+                "filter": ""
+              },
+              "datasource": {
+                "uid": "$cwdatasource"
+              },
+              "dimensions": {
+                "DBInstanceIdentifier": "$dbinstanceidentifier"
+              },
+              "expression": "",
+              "functions": [],
+              "group": {
+                "filter": ""
+              },
+              "host": {
+                "filter": ""
+              },
+              "id": "",
+              "item": {
+                "filter": ""
+              },
+              "label": "",
+              "matchExact": true,
+              "metricEditorMode": 0,
+              "metricName": "ReadIOPS",
+              "metricQueryType": 0,
+              "mode": 0,
+              "namespace": "AWS/RDS",
+              "options": {
+                "showDisabledItems": false
+              },
+              "period": "",
+              "refId": "A",
+              "region": "$region",
+              "statistic": "Average"
+            },
+            {
+              "alias": "",
+              "application": {
+                "filter": ""
+              },
+              "datasource": {
+                "type": "cloudwatch",
+                "uid": "$cwdatasource"
+              },
+              "dimensions": {
+                "DBInstanceIdentifier": "$dbinstanceidentifier"
+              },
+              "expression": "",
+              "functions": [],
+              "group": {
+                "filter": ""
+              },
+              "host": {
+                "filter": ""
+              },
+              "id": "",
+              "item": {
+                "filter": ""
+              },
+              "label": "",
+              "matchExact": true,
+              "metricEditorMode": 0,
+              "metricName": "WriteIOPS",
+              "metricQueryType": 0,
+              "mode": 0,
+              "namespace": "AWS/RDS",
+              "options": {
+                "showDisabledItems": false
+              },
+              "period": "",
+              "refId": "B",
+              "region": "$region",
+              "statistic": "Average"
+            },
+            {
+              "alias": "",
+              "application": {
+                "filter": ""
+              },
+              "datasource": {
+                "uid": "$cwdatasource"
+              },
+              "dimensions": {
+                "DBInstanceIdentifier": "$dbinstanceidentifier"
+              },
+              "expression": "",
+              "functions": [],
+              "group": {
+                "filter": ""
+              },
+              "host": {
+                "filter": ""
+              },
+              "id": "",
+              "item": {
+                "filter": ""
+              },
+              "label": "",
+              "matchExact": true,
+              "metricEditorMode": 0,
+              "metricName": "BurstBalance",
+              "metricQueryType": 0,
+              "mode": 0,
+              "namespace": "AWS/RDS",
+              "options": {
+                "showDisabledItems": false
+              },
+              "period": "",
+              "refId": "C",
+              "region": "$region",
+              "statistic": "Average"
+            }
+          ],
+          "title": "ReadIOPS/WriteIOPS/BurstBalance",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "$cwdatasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "WriteLatency"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "semi-dark-yellow",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 99
+          },
+          "id": 20,
+          "options": {
+            "dataLinks": [],
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.3.1",
+          "targets": [
+            {
+              "alias": "",
+              "application": {
+                "filter": ""
+              },
+              "datasource": {
+                "uid": "$cwdatasource"
+              },
+              "dimensions": {
+                "DBInstanceIdentifier": "$dbinstanceidentifier"
+              },
+              "functions": [],
+              "group": {
+                "filter": ""
+              },
+              "host": {
+                "filter": ""
+              },
+              "item": {
+                "filter": ""
+              },
+              "label": "",
+              "metricEditorMode": 0,
+              "metricName": "ReadLatency",
+              "metricQueryType": 0,
+              "mode": 0,
+              "namespace": "AWS/RDS",
+              "options": {
+                "showDisabledItems": false
+              },
+              "period": "",
+              "refId": "A",
+              "region": "$region",
+              "statistic": "Average"
+            },
+            {
+              "alias": "",
+              "application": {
+                "filter": ""
+              },
+              "datasource": {
+                "type": "cloudwatch",
+                "uid": "$cwdatasource"
+              },
+              "dimensions": {
+                "DBInstanceIdentifier": "$dbinstanceidentifier"
+              },
+              "functions": [],
+              "group": {
+                "filter": ""
+              },
+              "host": {
+                "filter": ""
+              },
+              "item": {
+                "filter": ""
+              },
+              "label": "",
+              "metricEditorMode": 0,
+              "metricName": "WriteLatency",
+              "metricQueryType": 0,
+              "mode": 0,
+              "namespace": "AWS/RDS",
+              "options": {
+                "showDisabledItems": false
+              },
+              "period": "",
+              "refId": "B",
+              "region": "$region",
+              "statistic": "Average"
+            }
+          ],
+          "title": "ReadLatency/WriteLatency",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "$cwdatasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "binBps"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "WriteThroughput"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "semi-dark-yellow",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 99
+          },
+          "id": 21,
+          "options": {
+            "dataLinks": [],
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.3.1",
+          "targets": [
+            {
+              "alias": "",
+              "application": {
+                "filter": ""
+              },
+              "datasource": {
+                "type": "cloudwatch",
+                "uid": "$cwdatasource"
+              },
+              "dimensions": {
+                "DBInstanceIdentifier": "$dbinstanceidentifier"
+              },
+              "functions": [],
+              "group": {
+                "filter": ""
+              },
+              "host": {
+                "filter": ""
+              },
+              "item": {
+                "filter": ""
+              },
+              "label": "",
+              "metricEditorMode": 0,
+              "metricName": "ReadThroughput",
+              "metricQueryType": 0,
+              "mode": 0,
+              "namespace": "AWS/RDS",
+              "options": {
+                "showDisabledItems": false
+              },
+              "period": "",
+              "refId": "A",
+              "region": "$region",
+              "statistic": "Average"
+            },
+            {
+              "alias": "",
+              "application": {
+                "filter": ""
+              },
+              "datasource": {
+                "uid": "$cwdatasource"
+              },
+              "dimensions": {
+                "DBInstanceIdentifier": "$dbinstanceidentifier"
+              },
+              "functions": [],
+              "group": {
+                "filter": ""
+              },
+              "host": {
+                "filter": ""
+              },
+              "item": {
+                "filter": ""
+              },
+              "label": "",
+              "metricEditorMode": 0,
+              "metricName": "WriteThroughput",
+              "metricQueryType": 0,
+              "mode": 0,
+              "namespace": "AWS/RDS",
+              "options": {
+                "showDisabledItems": false
+              },
+              "period": "",
+              "refId": "B",
+              "region": "$region",
+              "statistic": "Average"
+            }
+          ],
+          "title": "ReadThroughput/WriteThroughput",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "$cwdatasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "binBps"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "NetworkTransmitThroughput"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "semi-dark-yellow",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 107
+          },
+          "id": 22,
+          "options": {
+            "dataLinks": [],
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.3.1",
+          "targets": [
+            {
+              "alias": "",
+              "application": {
+                "filter": ""
+              },
+              "datasource": {
+                "uid": "$cwdatasource"
+              },
+              "dimensions": {
+                "DBInstanceIdentifier": "$dbinstanceidentifier"
+              },
+              "functions": [],
+              "group": {
+                "filter": ""
+              },
+              "host": {
+                "filter": ""
+              },
+              "item": {
+                "filter": ""
+              },
+              "label": "",
+              "metricEditorMode": 0,
+              "metricName": "NetworkReceiveThroughput",
+              "metricQueryType": 0,
+              "mode": 0,
+              "namespace": "AWS/RDS",
+              "options": {
+                "showDisabledItems": false
+              },
+              "period": "",
+              "refId": "A",
+              "region": "$region",
+              "statistic": "Average"
+            },
+            {
+              "alias": "",
+              "application": {
+                "filter": ""
+              },
+              "datasource": {
+                "type": "cloudwatch",
+                "uid": "$cwdatasource"
+              },
+              "dimensions": {
+                "DBInstanceIdentifier": "$dbinstanceidentifier"
+              },
+              "functions": [],
+              "group": {
+                "filter": ""
+              },
+              "host": {
+                "filter": ""
+              },
+              "item": {
+                "filter": ""
+              },
+              "label": "",
+              "metricEditorMode": 0,
+              "metricName": "NetworkTransmitThroughput",
+              "metricQueryType": 0,
+              "mode": 0,
+              "namespace": "AWS/RDS",
+              "options": {
+                "showDisabledItems": false
+              },
+              "period": "",
+              "refId": "B",
+              "region": "$region",
+              "statistic": "Average"
+            }
+          ],
+          "title": "NetworkReceiveThroughput/NetworkTransmitThroughput",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "$cwdatasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "BinLogDiskUsage"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "semi-dark-yellow",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 107
+          },
+          "id": 23,
+          "options": {
+            "dataLinks": [],
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.3.1",
+          "targets": [
+            {
+              "alias": "",
+              "application": {
+                "filter": ""
+              },
+              "datasource": {
+                "type": "cloudwatch",
+                "uid": "$cwdatasource"
+              },
+              "dimensions": {
+                "DBInstanceIdentifier": "$dbinstanceidentifier"
+              },
+              "functions": [],
+              "group": {
+                "filter": ""
+              },
+              "host": {
+                "filter": ""
+              },
+              "item": {
+                "filter": ""
+              },
+              "label": "",
+              "metricEditorMode": 0,
+              "metricName": "SwapUsage",
+              "metricQueryType": 0,
+              "mode": 0,
+              "namespace": "AWS/RDS",
+              "options": {
+                "showDisabledItems": false
+              },
+              "period": "",
+              "refId": "A",
+              "region": "$region",
+              "statistic": "Average"
+            },
+            {
+              "alias": "",
+              "application": {
+                "filter": ""
+              },
+              "datasource": {
+                "uid": "$cwdatasource"
+              },
+              "dimensions": {
+                "DBInstanceIdentifier": "$dbinstanceidentifier"
+              },
+              "functions": [],
+              "group": {
+                "filter": ""
+              },
+              "host": {
+                "filter": ""
+              },
+              "item": {
+                "filter": ""
+              },
+              "label": "",
+              "metricEditorMode": 0,
+              "metricName": "BinLogDiskUsage",
+              "metricQueryType": 0,
+              "mode": 0,
+              "namespace": "AWS/RDS",
+              "options": {
+                "showDisabledItems": false
+              },
+              "period": "",
+              "refId": "B",
+              "region": "$region",
+              "statistic": "Average"
+            }
+          ],
+          "title": "SwapUsage/BinLogDiskUsage",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "$cwdatasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "CPUCreditBalance"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "semi-dark-yellow",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 115
+          },
+          "id": 24,
+          "options": {
+            "dataLinks": [],
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.3.1",
+          "targets": [
+            {
+              "alias": "",
+              "application": {
+                "filter": ""
+              },
+              "datasource": {
+                "uid": "$cwdatasource"
+              },
+              "dimensions": {
+                "DBInstanceIdentifier": "$dbinstanceidentifier"
+              },
+              "functions": [],
+              "group": {
+                "filter": ""
+              },
+              "host": {
+                "filter": ""
+              },
+              "item": {
+                "filter": ""
+              },
+              "label": "",
+              "metricEditorMode": 0,
+              "metricName": "CPUCreditUsage",
+              "metricQueryType": 0,
+              "mode": 0,
+              "namespace": "AWS/RDS",
+              "options": {
+                "showDisabledItems": false
+              },
+              "period": "",
+              "refId": "A",
+              "region": "$region",
+              "statistic": "Average"
+            },
+            {
+              "alias": "",
+              "application": {
+                "filter": ""
+              },
+              "datasource": {
+                "type": "cloudwatch",
+                "uid": "$cwdatasource"
+              },
+              "dimensions": {
+                "DBInstanceIdentifier": "$dbinstanceidentifier"
+              },
+              "functions": [],
+              "group": {
+                "filter": ""
+              },
+              "host": {
+                "filter": ""
+              },
+              "item": {
+                "filter": ""
+              },
+              "label": "",
+              "metricEditorMode": 0,
+              "metricName": "CPUCreditBalance",
+              "metricQueryType": 0,
+              "mode": 0,
+              "namespace": "AWS/RDS",
+              "options": {
+                "showDisabledItems": false
+              },
+              "period": "",
+              "refId": "B",
+              "region": "$region",
+              "statistic": "Average"
+            }
+          ],
+          "title": "CPUCreditUsage/CPUCreditBalance",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "$cwdatasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "ReplicaLag"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "semi-dark-yellow",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 115
+          },
+          "id": 25,
+          "options": {
+            "dataLinks": [],
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.3.1",
+          "targets": [
+            {
+              "alias": "",
+              "application": {
+                "filter": ""
+              },
+              "datasource": {
+                "type": "cloudwatch",
+                "uid": "$cwdatasource"
+              },
+              "dimensions": {
+                "DBInstanceIdentifier": "$dbinstanceidentifier"
+              },
+              "expression": "",
+              "functions": [],
+              "group": {
+                "filter": ""
+              },
+              "host": {
+                "filter": ""
+              },
+              "id": "",
+              "item": {
+                "filter": ""
+              },
+              "label": "",
+              "matchExact": true,
+              "metricEditorMode": 0,
+              "metricName": "OldestReplicationSlotLag",
+              "metricQueryType": 0,
+              "mode": 0,
+              "namespace": "AWS/RDS",
+              "options": {
+                "showDisabledItems": false
+              },
+              "period": "",
+              "refId": "A",
+              "region": "$region",
+              "statistic": "Average"
+            },
+            {
+              "alias": "",
+              "application": {
+                "filter": ""
+              },
+              "datasource": {
+                "uid": "$cwdatasource"
+              },
+              "dimensions": {
+                "DBInstanceIdentifier": "$dbinstanceidentifier"
+              },
+              "expression": "",
+              "functions": [],
+              "group": {
+                "filter": ""
+              },
+              "host": {
+                "filter": ""
+              },
+              "id": "",
+              "item": {
+                "filter": ""
+              },
+              "label": "",
+              "matchExact": true,
+              "metricEditorMode": 0,
+              "metricName": "ReplicaLag",
+              "metricQueryType": 0,
+              "mode": 0,
+              "namespace": "AWS/RDS",
+              "options": {
+                "showDisabledItems": false
+              },
+              "period": "",
+              "refId": "B",
+              "region": "$region",
+              "statistic": "Average"
+            }
+          ],
+          "title": "OldestReplicationSlotLag/ReplicaLag",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "$cwdatasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "TransactionLogsDiskUsage"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "semi-dark-yellow",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 123
+          },
+          "id": 26,
+          "options": {
+            "dataLinks": [],
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.3.1",
+          "targets": [
+            {
+              "alias": "",
+              "application": {
+                "filter": ""
+              },
+              "datasource": {
+                "uid": "$cwdatasource"
+              },
+              "dimensions": {
+                "DBInstanceIdentifier": "$dbinstanceidentifier"
+              },
+              "expression": "",
+              "functions": [],
+              "group": {
+                "filter": ""
+              },
+              "host": {
+                "filter": ""
+              },
+              "id": "",
+              "item": {
+                "filter": ""
+              },
+              "label": "",
+              "matchExact": true,
+              "metricEditorMode": 0,
+              "metricName": "ReplicationSlotDiskUsage",
+              "metricQueryType": 0,
+              "mode": 0,
+              "namespace": "AWS/RDS",
+              "options": {
+                "showDisabledItems": false
+              },
+              "period": "",
+              "refId": "A",
+              "region": "$region",
+              "statistic": "Average"
+            },
+            {
+              "alias": "",
+              "application": {
+                "filter": ""
+              },
+              "datasource": {
+                "type": "cloudwatch",
+                "uid": "$cwdatasource"
+              },
+              "dimensions": {
+                "DBInstanceIdentifier": "$dbinstanceidentifier"
+              },
+              "expression": "",
+              "functions": [],
+              "group": {
+                "filter": ""
+              },
+              "host": {
+                "filter": ""
+              },
+              "id": "",
+              "item": {
+                "filter": ""
+              },
+              "label": "",
+              "matchExact": true,
+              "metricEditorMode": 0,
+              "metricName": "TransactionLogsDiskUsage",
+              "metricQueryType": 0,
+              "mode": 0,
+              "namespace": "AWS/RDS",
+              "options": {
+                "showDisabledItems": false
+              },
+              "period": "",
+              "refId": "B",
+              "region": "$region",
+              "statistic": "Average"
+            }
+          ],
+          "title": "ReplicationSlotDiskUsage/TransactionLogsDiskUsage",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "$cwdatasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "TransactionLogsGeneration"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "semi-dark-yellow",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 123
+          },
+          "id": 27,
+          "options": {
+            "dataLinks": [],
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.3.1",
+          "targets": [
+            {
+              "alias": "",
+              "application": {
+                "filter": ""
+              },
+              "datasource": {
+                "type": "cloudwatch",
+                "uid": "$cwdatasource"
+              },
+              "dimensions": {
+                "DBInstanceIdentifier": "$dbinstanceidentifier"
+              },
+              "expression": "",
+              "functions": [],
+              "group": {
+                "filter": ""
+              },
+              "host": {
+                "filter": ""
+              },
+              "id": "",
+              "item": {
+                "filter": ""
+              },
+              "label": "",
+              "matchExact": true,
+              "metricEditorMode": 0,
+              "metricName": "MaximumUsedTransactionIDs",
+              "metricQueryType": 0,
+              "mode": 0,
+              "namespace": "AWS/RDS",
+              "options": {
+                "showDisabledItems": false
+              },
+              "period": "",
+              "refId": "A",
+              "region": "$region",
+              "statistic": "Average"
+            },
+            {
+              "alias": "",
+              "application": {
+                "filter": ""
+              },
+              "datasource": {
+                "uid": "$cwdatasource"
+              },
+              "dimensions": {
+                "DBInstanceIdentifier": "$dbinstanceidentifier"
+              },
+              "expression": "",
+              "functions": [],
+              "group": {
+                "filter": ""
+              },
+              "host": {
+                "filter": ""
+              },
+              "id": "",
+              "item": {
+                "filter": ""
+              },
+              "label": "",
+              "matchExact": true,
+              "metricEditorMode": 0,
+              "metricName": "TransactionLogsGeneration",
+              "metricQueryType": 0,
+              "mode": 0,
+              "namespace": "AWS/RDS",
+              "options": {
+                "showDisabledItems": false
+              },
+              "period": "",
+              "refId": "B",
+              "region": "$region",
+              "statistic": "Average"
+            }
+          ],
+          "title": "MaximumUsedTransactionIDs/TransactionLogsGeneration",
+          "type": "timeseries"
         }
       ],
       "preload": false,
       "refresh": "",
       "schemaVersion": 40,
       "tags": [
-        "api",
+        "${ENV_NAME}",
+        "Authz",
+        "LASSIE",
+        "IDAM",
         "LAA",
         "LAA Landing Page"
       ],
       "templating": {
-        "list": []
+        "list": [
+          {
+            "current": {
+              "text": "Cloudwatch",
+              "value": "P896B4444D3F0DAB8"
+            },
+            "hide": 2,
+            "includeAll": false,
+            "label": "Cloudwatch Datasource",
+            "name": "cwdatasource",
+            "options": [],
+            "query": "cloudwatch",
+            "refresh": 1,
+            "regex": "",
+            "type": "datasource"
+          },
+          {
+            "current": {
+              "text": "default",
+              "value": "default"
+            },
+            "datasource": {
+              "type": "cloudwatch",
+              "uid": "$cwdatasource"
+            },
+            "definition": "",
+            "hide": 2,
+            "includeAll": false,
+            "label": "Region",
+            "name": "region",
+            "options": [],
+            "query": "regions()",
+            "refresh": 1,
+            "regex": "",
+            "type": "query"
+          },
+          {
+            "current": {
+              "text": "${RDS_DB_IDENTIFIER}",
+              "value": "${RDS_DB_IDENTIFIER}"
+            },
+            "hide": 2,
+            "name": "dbinstanceidentifier",
+            "options": [
+              {
+                "selected": true,
+                "text": "${RDS_DB_IDENTIFIER}",
+                "value": "${RDS_DB_IDENTIFIER}"
+              }
+            ],
+            "query": "${RDS_DB_IDENTIFIER}",
+            "type": "textbox"
+          },
+          {
+            "current": {
+              "text": "${NAMESPACE}",
+              "value": "${NAMESPACE}"
+            },
+            "hide": 2,
+            "name": "cpnamespace",
+            "options": [
+              {
+                "selected": true,
+                "text": "${NAMESPACE}",
+                "value": "${NAMESPACE}"
+              }
+            ],
+            "query": "${NAMESPACE}",
+            "type": "textbox"
+          }
+        ]
       },
       "time": {
         "from": "now-12h",

--- a/deployments/templates/prometheus.yml
+++ b/deployments/templates/prometheus.yml
@@ -99,3 +99,77 @@ spec:
           for: 1m
           labels:
             severity: ${ALERT_SEVERITY}
+
+    - name: database-rules
+      rules:
+        - alert: RDSHighCPU
+          expr: aws_rds_cpuutilization_average{dbinstance_identifier="$RDS_DB_IDENTIFIER"} > 75
+          for: 1m
+          labels:
+            severity: ${ALERT_SEVERITY}
+          annotations:
+            message: CPU usage for the RDS instance in {{ $labels.namespace }} over 75%
+            dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/${NAMESPACE}"
+
+        - alert: RDSLowStorage
+          expr: aws_rds_free_storage_space_average{dbinstance_identifier="$RDS_DB_IDENTIFIER"} < 1024*1024*1024
+          for: 1m
+          labels:
+            severity: ${ALERT_SEVERITY}
+          annotations:
+            message: Free storage space for the RDS instance in {{ $labels.namespace }} is less than 1GB
+            dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/${NAMESPACE}"
+
+        - alert: RDSHighReadLatency
+          expr: aws_rds_read_latency_average{dbinstance_identifier="$RDS_DB_IDENTIFIER"} > 0.5
+          for: 1m
+          labels:
+            severity: ${ALERT_SEVERITY}
+          annotations:
+            message: Read latency for the RDS instance in {{ $labels.namespace }} is over 0.5 seconds
+            dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/${NAMESPACE}"
+
+        - alert: RDSHighWriteLatency
+          expr: aws_rds_write_latency_average{dbinstance_identifier="$RDS_DB_IDENTIFIER"} > 0.5
+          for: 1m
+          labels:
+            severity: ${ALERT_SEVERITY}
+          annotations:
+            message: Write latency for the RDS instance in {{ $labels.namespace }} is over 0.5 seconds
+            dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/${NAMESPACE}"
+
+        - alert: RDSLowFreeableMemory
+          expr: aws_rds_freeable_memory_average{dbinstance_identifier="$RDS_DB_IDENTIFIER"} < 500*1024*1024
+          for: 1m
+          labels:
+            severity: ${ALERT_SEVERITY}
+          annotations:
+            message: Freeable memory for the RDS instance in {{ $labels.namespace }} is less than 500MB
+            dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/${NAMESPACE}"
+
+        - alert: RDSHighWriteIOPS
+          expr: aws_rds_write_iops_average{dbinstance_identifier="$RDS_DB_IDENTIFIER"} > 300
+          for: 1m
+          labels:
+            severity: ${ALERT_SEVERITY}
+          annotations:
+            message: Write operations for the RDS instance in {{ $labels.namespace }} are over 300 per second
+            dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/${NAMESPACE}"
+
+        - alert: RDSHighReadIOPS
+          expr: aws_rds_read_iops_average{dbinstance_identifier="$RDS_DB_IDENTIFIER"} > 900
+          for: 1m
+          labels:
+            severity: ${ALERT_SEVERITY}
+          annotations:
+            message: Read operations for the RDS instance in {{ $labels.namespace }} are over 900 per second
+            dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/${NAMESPACE}"
+
+        - alert: RDSHighDatabaseConnections
+          expr: aws_rds_database_connections_average{dbinstance_identifier="$RDS_DB_IDENTIFIER"} > 65
+          for: 5m
+          labels:
+            severity: ${ALERT_SEVERITY}
+          annotations:
+            message: Database connection count for the RDS instance in {{ $labels.namespace }} is over 65
+            dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/${NAMESPACE}"

--- a/deployments/templates/prometheus.yml
+++ b/deployments/templates/prometheus.yml
@@ -13,7 +13,7 @@ spec:
       rules:
         - alert: KubePodNotReady
           annotations:
-            message: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready
+            message: Pod {{ $labels.namespace }}/{{ $labels.pod }} in ${ENV_NAME} has been in a non-ready
               state for longer than fifteen minutes.
             runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready
             dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/${NAMESPACE}"
@@ -21,15 +21,17 @@ spec:
           for: 15m
           labels:
             severity: ${ALERT_SEVERITY}
+
         - alert: KubePodCrashLooping
           annotations:
-            message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting excessively
+            message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) in ${ENV_NAME} is restarting excessively
             runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodcrashlooping
             dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/${NAMESPACE}"
           expr: rate(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace="${NAMESPACE}"}[10m]) * 60 * 10 > 1
           for: 5m
           labels:
             severity: ${ALERT_SEVERITY}
+
         - alert: KubeNamespaceQuotaNearing
           annotations:
             message: Namespace {{ $labels.namespace }} is using {{ printf "%0.0f" $value }}% of its {{ $labels.resource }} quota.
@@ -43,15 +45,17 @@ spec:
           for: 5m
           labels:
             severity: ${ALERT_SEVERITY}
+
         - alert: KubeJobFailed
           annotations:
-            message: Failed Cron Job in {{ $labels.namespace }}/{{ $labels.job_name }}
+            message: Failed Cron Job in {{ $labels.namespace }}/{{ $labels.job_name }} in ${ENV_NAME} 
             runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobfailed
             dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/${NAMESPACE}"
           expr: kube_job_status_failed{job="kube-state-metrics", namespace="${NAMESPACE}"}  > 0
           for: 1h
           labels:
             severity: ${ALERT_SEVERITY}
+
         - alert: KubeDeploymentGenerationMismatch
           annotations:
             message: Deployment generation mismatch in {{ $labels.namespace }} due to possible roll-back.
@@ -61,6 +65,7 @@ spec:
           for: 15m
           labels:
             severity: ${ALERT_SEVERITY}
+
         - alert: KubeDeploymentReplicasMismatch
           annotations:
             message: Deployment in {{ $labels.namespace }} has not matched the expected number of replicas.
@@ -70,11 +75,12 @@ spec:
           for: 15m
           labels:
             severity: ${ALERT_SEVERITY}
+
     - name: application-rules
       rules:
         - alert: nginx-SlowResponses
           annotations:
-            message: Ingress {{ $labels.ingress }} is serving slow responses over 2 seconds.
+            message: Ingress in ${ENV_NAME} is serving slow responses over 2 seconds.
             dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/${NAMESPACE}"
           expr: |-
             avg(rate(nginx_ingress_controller_request_duration_seconds_sum{exported_namespace = "${NAMESPACE}"}[5m])
@@ -83,93 +89,107 @@ spec:
           for: 1m
           labels:
             severity: ${ALERT_SEVERITY}
+
         - alert: 5xxErrorResponses
           annotations:
-            message: Ingress {{ $labels.ingress }} is serving 5XX responses.
+            message: Ingress in ${ENV_NAME} is serving 5XX responses.
             dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/${NAMESPACE}"
           expr: sum(rate(nginx_ingress_controller_requests{exported_namespace="${NAMESPACE}", status=~"5.*"}[5m]))*270 > 10
           for: 1m
           labels:
             severity: ${ALERT_SEVERITY}
+
         - alert: 4xxErrorResponses
           annotations:
-            message: Ingress {{ $labels.ingress }} is serving 4XX responses.
+            message: Ingress in ${ENV_NAME} is serving 4XX responses.
             dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/${NAMESPACE}"
           expr: sum(rate(nginx_ingress_controller_requests{exported_namespace="${NAMESPACE}", status=~"4.*"}[5m]))*270 > 10
           for: 1m
           labels:
             severity: ${ALERT_SEVERITY}
 
+        - alert: ContainerMemoryUsageHigh
+          annotations:
+            message: Memory usage compared to the memory limit on the container in ${ENV_NAME} is more than 85% for 5m
+            dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/${NAMESPACE}"
+          expr: |-
+            (sum(container_memory_working_set_bytes{namespace="${NAMESPACE}", container="laa-landing-page", image!=""}) 
+            / 
+            sum(kube_pod_container_resource_limits{namespace="${NAMESPACE}", container="laa-landing-page", unit="byte"})) * 100 > 85
+          for: 5m
+          labels:
+            severity: ${ALERT_SEVERITY}
+
     - name: database-rules
       rules:
         - alert: RDSHighCPU
+          annotations:
+            message: CPU usage for the RDS instance in {{ $labels.namespace }} over 75%
+            dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/${NAMESPACE}"
           expr: aws_rds_cpuutilization_average{dbinstance_identifier="$RDS_DB_IDENTIFIER"} > 75
           for: 1m
           labels:
             severity: ${ALERT_SEVERITY}
-          annotations:
-            message: CPU usage for the RDS instance in {{ $labels.namespace }} over 75%
-            dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/${NAMESPACE}"
 
         - alert: RDSLowStorage
+          annotations:
+            message: Free storage space for the RDS instance in {{ $labels.namespace }} is less than 1GB
+            dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/${NAMESPACE}"
           expr: aws_rds_free_storage_space_average{dbinstance_identifier="$RDS_DB_IDENTIFIER"} < 1024*1024*1024
           for: 1m
           labels:
             severity: ${ALERT_SEVERITY}
-          annotations:
-            message: Free storage space for the RDS instance in {{ $labels.namespace }} is less than 1GB
-            dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/${NAMESPACE}"
 
         - alert: RDSHighReadLatency
+          annotations:
+            message: Read latency for the RDS instance in {{ $labels.namespace }} is over 0.5 seconds
+            dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/${NAMESPACE}"
           expr: aws_rds_read_latency_average{dbinstance_identifier="$RDS_DB_IDENTIFIER"} > 0.5
           for: 1m
           labels:
             severity: ${ALERT_SEVERITY}
-          annotations:
-            message: Read latency for the RDS instance in {{ $labels.namespace }} is over 0.5 seconds
-            dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/${NAMESPACE}"
 
         - alert: RDSHighWriteLatency
+          annotations:
+            message: Write latency for the RDS instance in {{ $labels.namespace }} is over 0.5 seconds
+            dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/${NAMESPACE}"
           expr: aws_rds_write_latency_average{dbinstance_identifier="$RDS_DB_IDENTIFIER"} > 0.5
           for: 1m
           labels:
             severity: ${ALERT_SEVERITY}
-          annotations:
-            message: Write latency for the RDS instance in {{ $labels.namespace }} is over 0.5 seconds
-            dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/${NAMESPACE}"
 
         - alert: RDSLowFreeableMemory
-          expr: aws_rds_freeable_memory_average{dbinstance_identifier="$RDS_DB_IDENTIFIER"} < 500*1024*1024
+          annotations:
+            message: Freeable memory for the RDS instance in {{ $labels.namespace }} is less than ${RDS_LOW_FREEABLE_MEMORY_TRIGGER}MB
+            dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/${NAMESPACE}"
+          expr: aws_rds_freeable_memory_average{dbinstance_identifier="$RDS_DB_IDENTIFIER"} < ${RDS_LOW_FREEABLE_MEMORY_TRIGGER}*1024*1024
           for: 1m
           labels:
             severity: ${ALERT_SEVERITY}
-          annotations:
-            message: Freeable memory for the RDS instance in {{ $labels.namespace }} is less than 500MB
-            dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/${NAMESPACE}"
 
         - alert: RDSHighWriteIOPS
+          annotations:
+            message: Write operations for the RDS instance in {{ $labels.namespace }} are over 300 per second
+            dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/${NAMESPACE}"
           expr: aws_rds_write_iops_average{dbinstance_identifier="$RDS_DB_IDENTIFIER"} > 300
           for: 1m
           labels:
             severity: ${ALERT_SEVERITY}
-          annotations:
-            message: Write operations for the RDS instance in {{ $labels.namespace }} are over 300 per second
-            dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/${NAMESPACE}"
 
         - alert: RDSHighReadIOPS
+          annotations:
+            message: Read operations for the RDS instance in {{ $labels.namespace }} are over 900 per second
+            dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/${NAMESPACE}"
           expr: aws_rds_read_iops_average{dbinstance_identifier="$RDS_DB_IDENTIFIER"} > 900
           for: 1m
           labels:
             severity: ${ALERT_SEVERITY}
-          annotations:
-            message: Read operations for the RDS instance in {{ $labels.namespace }} are over 900 per second
-            dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/${NAMESPACE}"
 
         - alert: RDSHighDatabaseConnections
+          annotations:
+            message: Database connection count for the RDS instance in {{ $labels.namespace }} is over 65
+            dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/${NAMESPACE}"
           expr: aws_rds_database_connections_average{dbinstance_identifier="$RDS_DB_IDENTIFIER"} > 65
           for: 5m
           labels:
             severity: ${ALERT_SEVERITY}
-          annotations:
-            message: Database connection count for the RDS instance in {{ $labels.namespace }} is over 65
-            dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/${NAMESPACE}"

--- a/deployments/templates/prometheus.yml
+++ b/deployments/templates/prometheus.yml
@@ -48,7 +48,7 @@ spec:
 
         - alert: KubeJobFailed
           annotations:
-            message: Failed Cron Job in {{ $labels.namespace }}/{{ $labels.job_name }} in ${ENV_NAME} 
+            message: Failed Cron Job in {{ $labels.namespace }}/{{ $labels.job_name }} in ${ENV_NAME}
             runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobfailed
             dashboard_url: "https://grafana.live.cloud-platform.service.justice.gov.uk/d/${NAMESPACE}"
           expr: kube_job_status_failed{job="kube-state-metrics", namespace="${NAMESPACE}"}  > 0


### PR DESCRIPTION
- Adds custom alerts for our RDS databases
- Adds panels to display RDS metrics in our Grafana dashboards
- Reordered deployment to deploy monitoring in a separate step after deployment of other Cloud Platform resources, to ensure can gain database identifier after it exists
- Small improvements to Grafana dashboard json model to make it easier to edit in future, e.g. using templating variables
- Small improvements to current alerts

https://dsdmoj.atlassian.net/browse/STB-1714