### PR TITLE
Remove user selection checkboxes and disable button from users table

### DIFF
--- a/src/main/resources/templates/users.html
+++ b/src/main/resources/templates/users.html
@@ -67,7 +67,7 @@
                                 <div class="govuk-form-group">
                                     <label class="govuk-label moj-search__label govuk-!-font-weight-bold" for="search">
                                         Search users
-                                        <div id="offices-hint" class="govuk-hint">
+                                        <div id="offices-hint" class="govuk-hint">          
                                             You can search by name or email
                                         </div>
                                     </label>
@@ -84,7 +84,7 @@
                 </div>
 
                 <br>
-                <form method="post" th:action="@{/admin/users/disable}">
+                <form>
                     <table class="govuk-table" data-module="moj-sortable-table" data-id-prefix="users-">
                         <thead class="govuk-table__head">
                             <tr class="govuk-table__row">

--- a/src/main/resources/templates/users.html
+++ b/src/main/resources/templates/users.html
@@ -88,9 +88,6 @@
                     <table class="govuk-table" data-module="moj-sortable-table" data-id-prefix="users-">
                         <thead class="govuk-table__head">
                             <tr class="govuk-table__row">
-                                <td scope="col" class="govuk-table__header">
-                                    <span class="govuk-visually-hidden">Select user</span>
-                                </td>
                                 <th scope="col" class="govuk-table__header" aria-sort="ascending"><button type="button"
                                         data-index="0">Name</button></th>
                                 <th scope="col" class="govuk-table__header" aria-sort="none"><button type="button"
@@ -104,16 +101,6 @@
 
                         <tbody class="govuk-table__body">
                             <tr th:each="user : ${users}">
-                                <td class="govuk-table__cell govuk-checkboxes govuk-checkboxes--small"
-                                    data-module="govuk-checkboxes">
-                                    <div class="govuk-checkboxes__item">
-                                        <input class="govuk-checkboxes__input" id="disable-user" name="disable-user"
-                                            type="checkbox" th:value="${user.id}" />
-                                        <label class="govuk-label govuk-checkboxes__label" for="disable-user">
-                                            <span class="govuk-visually-hidden">Select to disable user</span>
-                                        </label>
-                                    </div>
-                                </td>
                                 <td class="govuk-table__cell">
                                     <a class="govuk-link" th:href="@{/admin/users/manage/{id}(id=${user.id})}"
                                         th:text="${user.fullName}"></a>
@@ -127,7 +114,6 @@
                             </tr>
                         </tbody>
                     </table>
-                    <button type="submit">Disable selected</button>
                 </form>
                 <nav class="moj-pagination" aria-label="Pagination navigation">
                     <ul class="moj-pagination__list">


### PR DESCRIPTION

<img width="1720" alt="Screenshot 2025-06-26 at 09 36 42" src="https://github.com/user-attachments/assets/841f75c6-3f95-4c36-a15a-b0f13a1f69f9" />


This pull request simplifies the user management interface by removing the ability to select and disable multiple users at once. The changes focus on improving the clarity and usability of the `users.html` template.

### Removal of multi-user selection and disable functionality:

* Removed the checkbox column from the user table, which allowed administrators to select users for disabling. (`src/main/resources/templates/users.html`, [[1]](diffhunk://#diff-5706460a5d76531ccf89d49fc69ba9783f296fd514786f7fa47ba80966473bd1L91-L93) [[2]](diffhunk://#diff-5706460a5d76531ccf89d49fc69ba9783f296fd514786f7fa47ba80966473bd1L107-L116)
* Removed the "Disable selected" button, which was used to disable the selected users. (`src/main/resources/templates/users.html`, [src/main/resources/templates/users.htmlL130](diffhunk://#diff-5706460a5d76531ccf89d49fc69ba9783f296fd514786f7fa47ba80966473bd1L130))