### PR TITLE
Fix: remove email verification message in success page

### DIFF
--- a/src/main/resources/templates/add-user-created.html
+++ b/src/main/resources/templates/add-user-created.html
@@ -23,8 +23,6 @@
             </div>
             <h2 class="govuk-heading-m govuk-!-padding-top-3">What happens next</h2>
             
-            <p class="govuk-body">An email has been sent to the user asking them to activate their account.</p>
-            
             <p class="govuk-body">You can:</p>
             
             <ul class="govuk-list govuk-list--bullet">


### PR DESCRIPTION
Intended as a temporary fix. No External users will actually have emails sent at this stage, so the message is misleading.