### PR TITLE
Fixed bug where app screen was still referencing old user link

### DIFF
--- a/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/AppSelectionTest.java
+++ b/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/AppSelectionTest.java
@@ -106,7 +106,7 @@ public class AppSelectionTest extends BaseIntegrationTest {
                 .andExpect(status().is3xxRedirection())
                 .andReturn();
         assertNotNull(result.getResponse().getRedirectedUrl());
-        assertEquals(result.getResponse().getRedirectedUrl(), String.format("/users/edit/%s/roles", userId));
+        assertEquals(result.getResponse().getRedirectedUrl(), String.format("/admin/users/edit/%s/roles", userId));
         HttpSession session = result.getRequest().getSession();
         assertNotNull(session.getAttribute("selectedApps"));
         List<String> returnedSelectApps = (List<String>) session.getAttribute("selectedApps");

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
@@ -349,7 +349,7 @@ public class UserController {
     public RedirectView updateUserRoles(@PathVariable String id,
             @RequestParam(required = false) List<String> selectedRoles) {
         userService.updateUserRoles(id, selectedRoles);
-        return new RedirectView("/users");
+        return new RedirectView("/admin/users");
     }
 
     /**
@@ -374,6 +374,6 @@ public class UserController {
         session.setAttribute("selectedApps", apps);
         // Ensure passed in ID is a valid UUID to avoid open redirects.
         UUID uuid = UUID.fromString(id);
-        return new RedirectView(String.format("/users/edit/%s/roles", uuid));
+        return new RedirectView(String.format("/admin/users/edit/%s/roles", uuid));
     }
 }

--- a/src/main/resources/templates/edit-user-apps.html
+++ b/src/main/resources/templates/edit-user-apps.html
@@ -20,7 +20,7 @@
             <a class="govuk-breadcrumbs__link" href="/">Home</a>
         </li>
         <li class="govuk-breadcrumbs__list-item">
-            <a class="govuk-breadcrumbs__link" href="/users">Users</a>
+            <a class="govuk-breadcrumbs__link" href="/admin/users">Users</a>
         </li>
         <li class="govuk-breadcrumbs__list-item">
             Edit Apps for <span th:text="${user.fullName}"></span>
@@ -30,7 +30,7 @@
 
 <main class="govuk-main-wrapper" id="main-content">
     <div th:if="${#authentication.isAuthenticated()}">
-        <a class="govuk-back-link govuk-!-margin-bottom-3" th:href="@{/users}">
+        <a class="govuk-back-link govuk-!-margin-bottom-3" th:href="@{/admin/users}">
             Back
         </a>
 
@@ -38,7 +38,7 @@
 
         <h1 class="govuk-heading-l">Add permissions for <span th:text="${user.fullName}"></span></h1>
 
-        <form method="post" th:action="@{/users/edit/{id}/apps(id=${user.id})}">
+        <form method="post" th:action="@{/admin/users/edit/{id}/apps(id=${user.id})}">
             <fieldset class="govuk-fieldset">
                 <p class="govuk-hint govuk-!-margin-bottom-3">
                     Select all that apply. Roles will be displayed for the user based on what has been selected.

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/UserControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/UserControllerTest.java
@@ -631,7 +631,7 @@ class UserControllerTest {
         RedirectView view = userController.updateUserRoles(userId, selectedRoles);
 
         // Then
-        Assertions.assertEquals("/users", view.getUrl());
+        Assertions.assertEquals("/admin/users", view.getUrl());
     }
 
     @Test
@@ -680,7 +680,7 @@ class UserControllerTest {
         RedirectView redirectView = userController.setSelectedAppsEdit(userId.toString(), apps, session);
 
         // Then
-        assertThat(redirectView.getUrl()).isEqualTo(String.format("/users/edit/%s/roles", userId));
+        assertThat(redirectView.getUrl()).isEqualTo(String.format("/admin/users/edit/%s/roles", userId));
         assertThat(session.getAttribute("selectedApps")).isNotNull();
         List<String> returnedApps = (List<String>) session.getAttribute("selectedApps");
         assertThat(returnedApps).hasSize(1);


### PR DESCRIPTION
The application assignment work was added after we pre-pended a lot of our endpoints with /admin/. This PR fixes that.