### PR TITLE
Add show firm admins checkbox to user listing screen

### DIFF
--- a/src/main/resources/templates/users.html
+++ b/src/main/resources/templates/users.html
@@ -53,7 +53,7 @@
                                 <button type="button" class="govuk-button govuk-button--secondary"
                                     data-module="govuk-button" data-govuk-button-init=""
                                     onclick="location.href='/admin/user/create/details';">
-                                    Create a user
+                                    Create a new user
                                 </button>
                             </div>
                         </div>
@@ -65,9 +65,10 @@
                         <form method="get" th:action="@{/admin/users}" role="search">
                             <div class="moj-search">
                                 <div class="govuk-form-group">
-                                    <label class="govuk-label moj-search__label govuk-!-font-weight-bold" for="search">
+                                    <label class="govuk-label govuk-label--m moj-search__label govuk-!-font-weight-bold"
+                                        for="search">
                                         Search users
-                                        <div id="offices-hint" class="govuk-hint">          
+                                        <div id="offices-hint" class="govuk-hint govuk-!-margin-top-1">
                                             You can search by name or email
                                         </div>
                                     </label>
@@ -83,8 +84,34 @@
                     </div>
                 </div>
 
-                <br>
-                <form>
+                <form class="govuk-form" role="form">
+                    <div class="govuk-form-group govuk-!-margin-top-3">
+                        <fieldset class="govuk-fieldset">
+                            <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
+                                <div class="govuk-checkboxes__item">
+                                    <input class="govuk-checkboxes__input" id="show-firm-admins" name="show-firm-admins"
+                                        type="checkbox" value="true" onchange="handleShowFirmAdmins(this)"
+                                        th:checked="${param.showFirmAdmins != null}">
+                                    <label class="govuk-label govuk-checkboxes__label" for="organisation">
+                                        Show firm admins
+                                    </label>
+                                </div>
+                            </div>
+                        </fieldset>
+                    </div>
+                    <script>
+                        function handleShowFirmAdmins(checkbox) {
+                            const url = new URL(window.location.href);
+                            if (checkbox.checked) {
+                                url.searchParams.set('showFirmAdmins', 'true');
+                            } else {
+                                url.searchParams.delete('showFirmAdmins');
+                            }
+                            window.location.href = url.toString();
+                        }
+                    </script>
+                </form>
+                <form class="govuk-form-group govuk-!-margin-top-3">
                     <table class="govuk-table" data-module="moj-sortable-table" data-id-prefix="users-">
                         <thead class="govuk-table__head">
                             <tr class="govuk-table__row">
@@ -100,7 +127,7 @@
                         </thead>
 
                         <tbody class="govuk-table__body">
-                            <tr th:each="user : ${users}">
+                            <tr class="govuk-table__row" th:each="user : ${users}">
                                 <td class="govuk-table__cell">
                                     <a class="govuk-link" th:href="@{/admin/users/manage/{id}(id=${user.id})}"
                                         th:text="${user.fullName}"></a>


### PR DESCRIPTION


https://github.com/user-attachments/assets/c218e87e-5736-42ac-a901-b773877eb830



This pull request updates the `users.html` template to enhance accessibility, improve styling consistency with the GOV.UK Design System, and add new functionality for filtering user data. The most important changes include modifying button text, updating label and hint styling, adding a new filter for firm admins, and refining table row classes.

### Accessibility and Styling Improvements:

* Updated button text from "Create a user" to "Create a new user" for improved clarity. (`src/main/resources/templates/users.html`, [src/main/resources/templates/users.htmlL56-R56](diffhunk://#diff-5706460a5d76531ccf89d49fc69ba9783f296fd514786f7fa47ba80966473bd1L56-R56))
* Adjusted label and hint styling by adding `govuk-label--m` and `govuk-!-margin-top-1` classes for better alignment with the GOV.UK Design System. (`src/main/resources/templates/users.html`, [src/main/resources/templates/users.htmlL68-R71](diffhunk://#diff-5706460a5d76531ccf89d49fc69ba9783f296fd514786f7fa47ba80966473bd1L68-R71))

### New Functionality:

* Added a "Show firm admins" filter with a checkbox, including a JavaScript function to dynamically update the URL based on the checkbox state. (`src/main/resources/templates/users.html`, [src/main/resources/templates/users.htmlL86-R114](diffhunk://#diff-5706460a5d76531ccf89d49fc69ba9783f296fd514786f7fa47ba80966473bd1L86-R114))

### Code Refinements:

* Added the `govuk-table__row` class to table rows for consistency with the GOV.UK Design System. (`src/main/resources/templates/users.html`, [src/main/resources/templates/users.htmlL103-R130](diffhunk://#diff-5706460a5d76531ccf89d49fc69ba9783f296fd514786f7fa47ba80966473bd1L103-R130))