### PR TITLE
STB-2085: Added error handling to redirect user back to create user details screen if they skip ahead.

### DIFF
--- a/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/UserCreationTest.java
+++ b/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/UserCreationTest.java
@@ -1,0 +1,65 @@
+package uk.gov.justice.laa.portal.landingpage.controller;
+
+import jakarta.servlet.http.HttpSession;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MvcResult;
+import uk.gov.justice.laa.portal.landingpage.config.TestSecurityConfig;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+
+@Import(TestSecurityConfig.class)
+public class UserCreationTest extends BaseIntegrationTest {
+
+    @Test
+    public void testUserIsRedirectedWhenGoingStraightToCreateAppsScreen() throws Exception {
+        final String path = "/admin/user/create/services";
+        final String expectedRedirectUrl = "/admin/user/create/details";
+        MvcResult result = mockMvc.perform(get(path))
+                .andExpect(status().is3xxRedirection())
+                .andReturn();
+        assertNotNull(result.getResponse().getRedirectedUrl());
+        assertEquals(expectedRedirectUrl, result.getResponse().getRedirectedUrl());
+    }
+
+    @Test
+    public void testUserIsRedirectedWhenGoingStraightToCreateRolesScreen() throws Exception {
+        final String path = "/admin/user/create/roles";
+        final String expectedRedirectUrl = "/admin/user/create/details";
+        MvcResult result = mockMvc.perform(get(path))
+                .andExpect(status().is3xxRedirection())
+                .andReturn();
+        assertNotNull(result.getResponse().getRedirectedUrl());
+        assertEquals(expectedRedirectUrl, result.getResponse().getRedirectedUrl());
+    }
+
+    @Test
+    public void testUserIsRedirectedWhenGoingStraightToCreateOfficesScreen() throws Exception {
+        final String path = "/admin/user/create/offices";
+        final String expectedRedirectUrl = "/admin/user/create/details";
+        MvcResult result = mockMvc.perform(get(path))
+                .andExpect(status().is3xxRedirection())
+                .andReturn();
+        assertNotNull(result.getResponse().getRedirectedUrl());
+        assertEquals(expectedRedirectUrl, result.getResponse().getRedirectedUrl());
+    }
+
+    @Test
+    public void testUserIsRedirectedWhenGoingStraightToCheckAnswersScreen() throws Exception {
+        final String path = "/admin/user/create/check-answers";
+        final String expectedRedirectUrl = "/admin/user/create/details";
+        MvcResult result = mockMvc.perform(get(path))
+                .andExpect(status().is3xxRedirection())
+                .andReturn();
+        assertNotNull(result.getResponse().getRedirectedUrl());
+        assertEquals(expectedRedirectUrl, result.getResponse().getRedirectedUrl());
+    }
+
+
+}

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
@@ -38,6 +38,7 @@ import uk.gov.justice.laa.portal.landingpage.dto.FirmDto;
 import uk.gov.justice.laa.portal.landingpage.dto.OfficeData;
 import uk.gov.justice.laa.portal.landingpage.entity.EntraUser;
 import uk.gov.justice.laa.portal.landingpage.entity.Office;
+import uk.gov.justice.laa.portal.landingpage.exception.CreateUserDetailsIncompleteException;
 import uk.gov.justice.laa.portal.landingpage.forms.ApplicationsForm;
 import uk.gov.justice.laa.portal.landingpage.forms.OfficesForm;
 import uk.gov.justice.laa.portal.landingpage.forms.RolesForm;
@@ -231,7 +232,7 @@ public class UserController {
                     return appViewModel;
                 }).toList();
         model.addAttribute("apps", apps);
-        User user = getObjectFromHttpSession(session, "user", User.class).orElseGet(User::new);
+        User user = getObjectFromHttpSession(session, "user", User.class).orElseThrow(CreateUserDetailsIncompleteException::new);
         model.addAttribute("user", user);
         return "add-user-apps";
     }
