### PR TITLE
STB-2453: Fixed bug where external user admins could not access another user of the same firm.

### DIFF
--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/service/AccessControlService.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/service/AccessControlService.java
@@ -58,7 +58,7 @@ public class AccessControlService {
         }
 
         boolean canAccess = userHasPermission(authenticatedUser, Permission.VIEW_EXTERNAL_USER) && !userService.isInternal(accessedUser.getId())
-                && usersAreInSameFirm(authenticatedUser, accessedUser.getId());
+                && usersAreInSameFirm(authenticatedUser, userProfileId);
         if (!canAccess) {
             CurrentUserDto currentUserDto = loginService.getCurrentUser(authentication);
             log.warn("User {} does not have permission to access this userId {}", currentUserDto.getName(), userProfileId);
@@ -93,9 +93,9 @@ public class AccessControlService {
         return canAccess;
     }
 
-    private boolean usersAreInSameFirm(EntraUser authenticatedUser, String accessedUserId) {
+    private boolean usersAreInSameFirm(EntraUser authenticatedUser, String accessedUserProfileId) {
         List<UUID> userManagerFirms = firmService.getUserAllFirms(authenticatedUser).stream().map(FirmDto::getId).toList();
-        List<FirmDto> userFirms = firmService.getUserFirmsByUserId(accessedUserId);
+        List<FirmDto> userFirms = firmService.getUserFirmsByUserId(accessedUserProfileId);
         return userFirms.stream().map(FirmDto::getId).anyMatch(userManagerFirms::contains);
     }
 

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/service/AccessControlServiceTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/service/AccessControlServiceTest.java
@@ -100,7 +100,7 @@ public class AccessControlServiceTest {
         FirmDto firmDto = FirmDto.builder().id(firmId).build();
         Mockito.when(loginService.getCurrentEntraUser(authentication)).thenReturn(entraUser);
         Mockito.when(firmService.getUserAllFirms(entraUser)).thenReturn(List.of(firmDto));
-        Mockito.when(firmService.getUserFirmsByUserId(accessedUserId.toString())).thenReturn(List.of(firmDto));
+        Mockito.when(firmService.getUserFirmsByUserId(any())).thenReturn(List.of(firmDto));
         Mockito.when(userService.getUserProfileById(any())).thenReturn(Optional.of(accessedUserProfile));
 
 
@@ -133,7 +133,7 @@ public class AccessControlServiceTest {
         Mockito.when(loginService.getCurrentUser(authentication)).thenReturn(entraUserDto);
         UUID accessedUserId = UUID.randomUUID();
         Mockito.when(firmService.getUserAllFirms(entraUser)).thenReturn(List.of(firmDto1));
-        Mockito.when(firmService.getUserFirmsByUserId(accessedUserId.toString())).thenReturn(List.of(firmDto2));
+        Mockito.when(firmService.getUserFirmsByUserId(any())).thenReturn(List.of(firmDto2));
         EntraUserDto accessedUser = EntraUserDto.builder().id(accessedUserId.toString()).email("test2@email.com").build();
         UserProfileDto accessedUserProfile = UserProfileDto.builder().activeProfile(true).entraUser(accessedUser).build();
         Mockito.when(userService.getUserProfileById(any())).thenReturn(Optional.of(accessedUserProfile));
@@ -163,7 +163,7 @@ public class AccessControlServiceTest {
         FirmDto firmDto = FirmDto.builder().id(UUID.randomUUID()).build();
         Mockito.when(loginService.getCurrentEntraUser(authentication)).thenReturn(entraUser);
         Mockito.when(firmService.getUserAllFirms(entraUser)).thenReturn(List.of(firmDto));
-        Mockito.when(firmService.getUserFirmsByUserId(accessedUserId.toString())).thenReturn(Collections.emptyList());
+        Mockito.when(firmService.getUserFirmsByUserId(any())).thenReturn(Collections.emptyList());
         CurrentUserDto entraUserDto = new CurrentUserDto();
         entraUserDto.setName("test");
         Mockito.when(loginService.getCurrentUser(authentication)).thenReturn(entraUserDto);


### PR DESCRIPTION
Access control was using userId as opposed to user profile id. Changed the variable passed in to reflect this. Updated tests.