### PR TITLE
Added validation to ensure a user has to select at least 1 application/service before moving on to assign roles.

### DIFF
--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
@@ -167,8 +167,6 @@ public class UserController {
         userDetailsForm = UserUtils.populateUserDetailsFormWithSession(userDetailsForm, user, session);
         model.addAttribute("userDetailsForm", userDetailsForm);
         model.addAttribute("user", user);
-        model.addAttribute("userDetailsForm", userDetailsForm);
-        model.addAttribute("user", user);
 
         // Store the model in session to handle validation errors later
         session.setAttribute("createUserDetailsModel", model);

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
@@ -12,7 +12,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.modelmapper.ModelMapper;
-
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
@@ -37,7 +36,6 @@ import uk.gov.justice.laa.portal.landingpage.dto.CurrentUserDto;
 import uk.gov.justice.laa.portal.landingpage.dto.EntraUserDto;
 import uk.gov.justice.laa.portal.landingpage.dto.FirmDto;
 import uk.gov.justice.laa.portal.landingpage.dto.OfficeData;
-
 import uk.gov.justice.laa.portal.landingpage.entity.EntraUser;
 import uk.gov.justice.laa.portal.landingpage.entity.Office;
 import uk.gov.justice.laa.portal.landingpage.forms.ApplicationsForm;
@@ -51,9 +49,6 @@ import uk.gov.justice.laa.portal.landingpage.service.FirmService;
 import uk.gov.justice.laa.portal.landingpage.service.LoginService;
 import uk.gov.justice.laa.portal.landingpage.service.OfficeService;
 import uk.gov.justice.laa.portal.landingpage.service.UserService;
-import uk.gov.justice.laa.portal.landingpage.viewmodel.AppRoleViewModel;
-import uk.gov.justice.laa.portal.landingpage.viewmodel.AppViewModel;
-
 import static uk.gov.justice.laa.portal.landingpage.utils.RestUtils.getListFromHttpSession;
 import static uk.gov.justice.laa.portal.landingpage.utils.RestUtils.getObjectFromHttpSession;
 import uk.gov.justice.laa.portal.landingpage.utils.UserUtils;
@@ -234,17 +229,31 @@ public class UserController {
         model.addAttribute("apps", apps);
         User user = getObjectFromHttpSession(session, "user", User.class).orElseGet(User::new);
         model.addAttribute("user", user);
+        // Store the model in session to handle validation errors later
+        session.setAttribute("userCreateAppsModel", model);
         return "add-user-apps";
     }
 
     @PostMapping("/user/create/services")
-    public String setSelectedApps(ApplicationsForm applicationsForm, Model model,
-            HttpSession session
-    ) {
-        if (applicationsForm.getApps() == null || applicationsForm.getApps().isEmpty()) {
-            return "redirect:/admin/user/create/check-answers";
+    public String setSelectedApps(@Valid ApplicationsForm applicationsForm, BindingResult result, Model model,
+            HttpSession session) {
+
+        if (result.hasErrors()) {
+            log.debug("Validation errors occurred while selecting applications: {}", result.getAllErrors());
+            // If there are validation errors, return to the apps page with errors
+            Model modelFromSession = (Model) session.getAttribute("userCreateAppsModel");
+            if (modelFromSession == null) {
+                return "redirect:/admin/user/create/services";
+            }
+            model.addAttribute("apps", modelFromSession.getAttribute("apps"));
+            model.addAttribute("user", modelFromSession.getAttribute("user"));
+            return "add-user-apps";
         }
+
         session.setAttribute("apps", applicationsForm.getApps());
+        // Clear the userCreateAppsModel from session to avoid stale data
+        session.removeAttribute("userCreateAppsModel");
+        // Redirect to roles selection page
         return "redirect:/admin/user/create/roles";
     }
 
@@ -293,13 +302,14 @@ public class UserController {
 
     @GetMapping("/user/create/offices")
     public String offices(OfficesForm officesForm, HttpSession session, Model model) {
-        OfficeData selectedOfficeData = getObjectFromHttpSession(session, "officeData", OfficeData.class).orElseGet(OfficeData::new);
-        //if user has firms, use officeService.getOfficesByFirms();
+        OfficeData selectedOfficeData = getObjectFromHttpSession(session, "officeData", OfficeData.class)
+                .orElseGet(OfficeData::new);
+        // if user has firms, use officeService.getOfficesByFirms();
         List<Office> offices = officeService.getOffices();
         List<OfficeModel> officeData = offices.stream()
                 .map(office -> new OfficeModel(office.getName(), office.getAddress(),
-                office.getId().toString(), Objects.nonNull(selectedOfficeData.getSelectedOffices())
-                && selectedOfficeData.getSelectedOffices().contains(office.getId().toString())))
+                        office.getId().toString(), Objects.nonNull(selectedOfficeData.getSelectedOffices())
+                                && selectedOfficeData.getSelectedOffices().contains(office.getId().toString())))
                 .collect(Collectors.toList());
         model.addAttribute("officeData", officeData);
         User user = getObjectFromHttpSession(session, "user", User.class).orElseGet(User::new);
@@ -311,8 +321,7 @@ public class UserController {
     }
 
     @PostMapping("/user/create/offices")
-    public String postOffices(@Valid OfficesForm officesForm, BindingResult result, Model model, HttpSession session
-    ) {
+    public String postOffices(@Valid OfficesForm officesForm, BindingResult result, Model model, HttpSession session) {
 
         if (result.hasErrors()) {
             log.debug("Validation errors occurred while selecting offices: {}", result.getAllErrors());
@@ -330,7 +339,7 @@ public class UserController {
         OfficeData officeData = new OfficeData();
         List<String> selectedOffices = officesForm.getOffices();
         officeData.setSelectedOffices(officesForm.getOffices());
-        //if user has firms, use officeService.getOfficesByFirms();
+        // if user has firms, use officeService.getOfficesByFirms();
         List<Office> offices = officeService.getOffices();
         List<String> selectedDisplayNames = new ArrayList<>();
         for (Office office : offices) {
@@ -352,7 +361,8 @@ public class UserController {
         List<String> selectedApps = getListFromHttpSession(session, "apps", String.class).orElseGet(ArrayList::new);
         if (!selectedApps.isEmpty()) {
             List<AppRoleDto> roles = userService.getAllAvailableRolesForApps(selectedApps);
-            List<String> selectedRoles = getListFromHttpSession(session, "roles", String.class).orElseGet(ArrayList::new);
+            List<String> selectedRoles = getListFromHttpSession(session, "roles", String.class)
+                    .orElseGet(ArrayList::new);
             Map<String, List<AppRoleViewModel>> cyaRoles = new HashMap<>();
             List<String> displayRoles = new ArrayList<>();
             for (AppRoleDto role : roles) {
@@ -370,7 +380,8 @@ public class UserController {
         User user = getObjectFromHttpSession(session, "user", User.class).orElseGet(User::new);
         model.addAttribute("user", user);
 
-        OfficeData officeData = getObjectFromHttpSession(session, "officeData", OfficeData.class).orElseGet(OfficeData::new);
+        OfficeData officeData = getObjectFromHttpSession(session, "officeData", OfficeData.class)
+                .orElseGet(OfficeData::new);
         model.addAttribute("officeData", officeData);
 
         FirmDto selectedFirm = (FirmDto) session.getAttribute("firm");
@@ -382,13 +393,15 @@ public class UserController {
     }
 
     @PostMapping("/user/create/check-answers")
-    //@PreAuthorize("hasAuthority('SCOPE_User.ReadWrite.All') and hasAuthority('SCOPE_Directory.ReadWrite.All')")
+    // @PreAuthorize("hasAuthority('SCOPE_User.ReadWrite.All') and
+    // hasAuthority('SCOPE_Directory.ReadWrite.All')")
     public RedirectView addUserCheckAnswers(HttpSession session, Authentication authentication) {
         Optional<User> userOptional = getObjectFromHttpSession(session, "user", User.class);
         Optional<List<String>> selectedRolesOptional = getListFromHttpSession(session, "roles", String.class);
         Optional<FirmDto> firmOptional = Optional.ofNullable((FirmDto) session.getAttribute("firm"));
         Optional<Boolean> isFirmAdminOptional = Optional.ofNullable((Boolean) session.getAttribute("isFirmAdmin"));
-        Optional<OfficeData> optionalSelectedOfficeData = getObjectFromHttpSession(session, "officeData", OfficeData.class);
+        Optional<OfficeData> optionalSelectedOfficeData = getObjectFromHttpSession(session, "officeData",
+                OfficeData.class);
 
         if (userOptional.isPresent()) {
             User user = userOptional.get();
@@ -398,11 +411,15 @@ public class UserController {
 
             FirmDto selectedFirm = firmOptional.orElseGet(FirmDto::new);
             Boolean isFirmAdmin = isFirmAdminOptional.orElse(Boolean.FALSE);
-            List<String> selectedOffices = optionalSelectedOfficeData.map(OfficeData::getSelectedOffices).orElseGet(ArrayList::new);
-            List<String> selectedOfficesDisplay = optionalSelectedOfficeData.map(OfficeData::getSelectedOfficesDisplay).orElseGet(ArrayList::new);
+            List<String> selectedOffices = optionalSelectedOfficeData.map(OfficeData::getSelectedOffices)
+                    .orElseGet(ArrayList::new);
+            List<String> selectedOfficesDisplay = optionalSelectedOfficeData.map(OfficeData::getSelectedOfficesDisplay)
+                    .orElseGet(ArrayList::new);
             CurrentUserDto currentUserDto = loginService.getCurrentUser(authentication);
-            EntraUser entraUser = userService.createUser(user, selectedRoles, selectedOffices, selectedFirm, isFirmAdmin, currentUserDto.getName());
-            eventService.auditUserCreate(currentUserDto, entraUser, displayRoles, selectedOfficesDisplay, selectedFirm.getName());
+            EntraUser entraUser = userService.createUser(user, selectedRoles, selectedOffices, selectedFirm,
+                    isFirmAdmin, currentUserDto.getName());
+            eventService.auditUserCreate(currentUserDto, entraUser, displayRoles, selectedOfficesDisplay,
+                    selectedFirm.getName());
 
             String successMessage = "" + user.getGivenName() + " "
                     + user.getSurname()
@@ -440,7 +457,8 @@ public class UserController {
     @GetMapping("/users/edit/{id}/roles")
     public String editUserRoles(@PathVariable String id, Model model, HttpSession session) {
         EntraUserDto user = userService.getEntraUserById(id).orElseThrow();
-        List<String> selectedApps = getListFromHttpSession(session, "selectedApps", String.class).orElseGet(ArrayList::new);
+        List<String> selectedApps = getListFromHttpSession(session, "selectedApps", String.class)
+                .orElseGet(ArrayList::new);
         List<AppRoleDto> userRoles = userService.getUserAppRolesByUserId(id);
         List<AppRoleDto> availableRoles = userService.getAppRolesByAppIds(selectedApps);
 

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
@@ -366,7 +366,9 @@ public class UserController {
             for (AppRoleDto role : roles) {
                 if (selectedRoles.contains(role.getId())) {
                     List<AppRoleViewModel> appRoles = cyaRoles.getOrDefault(role.getApp().getId(), new ArrayList<>());
-                    appRoles.add(mapper.map(role, AppRoleViewModel.class));
+                    AppRoleViewModel appRoleViewModel = mapper.map(role, AppRoleViewModel.class);
+                    appRoleViewModel.setAppName(role.getApp().getName());
+                    appRoles.add(appRoleViewModel);
                     cyaRoles.put(role.getApp().getId(), appRoles);
                     displayRoles.add(role.getName());
                 }

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/forms/ApplicationsForm.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/forms/ApplicationsForm.java
@@ -2,9 +2,11 @@ package uk.gov.justice.laa.portal.landingpage.forms;
 
 import java.util.List;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 @Data
 public class ApplicationsForm {
+    @NotNull(message = "At least one application must be selected")
     List<String> apps;
 }

--- a/src/main/resources/templates/add-user-apps.html
+++ b/src/main/resources/templates/add-user-apps.html
@@ -20,8 +20,22 @@
     </nav>
     <main class="govuk-main-wrapper" id="main-content">
         <form method="post" th:action="@{/admin/user/create/services}" th:object="${applicationsForm}">
+            <div th:if="${#fields.hasErrors()}">
+                <div class="govuk-error-summary" role="alert" aria-labelledby="error-summary-title"
+                    aria-describedby="error-summary-description" data-module="govuk-error-summary">
+                    <h2 class="govuk-error-summary__title" id="error-summary-title">
+                        There is a problem
+                    </h2>
+                    <div class="govuk-error-summary__body" id="error-summary-description">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li th:each="error : ${#fields.errors()}"><a href="#" th:text="${error}"></a></li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
             <div class="govuk-form-group">
-                <fieldset class="govuk-fieldset">
+                <fieldset class="govuk-fieldset"
+                    th:classappend="${#fields.hasErrors('apps')} ? 'govuk-form-group--error'">
                     <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
                         <h1 class="govuk-fieldset__heading">
                             Which services will <span th:text="${user.givenName}"></span> <span
@@ -31,11 +45,16 @@
                     <div id="offices-hint" class="govuk-hint">
                         Select all that apply
                     </div>
-                    <div class="govuk-checkboxes govuk-!-padding-top-3" data-module="govuk-checkboxes">
+                    <div th:if="${#fields.hasErrors('apps')}" class="govuk-error-message">
+                        <span class="govuk-visually-hidden">Error:</span>
+                        <span th:each="err : ${#fields.errors('apps')}" th:text="${err}"></span>
+                    </div>
+                    <div class="govuk-checkboxes govuk-!-padding-top-3" data-module="govuk-checkboxes"
+                        th:classappend="${#fields.hasErrors('apps')} ? 'govuk-form-group--error'">
                         <div class="govuk-checkboxes__item" th:each="app : ${apps}">
-                            <input class="govuk-checkboxes__input" id="apps" name="apps" th:checked="${app.selected}"
-                                th:value="${app.id}" type="checkbox">
-                            <label class="govuk-label govuk-checkboxes__label" th:for="${app.id}">
+                            <input class="govuk-checkboxes__input" id="apps__${app.id}" name="apps"
+                                th:checked="${app.selected}" th:value="${app.id}" type="checkbox">
+                            <label class="govuk-label govuk-checkboxes__label" th:for="${'apps__' + app.id}">
                                 <span th:text="${app.name}"></span>
                             </label>
                         </div>

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/UserControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/UserControllerTest.java
@@ -86,7 +86,8 @@ class UserControllerTest {
 
     @BeforeEach
     void setUp() {
-        userController = new UserController(loginService, userService, officeService, eventService, firmService, new MapperConfig().modelMapper());
+        userController = new UserController(loginService, userService, officeService, eventService, firmService,
+                new MapperConfig().modelMapper());
         model = new ExtendedModelMap();
     }
 
@@ -395,7 +396,8 @@ class UserControllerTest {
         ApplicationsForm applicationsForm = new ApplicationsForm();
         applicationsForm.setApps(ids);
         Model model = new ExtendedModelMap();
-        String redirectUrl = userController.setSelectedApps(applicationsForm, model, session);
+        BindingResult bindingResult = Mockito.mock(BindingResult.class);
+        String redirectUrl = userController.setSelectedApps(applicationsForm, bindingResult, model, session);
         assertThat(session.getAttribute("apps")).isNotNull();
         assertThat(redirectUrl).isEqualTo("redirect:/admin/user/create/roles");
     }
@@ -507,7 +509,8 @@ class UserControllerTest {
         String view = userController.getUserCheckAnswers(model, session);
         assertThat(view).isEqualTo("add-user-check-answers");
         assertThat(model.getAttribute("roles")).isNotNull();
-        Map<String, List<AppRoleViewModel>> cyaRoles = (Map<String, List<AppRoleViewModel>>) model.getAttribute("roles");
+        Map<String, List<AppRoleViewModel>> cyaRoles = (Map<String, List<AppRoleViewModel>>) model
+                .getAttribute("roles");
 
         assertThat(cyaRoles.get("app1").getFirst().getId()).isEqualTo("app1-dev");
         assertThat(model.getAttribute("user")).isNotNull();
@@ -953,25 +956,14 @@ class UserControllerTest {
     }
 
     @Test
-    void setSelectedApps_shouldRedirectToCheckAnswersIfNoApps() {
-        ApplicationsForm form = new ApplicationsForm();
-        form.setApps(new ArrayList<>());
-        HttpSession session = new MockHttpSession();
-        Model model = new ExtendedModelMap();
-
-        String view = userController.setSelectedApps(form, model, session);
-
-        assertThat(view).isEqualTo("redirect:/admin/user/create/check-answers");
-    }
-
-    @Test
     void setSelectedApps_shouldSetAppsAndRedirectToRoles() {
         ApplicationsForm form = new ApplicationsForm();
         form.setApps(List.of("app1"));
         HttpSession session = new MockHttpSession();
         Model model = new ExtendedModelMap();
 
-        String view = userController.setSelectedApps(form, model, session);
+        BindingResult bindingResult = Mockito.mock(BindingResult.class);
+        String view = userController.setSelectedApps(form, bindingResult, model, session);
 
         assertThat(view).isEqualTo("redirect:/admin/user/create/roles");
         assertThat(session.getAttribute("apps")).isEqualTo(List.of("app1"));


### PR DESCRIPTION
This pull request refactors the `UserController` class to improve validation handling, enhance error messaging in the UI, and clean up unused imports and duplicate code. It also updates the corresponding templates and unit tests to support these changes.

### Controller Enhancements:
* Added validation logic to `setSelectedApps` and `postOffices` methods, including handling `BindingResult` for error scenarios. This ensures that validation errors are properly captured and displayed to the user. [[1]](diffhunk://#diff-1c3931784714b5992966f392b56dad9140ea42ba7303dfce45c2cb8533ed3885R230-R254) [[2]](diffhunk://#diff-1c3931784714b5992966f392b56dad9140ea42ba7303dfce45c2cb8533ed3885L314-R322)
* Removed duplicate `model.addAttribute` calls in the `createUser` method to eliminate redundancy.
* Updated session management to store and clear models for validation error handling, preventing stale data.

### UI Improvements:
* Enhanced the `add-user-apps.html` template to display validation error messages using the `govuk-error-summary` component and highlight invalid fields. [[1]](diffhunk://#diff-6a1e91ae7a3cce5dc5aa2c9183335bac40fe9063c956b685632e3763e99e1762R23-R38) [[2]](diffhunk://#diff-6a1e91ae7a3cce5dc5aa2c9183335bac40fe9063c956b685632e3763e99e1762L34-R57)

### Validation Updates:
* Added a `@NotNull` annotation to the `ApplicationsForm` class to enforce that at least one application must be selected.

### Code Cleanup:
* Removed unused imports and improved code formatting for better readability and maintainability. [[1]](diffhunk://#diff-1c3931784714b5992966f392b56dad9140ea42ba7303dfce45c2cb8533ed3885L15) [[2]](diffhunk://#diff-1c3931784714b5992966f392b56dad9140ea42ba7303dfce45c2cb8533ed3885L54-L56)

### Test Adjustments:
* Updated unit tests to mock `BindingResult` and validate the new error handling logic. Removed a redundant test case for `setSelectedApps` that no longer applies. [[1]](diffhunk://#diff-21057d4cac378b8df4513dea5fe6f79c549a4ccfaf968a2440e01349f6417183L398-R400) [[2]](diffhunk://#diff-21057d4cac378b8df4513dea5fe6f79c549a4ccfaf968a2440e01349f6417183L955-R966)