### PR TITLE
Adding role descriptions + specific sections for CCMS apps

### DIFF
--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/dto/AppRoleDto.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/dto/AppRoleDto.java
@@ -7,6 +7,8 @@ import uk.gov.justice.laa.portal.landingpage.entity.RoleType;
 public class AppRoleDto {
     private String id;
     private String name;
+    private String description;
+    private String ccmsCode;
     private AppDto app;
     private RoleType roleType;
 }

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/repository/AppRoleRepository.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/repository/AppRoleRepository.java
@@ -1,18 +1,21 @@
 package uk.gov.justice.laa.portal.landingpage.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-import uk.gov.justice.laa.portal.landingpage.entity.AppRole;
-import uk.gov.justice.laa.portal.landingpage.entity.RoleType;
-
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import uk.gov.justice.laa.portal.landingpage.entity.AppRole;
+import uk.gov.justice.laa.portal.landingpage.entity.RoleType;
+
 @Repository
 public interface AppRoleRepository extends JpaRepository<AppRole, UUID> {
     Optional<AppRole> findByName(String roleName);
+
+    Optional<AppRole> findByCcmsCode(String ccmsCode);
 
     List<AppRole> findByRoleTypeIn(Collection<RoleType> roleTypes);
 

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/utils/CcmsRoleGroupsUtil.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/utils/CcmsRoleGroupsUtil.java
@@ -1,0 +1,133 @@
+package uk.gov.justice.laa.portal.landingpage.utils;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import uk.gov.justice.laa.portal.landingpage.dto.AppRoleDto;
+
+/**
+ * Utility class for dynamically organizing CCMS roles based on their ccmsCode patterns
+ * matching the government service UI layout.
+ */
+public class CcmsRoleGroupsUtil {
+    
+    public static final String PROVIDER_SECTION = "Provider";
+    public static final String CHAMBERS_SECTION = "Chambers";
+    public static final String ADVOCATE_SECTION = "Advocate";
+    public static final String OTHER_SECTION = "Other";
+    
+    /**
+     * Dynamically organize CCMS app roles by section based on role code patterns
+     * @param ccmsRoles List of CCMS app roles to organize
+     * @return Map with section names as keys and lists of app roles as values
+     */
+    public static Map<String, List<AppRoleDto>> organizeCcmsRolesBySection(List<AppRoleDto> ccmsRoles) {
+        Map<String, List<AppRoleDto>> organizedRoles = new LinkedHashMap<>();
+        
+        // Filter and group roles by their ccmsCode patterns
+        organizedRoles.put(PROVIDER_SECTION, filterRolesByPattern(ccmsRoles, getProviderPatterns()));
+        organizedRoles.put(CHAMBERS_SECTION, filterRolesByPattern(ccmsRoles, getChambersPatterns()));
+        organizedRoles.put(ADVOCATE_SECTION, filterRolesByPattern(ccmsRoles, getAdvocatePatterns()));
+        
+        // Collect any remaining CCMS roles that don't match the known patterns
+        List<AppRoleDto> categorizedRoles = organizedRoles.values().stream()
+                .flatMap(List::stream)
+                .collect(Collectors.toList());
+        
+        List<AppRoleDto> otherRoles = ccmsRoles.stream()
+                .filter(role -> !categorizedRoles.contains(role))
+                .collect(Collectors.toList());
+        
+        if (!otherRoles.isEmpty()) {
+            organizedRoles.put(OTHER_SECTION, otherRoles);
+        }
+        
+        return organizedRoles;
+    }
+    
+    /**
+     * Check if a role code is a CCMS role
+     * @param roleCode The role code to check
+     * @return true if the role code starts with XXCCMS_
+     */
+    public static boolean isCcmsRole(String roleCode) {
+        return roleCode != null && roleCode.startsWith("XXCCMS_");
+    }
+    
+    /**
+     * Get the section name for a given CCMS role code based on patterns
+     * @param roleCode The role code to categorize
+     * @return The section name (Provider, Chambers, Advocate, or Other) or null if not a CCMS role
+     */
+    public static String getSectionForRoleCode(String roleCode) {
+        if (!isCcmsRole(roleCode)) {
+            return null;
+        }
+        
+        if (matchesAnyPattern(roleCode, getProviderPatterns())) {
+            return PROVIDER_SECTION;
+        } else if (matchesAnyPattern(roleCode, getChambersPatterns())) {
+            return CHAMBERS_SECTION;
+        } else if (matchesAnyPattern(roleCode, getAdvocatePatterns())) {
+            return ADVOCATE_SECTION;
+        } else {
+            return OTHER_SECTION;
+        }
+    }
+    
+    /**
+     * Get patterns that identify Provider roles
+     */
+    private static List<String> getProviderPatterns() {
+        return List.of(
+            "XXCCMS_FIRM_",
+            "XXCCMS_OFFICE_",
+            "XXCCMS_CROSS_OFFICE",
+            "XXCCMS_PROVIDER_",
+            "XXCCMS_CASE_",
+            "XXCCMS_BILL_"
+        );
+    }
+    
+    /**
+     * Get patterns that identify Chambers roles
+     */
+    private static List<String> getChambersPatterns() {
+        return List.of(
+            "XXCCMS_CHAMBERS_",
+            "XXCCMS_COUNSEL"
+        );
+    }
+    
+    /**
+     * Get patterns that identify Advocate roles
+     */
+    private static List<String> getAdvocatePatterns() {
+        return List.of(
+            "XXCCMS_ADVOCATE"
+        );
+    }
+    
+    /**
+     * Filter app roles by matching any of the given patterns
+     */
+    private static List<AppRoleDto> filterRolesByPattern(List<AppRoleDto> roles, List<String> patterns) {
+        return roles.stream()
+            .filter(role -> matchesAnyPattern(role.getCcmsCode(), patterns))
+            .collect(Collectors.toList());
+    }
+    
+    /**
+     * Check if a role code matches any of the given patterns
+     */
+    private static boolean matchesAnyPattern(String roleCode, List<String> patterns) {
+        if (roleCode == null) {
+            return false;
+        }
+        
+        return patterns.stream()
+            .anyMatch(pattern -> roleCode.contains(pattern));
+    }
+}

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/viewmodel/AppRoleViewModel.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/viewmodel/AppRoleViewModel.java
@@ -7,5 +7,6 @@ public class AppRoleViewModel {
     private String id;
     private String name;
     private String appName;
+    private String description;
     private boolean selected;
 }

--- a/src/main/resources/templates/edit-user-roles.html
+++ b/src/main/resources/templates/edit-user-roles.html
@@ -27,8 +27,7 @@
 
     <main class="govuk-main-wrapper" id="main-content">
         <div th:if="${#authentication.isAuthenticated()}">
-            <a class="govuk-back-link govuk-!-margin-bottom-3"
-                th:href="@{/admin/users/manage/{id}(id=${user.id})}">
+            <a class="govuk-back-link govuk-!-margin-bottom-3" th:href="@{/admin/users/manage/{id}(id=${user.id})}">
                 Back
             </a>
             <form method="post"
@@ -63,13 +62,120 @@
                             <div class="govuk-checkboxes" data-module="govuk-checkboxes">
                                 <span class="govuk-error-message" th:if="${#fields.hasErrors('roles')}"
                                     th:errors="*{roles}"></span>
-                                <div class="govuk-checkboxes__item" th:each="role : ${roles}"
-                                    th:id="'role-' + ${role.id}">
-                                    <input class="govuk-checkboxes__input" id="roles" name="roles"
-                                        th:checked="${role.selected}" th:value="${role.id}" type="checkbox">
-                                    <label class="govuk-label govuk-checkboxes__label" th:for="'role-' + ${role.id}">
-                                        <span th:text="${role.name}"></span>
-                                    </label>
+
+                                <!-- CCMS App: Display roles organized by sections -->
+                                <div th:if="${isCcmsApp}">
+                                    <!-- Provider Section -->
+                                    <div th:if="${ccmsRolesBySection.containsKey('Provider') and !ccmsRolesBySection['Provider'].isEmpty()}"
+                                        class="govuk-!-margin-bottom-6">
+                                        <h3 class="govuk-heading-m">Provider</h3>
+                                        <div th:each="roleDto : ${ccmsRolesBySection['Provider']}">
+                                            <div th:each="roleViewModel : ${roles}"
+                                                th:if="${roleViewModel.id == roleDto.id}">
+                                                <div class="govuk-checkboxes__item govuk-!-margin-bottom-3"
+                                                    th:id="'role-' + ${roleViewModel.id}">
+                                                    <input class="govuk-checkboxes__input"
+                                                        th:id="'role-input-' + ${roleViewModel.id}" name="roles"
+                                                        th:checked="${roleViewModel.selected}"
+                                                        th:value="${roleViewModel.id}" type="checkbox">
+                                                    <label class="govuk-label govuk-checkboxes__label"
+                                                        th:for="'role-input-' + ${roleViewModel.id}">
+                                                        <span th:text="${roleViewModel.name}"></span>
+                                                    </label>
+                                                    <div class="govuk-hint govuk-checkboxes__hint"
+                                                        th:text="${roleViewModel.description}"></div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <!-- Chambers Section -->
+                                    <div th:if="${ccmsRolesBySection.containsKey('Chambers') and !ccmsRolesBySection['Chambers'].isEmpty()}"
+                                        class="govuk-!-margin-bottom-6">
+                                        <h3 class="govuk-heading-m">Chambers</h3>
+                                        <div th:each="roleDto : ${ccmsRolesBySection['Chambers']}">
+                                            <div th:each="roleViewModel : ${roles}"
+                                                th:if="${roleViewModel.id == roleDto.id}">
+                                                <div class="govuk-checkboxes__item govuk-!-margin-bottom-3"
+                                                    th:id="'role-' + ${roleViewModel.id}">
+                                                    <input class="govuk-checkboxes__input"
+                                                        th:id="'role-input-' + ${roleViewModel.id}" name="roles"
+                                                        th:checked="${roleViewModel.selected}"
+                                                        th:value="${roleViewModel.id}" type="checkbox">
+                                                    <label class="govuk-label govuk-checkboxes__label"
+                                                        th:for="'role-input-' + ${roleViewModel.id}">
+                                                        <span th:text="${roleViewModel.name}"></span>
+                                                    </label>
+                                                    <div class="govuk-hint govuk-checkboxes__hint"
+                                                        th:text="${roleViewModel.description}"></div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <!-- Advocate Section -->
+                                    <div th:if="${ccmsRolesBySection.containsKey('Advocate') and !ccmsRolesBySection['Advocate'].isEmpty()}"
+                                        class="govuk-!-margin-bottom-6">
+                                        <h3 class="govuk-heading-m">Advocate</h3>
+                                        <div th:each="roleDto : ${ccmsRolesBySection['Advocate']}">
+                                            <div th:each="roleViewModel : ${roles}"
+                                                th:if="${roleViewModel.id == roleDto.id}">
+                                                <div class="govuk-checkboxes__item govuk-!-margin-bottom-3"
+                                                    th:id="'role-' + ${roleViewModel.id}">
+                                                    <input class="govuk-checkboxes__input"
+                                                        th:id="'role-input-' + ${roleViewModel.id}" name="roles"
+                                                        th:checked="${roleViewModel.selected}"
+                                                        th:value="${roleViewModel.id}" type="checkbox">
+                                                    <label class="govuk-label govuk-checkboxes__label"
+                                                        th:for="'role-input-' + ${roleViewModel.id}">
+                                                        <span th:text="${roleViewModel.name}"></span>
+                                                    </label>
+                                                    <div class="govuk-hint govuk-checkboxes__hint"
+                                                        th:text="${roleViewModel.description}"></div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <!-- Other CCMS Roles Section (if any) -->
+                                    <div th:if="${ccmsRolesBySection.containsKey('Other') and !ccmsRolesBySection['Other'].isEmpty()}"
+                                        class="govuk-!-margin-bottom-6">
+                                        <h3 class="govuk-heading-m">Other</h3>
+                                        <div th:each="roleDto : ${ccmsRolesBySection['Other']}">
+                                            <div th:each="roleViewModel : ${roles}"
+                                                th:if="${roleViewModel.id == roleDto.id}">
+                                                <div class="govuk-checkboxes__item govuk-!-margin-bottom-3"
+                                                    th:id="'role-' + ${roleViewModel.id}">
+                                                    <input class="govuk-checkboxes__input"
+                                                        th:id="'role-input-' + ${roleViewModel.id}" name="roles"
+                                                        th:checked="${roleViewModel.selected}"
+                                                        th:value="${roleViewModel.id}" type="checkbox">
+                                                    <label class="govuk-label govuk-checkboxes__label"
+                                                        th:for="'role-input-' + ${roleViewModel.id}">
+                                                        <span th:text="${roleViewModel.name}"></span>
+                                                    </label>
+                                                    <div class="govuk-hint govuk-checkboxes__hint"
+                                                        th:text="${roleViewModel.description}"></div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <!-- Non-CCMS App: Display roles in flat list -->
+                                <div th:unless="${isCcmsApp}">
+                                    <div class="govuk-checkboxes__item govuk-!-margin-bottom-3"
+                                        th:each="role : ${roles}" th:id="'role-' + ${role.id}">
+                                        <input class="govuk-checkboxes__input" th:id="'role-input-' + ${role.id}"
+                                            name="roles" th:checked="${role.selected}" th:value="${role.id}"
+                                            type="checkbox">
+                                        <label class="govuk-label govuk-checkboxes__label"
+                                            th:for="'role-input-' + ${role.id}">
+                                            <span th:text="${role.name}"></span>
+                                        </label>
+                                        <div class="govuk-hint govuk-checkboxes__hint" th:text="${role.description}">
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
                         </div>

--- a/src/main/resources/templates/grant-access-user-roles.html
+++ b/src/main/resources/templates/grant-access-user-roles.html
@@ -52,13 +52,114 @@
                     <div class="govuk-form-group govuk-!-padding-top-3"
                         th:classappend="${#fields.hasErrors('roles')} ? 'govuk-form-group--error'">
                         <div class="govuk-checkboxes" data-module="govuk-checkboxes">
-                            <div class="govuk-checkboxes__item" th:each="role : ${roles}">
-                                <input class="govuk-checkboxes__input" th:id="${role.id}" name="roles" type="checkbox"
-                                    th:value="${role.id}" th:checked="${role.selected}">
-                                <label class="govuk-label govuk-checkboxes__label" th:for="${role.id}">
-                                    <span th:text="${role.name}"></span>
-                                </label>
+
+                            <!-- CCMS App: Display roles organized by sections -->
+                            <div th:if="${isCcmsApp}">
+                                <!-- Provider Section -->
+                                <div th:if="${ccmsRolesBySection.containsKey('Provider') and !ccmsRolesBySection['Provider'].isEmpty()}"
+                                    class="govuk-!-margin-bottom-6">
+                                    <h3 class="govuk-heading-m">Provider</h3>
+                                    <div th:each="roleDto : ${ccmsRolesBySection['Provider']}">
+                                        <div th:each="roleViewModel : ${roles}"
+                                            th:if="${roleViewModel.id == roleDto.id}">
+                                            <div class="govuk-checkboxes__item govuk-!-margin-bottom-3">
+                                                <input class="govuk-checkboxes__input" th:id="${roleViewModel.id}"
+                                                    name="roles" type="checkbox" th:value="${roleViewModel.id}"
+                                                    th:checked="${roleViewModel.selected}">
+                                                <label class="govuk-label govuk-checkboxes__label"
+                                                    th:for="${roleViewModel.id}">
+                                                    <span th:text="${roleViewModel.name}"></span>
+                                                </label>
+                                                <div class="govuk-hint govuk-checkboxes__hint"
+                                                    th:text="${roleViewModel.description}">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <!-- Chambers Section -->
+                                <div th:if="${ccmsRolesBySection.containsKey('Chambers') and !ccmsRolesBySection['Chambers'].isEmpty()}"
+                                    class="govuk-!-margin-bottom-6">
+                                    <h3 class="govuk-heading-m">Chambers</h3>
+                                    <div th:each="roleDto : ${ccmsRolesBySection['Chambers']}">
+                                        <div th:each="roleViewModel : ${roles}"
+                                            th:if="${roleViewModel.id == roleDto.id}">
+                                            <div class="govuk-checkboxes__item govuk-!-margin-bottom-3">
+                                                <input class="govuk-checkboxes__input" th:id="${roleViewModel.id}"
+                                                    name="roles" type="checkbox" th:value="${roleViewModel.id}"
+                                                    th:checked="${roleViewModel.selected}">
+                                                <label class="govuk-label govuk-checkboxes__label"
+                                                    th:for="${roleViewModel.id}">
+                                                    <span th:text="${roleViewModel.name}"></span>
+                                                </label>
+                                                <div class="govuk-hint govuk-checkboxes__hint"
+                                                    th:text="${roleViewModel.description}">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <!-- Advocate Section -->
+                                <div th:if="${ccmsRolesBySection.containsKey('Advocate') and !ccmsRolesBySection['Advocate'].isEmpty()}"
+                                    class="govuk-!-margin-bottom-6">
+                                    <h3 class="govuk-heading-m">Advocate</h3>
+                                    <div th:each="roleDto : ${ccmsRolesBySection['Advocate']}">
+                                        <div th:each="roleViewModel : ${roles}"
+                                            th:if="${roleViewModel.id == roleDto.id}">
+                                            <div class="govuk-checkboxes__item govuk-!-margin-bottom-3">
+                                                <input class="govuk-checkboxes__input" th:id="${roleViewModel.id}"
+                                                    name="roles" type="checkbox" th:value="${roleViewModel.id}"
+                                                    th:checked="${roleViewModel.selected}">
+                                                <label class="govuk-label govuk-checkboxes__label"
+                                                    th:for="${roleViewModel.id}">
+                                                    <span th:text="${roleViewModel.name}"></span>
+                                                </label>
+                                                <div class="govuk-hint govuk-checkboxes__hint"
+                                                    th:text="${roleViewModel.description}">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <!-- Other CCMS Roles Section (if any) -->
+                                <div th:if="${ccmsRolesBySection.containsKey('Other') and !ccmsRolesBySection['Other'].isEmpty()}"
+                                    class="govuk-!-margin-bottom-6">
+                                    <h3 class="govuk-heading-m">Other</h3>
+                                    <div th:each="roleDto : ${ccmsRolesBySection['Other']}">
+                                        <div th:each="roleViewModel : ${roles}"
+                                            th:if="${roleViewModel.id == roleDto.id}">
+                                            <div class="govuk-checkboxes__item govuk-!-margin-bottom-3">
+                                                <input class="govuk-checkboxes__input" th:id="${roleViewModel.id}"
+                                                    name="roles" type="checkbox" th:value="${roleViewModel.id}"
+                                                    th:checked="${roleViewModel.selected}">
+                                                <label class="govuk-label govuk-checkboxes__label"
+                                                    th:for="${roleViewModel.id}">
+                                                    <span th:text="${roleViewModel.name}"></span>
+                                                </label>
+                                                <div class="govuk-hint govuk-checkboxes__hint govuk-!-margin-top-1"
+                                                    th:text="${roleViewModel.description}">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
                             </div>
+
+                            <!-- Non-CCMS App: Display roles in flat list -->
+                            <div th:unless="${isCcmsApp}">
+                                <div class="govuk-checkboxes__item govuk-!-margin-bottom-3" th:each="role : ${roles}">
+                                    <input class="govuk-checkboxes__input" th:id="${role.id}" name="roles"
+                                        type="checkbox" th:value="${role.id}" th:checked="${role.selected}">
+                                    <label class="govuk-label govuk-checkboxes__label" th:for="${role.id}">
+                                        <span th:text="${role.name}"></span>
+                                    </label>
+                                    <div class="govuk-hint govuk-checkboxes__hint" th:text="${role.description}"></div>
+                                </div>
+                            </div>
+
                         </div>
                     </div>
                 </fieldset>

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/service/RoleChangeNotificationServiceTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/service/RoleChangeNotificationServiceTest.java
@@ -1,29 +1,29 @@
 package uk.gov.justice.laa.portal.landingpage.service;
 
-import uk.gov.justice.laa.portal.landingpage.client.CcmsApiClient;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import uk.gov.justice.laa.portal.landingpage.client.CcmsApiClient;
 import uk.gov.justice.laa.portal.landingpage.entity.AppRole;
 import uk.gov.justice.laa.portal.landingpage.entity.EntraUser;
 import uk.gov.justice.laa.portal.landingpage.entity.Firm;
 import uk.gov.justice.laa.portal.landingpage.entity.UserProfile;
 import uk.gov.justice.laa.portal.landingpage.entity.UserType;
 import uk.gov.justice.laa.portal.landingpage.model.CcmsMessage;
-
-import java.util.Set;
-import java.util.UUID;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class RoleChangeNotificationServiceTest {
@@ -63,6 +63,7 @@ class RoleChangeNotificationServiceTest {
         puiRole1 = AppRole.builder()
                 .id(UUID.randomUUID())
                 .name("PUI_ROLE_1")
+                .description("PUI Role 1 Description")
                 .ccmsCode("CCMS_PUI_001")
                 .legacySync(true)
                 .build();
@@ -70,6 +71,7 @@ class RoleChangeNotificationServiceTest {
         puiRole2 = AppRole.builder()
                 .id(UUID.randomUUID())
                 .name("PUI_ROLE_2")
+                .description("PUI Role 2 Description")
                 .ccmsCode("CCMS_PUI_002")
                 .legacySync(true)
                 .build();
@@ -77,6 +79,7 @@ class RoleChangeNotificationServiceTest {
         nonPuiRole = AppRole.builder()
                 .id(UUID.randomUUID())
                 .name("NON_PUI_ROLE")
+                .description("Non-PUI Role Description")
                 .ccmsCode("NON_CCMS_001")
                 .build();
 
@@ -134,8 +137,8 @@ class RoleChangeNotificationServiceTest {
         doThrow(new RuntimeException("CCMS API call failed"))
                 .when(ccmsApiClient).sendUserRoleChange(any(CcmsMessage.class));
 
-        RuntimeException exception = assertThrows(RuntimeException.class, () ->
-                roleChangeNotificationService.sendMessage(userProfile, newPuiRoles, oldPuiRoles));
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> roleChangeNotificationService.sendMessage(userProfile, newPuiRoles, oldPuiRoles));
 
         assertThat(exception.getMessage()).isEqualTo("Failed to send message");
         assertThat(exception.getCause().getMessage()).isEqualTo("CCMS API call failed");

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/service/UserServiceTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/service/UserServiceTest.java
@@ -30,14 +30,12 @@ import static org.mockito.ArgumentMatchers.eq;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import org.mockito.junit.jupiter.MockitoExtension;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -2649,6 +2647,7 @@ class UserServiceTest {
             AppRole oldRole = AppRole.builder()
                     .id(UUID.randomUUID())
                     .name("OLD_ROLE")
+                    .description("Old Role Description")
                     .ccmsCode("CCMS_OLD")
                     .legacySync(true)
                     .roleType(RoleType.EXTERNAL)
@@ -2658,6 +2657,7 @@ class UserServiceTest {
             final AppRole newRole = AppRole.builder()
                     .id(UUID.fromString(selectedRoles.get(0)))
                     .name("NEW_ROLE")
+                    .description("New Role Description")
                     .ccmsCode("CCMS_NEW")
                     .legacySync(true)
                     .roleType(RoleType.EXTERNAL)
@@ -2712,6 +2712,7 @@ class UserServiceTest {
             final AppRole newRole = AppRole.builder()
                     .id(UUID.fromString(selectedRoles.get(0)))
                     .name("NEW_ROLE")
+                    .description("New Role Description")
                     .ccmsCode("CCMS_NEW")
                     .legacySync(true)
                     .roleType(RoleType.EXTERNAL)


### PR DESCRIPTION
This pull request introduces dynamic organization of CCMS (Client and Cost Management System) roles within the user roles management UI. The main goal is to group CCMS roles by their type (Provider, Chambers, Advocate, Other) for improved clarity and maintainability. This is achieved through a new utility class and updates to both backend logic and the frontend template. Additionally, role DTOs and view models are extended to support new fields, and a repository method is added for CCMS role lookups.

**CCMS Role Organization and Display:**

* Added a new utility class `CcmsRoleGroupsUtil` to dynamically categorize CCMS roles by section (Provider, Chambers, Advocate, Other) based on their `ccmsCode` patterns. This supports future changes in role codes and keeps the logic maintainable.
* Updated `UserController` to use `CcmsRoleGroupsUtil` for organizing CCMS roles when editing or granting user roles. The controller now passes organized role groups and a flag indicating CCMS context to the view. [[1]](diffhunk://#diff-1c3931784714b5992966f392b56dad9140ea42ba7303dfce45c2cb8533ed3885R783-R809) [[2]](diffhunk://#diff-1c3931784714b5992966f392b56dad9140ea42ba7303dfce45c2cb8533ed3885R1219-R1245)
* The `edit-user-roles.html` template now displays CCMS roles grouped by section with headings and descriptions, while non-CCMS roles remain in a flat list.

**Role Model and Repository Enhancements:**

* Extended `AppRoleDto` and `AppRoleViewModel` to include new fields: `description` and `ccmsCode`, enabling richer UI display and backend logic. [[1]](diffhunk://#diff-386b9f06e6cd1d86ae557e5803a0ba459c7f84b7993bfc40adcff1c11bd0648bR10-R11) [[2]](diffhunk://#diff-36389b2ebda37927d8669c36fb699eeb04e37318ce908e92cf05c4fa4bcedae9R10)
* Added a repository method `findByCcmsCode` in `AppRoleRepository` to support efficient lookups of roles by their CCMS code.