### PR TITLE
Add meta tags and icons to head section

### DIFF
--- a/src/main/resources/templates/partials/head.html
+++ b/src/main/resources/templates/partials/head.html
@@ -1,4 +1,17 @@
 <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <meta name="theme-color" content="#0b0c0c">
+    
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    
+    <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="/assets/images/favicon.ico" type="image/x-icon">
+    <link rel="mask-icon" href="/assets/images/govuk-mask-icon.svg" color="#0b0c0c">
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/images/govuk-apple-touch-icon-180x180.png">
+    <link rel="apple-touch-icon" sizes="167x167" href="/assets/images/govuk-apple-touch-icon-167x167.png">
+    <link rel="apple-touch-icon" sizes="152x152" href="/assets/images/govuk-apple-touch-icon-152x152.png">
+    <link rel="apple-touch-icon" href="/assets/images/govuk-apple-touch-icon.png">
+    
     <link th:href="@{/css/govuk-frontend-5.8.0.min.css}" rel="stylesheet" type="text/css">
     <link th:href="@{/css/moj-frontend-5.1.2.min.css}" rel="stylesheet" type="text/css">
     <link th:href="@{/css/styles.css}" rel="stylesheet" />


### PR DESCRIPTION
This pull request adds several important meta tags and icon links to the `<head>` section of the `head.html` template. These changes improve browser compatibility, mobile device support, and branding consistency.

<img width="118" height="42" alt="Screenshot 2025-08-06 at 13 06 09" src="https://github.com/user-attachments/assets/9051af7c-259d-4628-ba3c-197cdf2e2f8e" />


Enhancements to HTML head for compatibility and branding:

* Added meta tags for character set, viewport settings, theme color, and compatibility with Internet Explorer to improve accessibility and device support.
* Added various favicon and Apple touch icon links to ensure proper display of the site icon across different platforms and devices.