### PR TITLE
Email field - size/format validation. Names fields - size validation

### DIFF
--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/forms/UserDetailsForm.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/forms/UserDetailsForm.java
@@ -3,19 +3,23 @@ package uk.gov.justice.laa.portal.landingpage.forms;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Data;
 
 @Data
 public class UserDetailsForm {
 
+    @Size(max = 99, message = "First name must not be longer than 99 characters")
     @NotEmpty(message = "Enter a first name")
     private String firstName;
 
+    @Size(max = 99, message = "Last name must not be longer than 99 characters")
     @NotEmpty(message = "Enter a last name")
     private String lastName;
 
+    @Size(max = 254, message = "Email must not be longer than 254 characters")
     @NotEmpty(message = "Enter an email address")
-    @Email
+    @Email(message = "Enter an email address in the correct format")
     private String email;
 
     @NotNull(message = "A firm is required")

--- a/src/main/resources/templates/add-user-details.html
+++ b/src/main/resources/templates/add-user-details.html
@@ -72,7 +72,7 @@
                         Please ensure the email address you provide is accurate.
                     </p>
                     <div th:if="${#fields.hasErrors('email')}" class="govuk-error-message">
-                        <span th:each="err : ${#fields.errors('email')}" th:text="${err}"></span>
+                        <p th:each="err : ${#fields.errors('email')}" th:text="${err}"></p>
                     </div>
                     <input class="govuk-input govuk-!-width-one-third" name="email" type="email" th:value="*{email}"
                         id="email" th:aria-describedby="${#fields.hasErrors('email')} ? 'email-error' : null" />
@@ -83,7 +83,7 @@
                         First Name
                     </label>
                     <div th:if="${#fields.hasErrors('firstName')}" class="govuk-error-message">
-                        <span th:each="err : ${#fields.errors('firstName')}" th:text="${err}"></span>
+                        <p th:each="err : ${#fields.errors('firstName')}" th:text="${err}"></p>
                     </div>
                     <input class="govuk-input govuk-!-width-one-third" name="firstName" type="text"
                         th:value="*{firstName}" id="firstName"
@@ -95,7 +95,7 @@
                         Last Name
                     </label>
                     <div th:if="${#fields.hasErrors('lastName')}" class="govuk-error-message">
-                        <span th:each="err : ${#fields.errors('lastName')}" th:text="${err}"></span>
+                        <p th:each="err : ${#fields.errors('lastName')}" th:text="${err}"></p>
                     </div>
                     <input class="govuk-input govuk-!-width-one-third" name="lastName" type="text"
                         th:value="*{lastName}" id="lastName"


### PR DESCRIPTION
**Email field - size (max 254 characters) + format validation. 

Names fields - size (max 99 characters) validation**


![Screenshot 2025-06-26 at 09 58 22](https://github.com/user-attachments/assets/41f5e571-6074-4321-802a-35683788a5fb)


This pull request introduces validation improvements for user input fields and enhances error message rendering in the user details form. The key changes include adding character length constraints to form fields and updating the HTML templates to use semantic tags for error messages.

### Validation improvements:
* [`src/main/java/uk/gov/justice/laa/portal/landingpage/forms/UserDetailsForm.java`](diffhunk://#diff-dcce0d0ac1ee4fc81c3f944d9d79b993905f5ce038b62ccbc6a689367442dbf2R6-R22): Added `@Size` constraints to the `firstName`, `lastName`, and `email` fields to enforce maximum character limits (99 for names, 254 for email). Updated the `@Email` annotation to include a custom error message.

### HTML template updates:
* `src/main/resources/templates/add-user-details.html`:
  - Updated error message rendering for `email` to use a `<p>` tag instead of `<span>` for better semantic HTML.
  - Updated error message rendering for `firstName` to use a `<p>` tag instead of `<span>`.
  - Updated error message rendering for `lastName` to use a `<p>` tag instead of `<span>`.