@@ -249,7 +250,7 @@ public class UserController {
 
     @GetMapping("/user/create/roles")
     public String getSelectedRoles(RolesForm rolesForm, Model model, HttpSession session) {
-        List<String> selectedApps = getListFromHttpSession(session, "apps", String.class).orElseGet(ArrayList::new);
+        List<String> selectedApps = getListFromHttpSession(session, "apps", String.class).orElseThrow(CreateUserDetailsIncompleteException::new);
         Model modelFromSession = (Model) session.getAttribute("userCreateRolesModel");
         Integer selectedAppIndex;
         if (modelFromSession != null && modelFromSession.getAttribute("createUserRolesSelectedAppIndex") != null) {
@@ -266,7 +267,7 @@ public class UserController {
                     viewModel.setSelected(selectedRoles.contains(appRoleDto.getId()));
                     return viewModel;
                 }).toList();
-        User user = getObjectFromHttpSession(session, "user", User.class).orElseGet(User::new);
+        User user = getObjectFromHttpSession(session, "user", User.class).orElseThrow(CreateUserDetailsIncompleteException::new);
         model.addAttribute("user", user);
         model.addAttribute("roles", appRoleViewModels);
         model.addAttribute("createUserRolesSelectedAppIndex", selectedAppIndex);
@@ -339,7 +340,7 @@ public class UserController {
                                 && selectedOfficeData.getSelectedOffices().contains(office.getId().toString())))
                 .collect(Collectors.toList());
         model.addAttribute("officeData", officeData);
-        User user = getObjectFromHttpSession(session, "user", User.class).orElseGet(User::new);
+        User user = getObjectFromHttpSession(session, "user", User.class).orElseThrow(CreateUserDetailsIncompleteException::new);
         model.addAttribute("user", user);
 
         // Store the model in session to handle validation errors later
@@ -406,7 +407,7 @@ public class UserController {
             model.addAttribute("roles", cyaRoles);
         }
 
-        User user = getObjectFromHttpSession(session, "user", User.class).orElseGet(User::new);
+        User user = getObjectFromHttpSession(session, "user", User.class).orElseThrow(CreateUserDetailsIncompleteException::new);
         model.addAttribute("user", user);
 
         OfficeData officeData = getObjectFromHttpSession(session, "officeData", OfficeData.class)

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/exception/CreateUserDetailsIncompleteException.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/exception/CreateUserDetailsIncompleteException.java
@@ -1,0 +1,15 @@
+package uk.gov.justice.laa.portal.landingpage.exception;
+
+/**
+ * An exception for handling cases where a user tries to move forward in a user details form (usually by manipulating the URL)
+ * without fully completing all details
+ */
+public class CreateUserDetailsIncompleteException extends RuntimeException {
+
+    public CreateUserDetailsIncompleteException() {}
+
+    public CreateUserDetailsIncompleteException(String message, Object... args) {
+        super(String.format(message, args));
+    }
+
+}

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/exception/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/exception/GlobalExceptionHandler.java
@@ -1,21 +1,22 @@
 package uk.gov.justice.laa.portal.landingpage.exception;
 
 import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.servlet.view.RedirectView;
 import uk.gov.justice.laa.portal.landingpage.dto.ClaimEnrichmentResponse;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
  * Global exception handler for the application.
  */
+@Slf4j
 @ControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -38,6 +39,12 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<ClaimEnrichmentResponse> handleConstraintViolation(ConstraintViolationException ex) {
         return createErrorResponse(HttpStatus.BAD_REQUEST, "Validation error: " + ex.getMessage());
+    }
+
+    @ExceptionHandler(CreateUserDetailsIncompleteException.class)
+    public RedirectView handleCreateUserDetailsIncompleteException(CreateUserDetailsIncompleteException ex) {
+        log.warn("A user has tried to skip parts of user creation (usually by changing the URL). Redirecting to user creation screen...");
+        return new RedirectView("/admin/user/create/details");
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/exception/CreateUserDetailsIncompleteExceptionTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/exception/CreateUserDetailsIncompleteExceptionTest.java
@@ -1,0 +1,30 @@
+package uk.gov.justice.laa.portal.landingpage.exception;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class CreateUserDetailsIncompleteExceptionTest {
+
+    @Test
+    public void testEmptyConstructorReturnsNullMessage() {
+        CreateUserDetailsIncompleteException exception = new CreateUserDetailsIncompleteException();
+        assertNull(exception.getMessage());
+    }
+
+    @Test
+    public void testConstructorWithMessageReturnsProvidedMessage() {
+        final String message = "Test Message";
+        CreateUserDetailsIncompleteException exception = new CreateUserDetailsIncompleteException(message);
+        assertEquals(message, exception.getMessage());
+    }
+
+    @Test
+    public void testConstructorWithFormattedMessageReturnsProvidedMessage() {
+        final String message = "Test Message 1";
+        CreateUserDetailsIncompleteException exception = new CreateUserDetailsIncompleteException("Test Message %d", 1);
+        assertEquals(message, exception.getMessage());
+    }
+
+}

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/exception/GlobalExceptionHandlerTest.java
@@ -1,5 +1,8 @@
 package uk.gov.justice.laa.portal.landingpage.exception;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import org.junit.jupiter.api.BeforeEach;
@@ -8,7 +11,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.servlet.view.RedirectView;
 import uk.gov.justice.laa.portal.landingpage.dto.ClaimEnrichmentResponse;
+import uk.gov.justice.laa.portal.landingpage.utils.LogMonitoring;
 
 import java.util.HashSet;
 import java.util.List;
@@ -81,6 +86,22 @@ class GlobalExceptionHandlerTest {
         assertEquals(400, response.getStatusCodeValue());
         assertFalse(response.getBody().isSuccess());
         assertTrue(response.getBody().getMessage().contains("Validation error"));
+    }
+
+    @Test
+    void handleCreateUserDetailsIncompleteException() {
+        // Arrange
+        CreateUserDetailsIncompleteException exception = new CreateUserDetailsIncompleteException();
+        ListAppender<ILoggingEvent> listAppender = LogMonitoring.addListAppenderToLogger(GlobalExceptionHandler.class);
+
+        // Act
+        RedirectView response = exceptionHandler.handleCreateUserDetailsIncompleteException(exception);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals("/admin/user/create/details", response.getUrl());
+        List<ILoggingEvent> warningLogs =  LogMonitoring.getLogsByLevel(listAppender, Level.WARN);
+        assertEquals(1, warningLogs.size());
     }
 
     @Test


### PR DESCRIPTION
A user was previously able to skip stages of user creation if they went directly to the relevant URL instead of going through the whole flow. This usually ended in the server throwing a 500 error. Added error handling to stop this.

- Added new exception CreateUserDetailsIncompleteException
- Added global exception handling for new exception
- Added logic to throw new exception when the user goes directly to screen they shouldnt access yet.
- Updated old unit tests.
- Added new unit tests.
- Added integration tests.

JIRA link: https://dsdmoj.atlassian.net/browse/STB-2085