### PR TITLE
STB-2259 - Bug: Create user - Office selection not persisted to  database

### DIFF
--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
@@ -356,8 +356,8 @@ public class UserController {
     public String offices(OfficesForm officesForm, HttpSession session, Model model) {
         OfficeData selectedOfficeData = getObjectFromHttpSession(session, "officeData", OfficeData.class)
                 .orElseGet(OfficeData::new);
-        // if user has firms, use officeService.getOfficesByFirms();
-        List<Office> offices = officeService.getOffices();
+        FirmDto selectedFirm = (FirmDto) session.getAttribute("firm");
+        List<Office> offices = officeService.getOfficesByFirms(List.of(selectedFirm.getId()));
         List<OfficeModel> officeData = offices.stream()
                 .map(office -> new OfficeModel(office.getName(), office.getAddress(),
                         office.getId().toString(), Objects.nonNull(selectedOfficeData.getSelectedOffices())
@@ -392,8 +392,8 @@ public class UserController {
         OfficeData officeData = new OfficeData();
         List<String> selectedOffices = officesForm.getOffices();
         officeData.setSelectedOffices(officesForm.getOffices());
-        // if user has firms, use officeService.getOfficesByFirms();
-        List<Office> offices = officeService.getOffices();
+        FirmDto selectedFirm = (FirmDto) session.getAttribute("firm");
+        List<Office> offices = officeService.getOfficesByFirms(List.of(selectedFirm.getId()));
         List<String> selectedDisplayNames = new ArrayList<>();
         for (Office office : offices) {
             if (Objects.nonNull(selectedOffices)

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
@@ -356,7 +356,8 @@ public class UserController {
     public String offices(OfficesForm officesForm, HttpSession session, Model model) {
         OfficeData selectedOfficeData = getObjectFromHttpSession(session, "officeData", OfficeData.class)
                 .orElseGet(OfficeData::new);
-        FirmDto selectedFirm = (FirmDto) session.getAttribute("firm");
+        FirmDto selectedFirm = getObjectFromHttpSession(session, "firm", FirmDto.class)
+                .orElseThrow(CreateUserDetailsIncompleteException::new);
         List<Office> offices = officeService.getOfficesByFirms(List.of(selectedFirm.getId()));
         List<OfficeModel> officeData = offices.stream()
                 .map(office -> new OfficeModel(office.getName(), office.getAddress(),

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/service/UserService.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/service/UserService.java
@@ -26,9 +26,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.repository.query.Param;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
@@ -375,7 +373,7 @@ public class UserService {
         entraUser.setEntraOid(newUser.getMail());
         Firm firm = mapper.map(firmDto, Firm.class);
         List<UUID> officeIds = selectedOffices.stream().map(UUID::fromString).toList();
-        Set<Office> offices = new HashSet<Office>(officeRepository.findOfficeByFirm_IdIn(officeIds));
+        Set<Office> offices = new HashSet<>(officeRepository.findAllById(officeIds));
         UserProfile userProfile = UserProfile.builder()
                 .activeProfile(true)
                 .appRoles(new HashSet<>(appRoles))

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/service/UserServiceTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/service/UserServiceTest.java
@@ -1,5 +1,17 @@
 package uk.gov.justice.laa.portal.landingpage.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -14,26 +26,14 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -1932,11 +1932,10 @@ class UserServiceTest {
             UUID roleId = UUID.randomUUID();
             AppRole appRole = AppRole.builder().id(roleId).roleType(RoleType.EXTERNAL).build();
             when(mockAppRoleRepository.findAllById(any())).thenReturn(List.of(appRole));
-            when(mockAppRoleRepository.findByRoleTypeIn(List.of(RoleType.EXTERNAL, RoleType.INTERNAL_AND_EXTERNAL)))
-                    .thenReturn(List.of(appRole));
+            when(mockAppRoleRepository.findByRoleTypeIn(anyList())).thenReturn(List.of(appRole));
             UUID officeId = UUID.randomUUID();
             Office office = Office.builder().id(officeId).build();
-            when(mockOfficeRepository.findOfficeByFirm_IdIn(any())).thenReturn(List.of(office));
+            when(mockOfficeRepository.findAllById(any())).thenReturn(List.of(office));
 
             EntraUser savedUser = EntraUser.builder().build();
             when(mockEntraUserRepository.saveAndFlush(any(EntraUser.class))).thenReturn(savedUser);
@@ -1961,8 +1960,8 @@ class UserServiceTest {
             User user = new User();
             user.setMail("test@example.com");
 
+            // Setup invitation mocks
             when(mockGraphServiceClient.invitations()).thenReturn(invitationsRequestBuilder);
-
             Invitation invitation = new Invitation();
             User invitedUser = new User();
             invitation.setInvitedUser(invitedUser);
@@ -1970,7 +1969,8 @@ class UserServiceTest {
             when(invitationsRequestBuilder.post(any(Invitation.class))).thenReturn(invitation);
 
             when(mockAppRoleRepository.findAllById(any())).thenReturn(Collections.emptyList());
-            when(mockOfficeRepository.findOfficeByFirm_IdIn(any())).thenReturn(Collections.emptyList());
+            when(mockAppRoleRepository.findByRoleTypeIn(anyList())).thenReturn(Collections.emptyList());
+            when(mockOfficeRepository.findAllById(any())).thenReturn(Collections.emptyList());
 
             ArgumentCaptor<EntraUser> userCaptor = ArgumentCaptor.forClass(EntraUser.class);
             when(mockEntraUserRepository.saveAndFlush(userCaptor.capture())).thenReturn(EntraUser.builder().build());


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/STB-2259

Create user offices were not being persisted to database. Fix added includes the following:

This pull request introduces changes to improve how offices are retrieved based on firms, updates related test cases, and simplifies the repository queries. The most important changes include replacing the `getOffices` method with `getOfficesByFirms`, ensuring firm data is passed in session attributes, and modifying repository calls to use `findAllById` instead of `findOfficeByFirm_IdIn`.

### Changes to office retrieval logic:

* [`src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java`](diffhunk://#diff-1c3931784714b5992966f392b56dad9140ea42ba7303dfce45c2cb8533ed3885L359-R361): Updated methods `offices` and `postOffices` to use `officeService.getOfficesByFirms` with firm IDs retrieved from session attributes instead of `officeService.getOffices`. Added exception handling for missing firm data. [[1]](diffhunk://#diff-1c3931784714b5992966f392b56dad9140ea42ba7303dfce45c2cb8533ed3885L359-R361) [[2]](diffhunk://#diff-1c3931784714b5992966f392b56dad9140ea42ba7303dfce45c2cb8533ed3885L395-R397)

### Repository query simplifications:

* [`src/main/java/uk/gov/justice/laa/portal/landingpage/service/UserService.java`](diffhunk://#diff-6aabdd441e69f5b84b1601da54ed939af904e20dedb9f975321863ed1bd96817L378-R376): Replaced `findOfficeByFirm_IdIn` with `findAllById` in the `persistNewUser` method to simplify query logic and improve maintainability.

### Test case updates:

* [`src/test/java/uk/gov/justice/laa/portal/landingpage/controller/UserControllerTest.java`](diffhunk://#diff-21057d4cac378b8df4513dea5fe6f79c549a4ccfaf968a2440e01349f6417183R561-R577): Updated multiple test cases to mock `getOfficesByFirms` instead of `getOffices`, added firm data setup in session attributes, and verified behavior when firm data is missing. [[1]](diffhunk://#diff-21057d4cac378b8df4513dea5fe6f79c549a4ccfaf968a2440e01349f6417183R561-R577) [[2]](diffhunk://#diff-21057d4cac378b8df4513dea5fe6f79c549a4ccfaf968a2440e01349f6417183R589-R601) [[3]](diffhunk://#diff-21057d4cac378b8df4513dea5fe6f79c549a4ccfaf968a2440e01349f6417183R1748-R1757) [[4]](diffhunk://#diff-21057d4cac378b8df4513dea5fe6f79c549a4ccfaf968a2440e01349f6417183R1769-R1778) [[5]](diffhunk://#diff-21057d4cac378b8df4513dea5fe6f79c549a4ccfaf968a2440e01349f6417183R1806-R1818) [[6]](diffhunk://#diff-21057d4cac378b8df4513dea5fe6f79c549a4ccfaf968a2440e01349f6417183R2093-R2111)
* [`src/test/java/uk/gov/justice/laa/portal/landingpage/service/UserServiceTest.java`](diffhunk://#diff-c78e68790aef818934168770b56764a6f723285b721fc685f42b0be8b1547188L1935-R1938): Adjusted repository mock calls to use `findAllById` instead of `findOfficeByFirm_IdIn` and ensured proper setup for role and office-related mocks. [[1]](diffhunk://#diff-c78e68790aef818934168770b56764a6f723285b721fc685f42b0be8b1547188L1935-R1938) [[2]](diffhunk://#diff-c78e68790aef818934168770b56764a6f723285b721fc685f42b0be8b1547188R1963-R1973)

### Code cleanup:

* [`src/main/java/uk/gov/justice/laa/portal/landingpage/service/UserService.java`](diffhunk://#diff-6aabdd441e69f5b84b1601da54ed939af904e20dedb9f975321863ed1bd96817L29-L31): Removed unused imports to clean up the codebase.
* [`src/test/java/uk/gov/justice/laa/portal/landingpage/service/UserServiceTest.java`](diffhunk://#diff-c78e68790aef818934168770b56764a6f723285b721fc685f42b0be8b1547188R3-R14): Reorganized imports for better readability and maintainability. [[1]](diffhunk://#diff-c78e68790aef818934168770b56764a6f723285b721fc685f42b0be8b1547188R3-R14) [[2]](diffhunk://#diff-c78e68790aef818934168770b56764a6f723285b721fc685f42b0be8b1547188L17-L36)