### PR TITLE
Fixed showFirmAdmins filter on user listing

### DIFF
--- a/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/RoleBasedAccessIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/RoleBasedAccessIntegrationTest.java
@@ -1,36 +1,25 @@
 package uk.gov.justice.laa.portal.landingpage.controller;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
-import org.springframework.security.oauth2.core.user.OAuth2User;
-import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
-import uk.gov.justice.laa.portal.landingpage.entity.App;
+
 import uk.gov.justice.laa.portal.landingpage.entity.AppRole;
 import uk.gov.justice.laa.portal.landingpage.entity.EntraUser;
 import uk.gov.justice.laa.portal.landingpage.entity.Firm;
-import uk.gov.justice.laa.portal.landingpage.entity.Permission;
-import uk.gov.justice.laa.portal.landingpage.entity.RoleType;
 import uk.gov.justice.laa.portal.landingpage.entity.UserProfile;
 import uk.gov.justice.laa.portal.landingpage.entity.UserType;
 import uk.gov.justice.laa.portal.landingpage.repository.AppRepository;
 import uk.gov.justice.laa.portal.landingpage.repository.AppRoleRepository;
 import uk.gov.justice.laa.portal.landingpage.repository.EntraUserRepository;
 import uk.gov.justice.laa.portal.landingpage.repository.FirmRepository;
+import uk.gov.justice.laa.portal.landingpage.repository.OfficeRepository;
 import uk.gov.justice.laa.portal.landingpage.repository.UserProfileRepository;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
 
 public abstract class RoleBasedAccessIntegrationTest extends BaseIntegrationTest {
 
@@ -53,6 +42,10 @@ public abstract class RoleBasedAccessIntegrationTest extends BaseIntegrationTest
     @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
     @Autowired
     protected FirmRepository firmRepository;
+
+    @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
+    @Autowired
+    protected OfficeRepository officeRepository;
 
     protected Firm testFirm1;
     protected Firm testFirm2;
@@ -237,6 +230,7 @@ public abstract class RoleBasedAccessIntegrationTest extends BaseIntegrationTest
     protected void clearRepositories() {
         userProfileRepository.deleteAll();
         entraUserRepository.deleteAll();
+        officeRepository.deleteAll(); // Delete offices first to avoid foreign key constraint violation
         firmRepository.deleteAll();
     }
 }

--- a/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/RoleBasedAccessUserListTest.java
+++ b/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/RoleBasedAccessUserListTest.java
@@ -1,20 +1,20 @@
 package uk.gov.justice.laa.portal.landingpage.controller;
 
+import java.util.List;
+import java.util.Objects;
+
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.web.servlet.MvcResult;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 import org.springframework.web.servlet.ModelAndView;
+
 import uk.gov.justice.laa.portal.landingpage.dto.UserProfileDto;
 import uk.gov.justice.laa.portal.landingpage.entity.EntraUser;
 import uk.gov.justice.laa.portal.landingpage.entity.Firm;
 import uk.gov.justice.laa.portal.landingpage.entity.UserProfile;
-
-import java.util.List;
-import java.util.Objects;
-
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
 public class RoleBasedAccessUserListTest extends RoleBasedAccessIntegrationTest {
 
@@ -34,7 +34,7 @@ public class RoleBasedAccessUserListTest extends RoleBasedAccessIntegrationTest 
     }
 
     @Test
-    public void testGlobalAdminCanSeeAllFirmAdminsAndGlobalAdminsWhenFiltered() throws Exception {
+    public void testGlobalAdminCanSeeAllFirmAdminsWhenFiltered() throws Exception {
         EntraUser loggedInUser = globalAdmins.getFirst();
         MvcResult result = this.mockMvc.perform(get("/admin/users?size=100&showFirmAdmins=true")
                         .with(userOauth2Login(loggedInUser)))
@@ -43,7 +43,7 @@ public class RoleBasedAccessUserListTest extends RoleBasedAccessIntegrationTest 
                 .andReturn();
         ModelAndView modelAndView = result.getModelAndView();
         List<UserProfileDto> users = (List<UserProfileDto>) modelAndView.getModel().get("users");
-        int expectedSize = externalUserAdmins.size() + globalAdmins.size();
+        int expectedSize = externalUserAdmins.size(); // Only EXTERNAL_SINGLE_FIRM_ADMIN users, no global admins
         Assertions.assertThat(users).hasSize(expectedSize);
         for (UserProfileDto userProfile : users) {
             Assertions.assertThat(userProfile.getEntraUser().getLastName()).contains("Admin");
@@ -68,7 +68,7 @@ public class RoleBasedAccessUserListTest extends RoleBasedAccessIntegrationTest 
     }
 
     @Test
-    public void testInternalUserManagerCanSeeOnlyGlobalAdminWhenFiltered() throws Exception {
+    public void testInternalUserManagerCannotSeeAnyUsersWhenFiltered() throws Exception {
         EntraUser loggedInUser = internalUserManagers.getFirst();
         MvcResult result = this.mockMvc.perform(get("/admin/users?size=100&showFirmAdmins=true")
                         .with(userOauth2Login(loggedInUser)))
@@ -77,11 +77,8 @@ public class RoleBasedAccessUserListTest extends RoleBasedAccessIntegrationTest 
                 .andReturn();
         ModelAndView modelAndView = result.getModelAndView();
         List<UserProfileDto> users = (List<UserProfileDto>) modelAndView.getModel().get("users");
-        int expectedSize = globalAdmins.size();
+        int expectedSize = 0; // No users shown since GLOBAL_ADMIN is excluded and no EXTERNAL_SINGLE_FIRM_ADMIN visible to internal user manager
         Assertions.assertThat(users).hasSize(expectedSize);
-        for (UserProfileDto userProfile : users) {
-            Assertions.assertThat(userProfile.getEntraUser().getLastName()).isEqualTo("GlobalAdmin");
-        }
     }
 
     @Test
@@ -115,7 +112,7 @@ public class RoleBasedAccessUserListTest extends RoleBasedAccessIntegrationTest 
     }
 
     @Test
-    public void testInternalAndExternalUserManagerCanSeeAllFirmAdminsAndGlobalAdminsWhenFiltered() throws Exception {
+    public void testInternalAndExternalUserManagerCanSeeAllFirmAdminsWhenFiltered() throws Exception {
         EntraUser loggedInUser = internalAndExternalUserManagers.getFirst();
         MvcResult result = this.mockMvc.perform(get("/admin/users?size=100&showFirmAdmins=true")
                         .with(userOauth2Login(loggedInUser)))
@@ -124,7 +121,7 @@ public class RoleBasedAccessUserListTest extends RoleBasedAccessIntegrationTest 
                 .andReturn();
         ModelAndView modelAndView = result.getModelAndView();
         List<UserProfileDto> users = (List<UserProfileDto>) modelAndView.getModel().get("users");
-        int expectedSize = externalUserAdmins.size() + globalAdmins.size();
+        int expectedSize = externalUserAdmins.size(); // Only EXTERNAL_SINGLE_FIRM_ADMIN users, no global admins
         Assertions.assertThat(users).hasSize(expectedSize);
     }
 


### PR DESCRIPTION
Moved logic of `showFirmAdmins` from permission logic to filtering list according to userTypes

https://github.com/user-attachments/assets/54807a94-771c-4c66-a4f1-c9d92554c8ed

User type filtering improvements:

* Introduced a new `userTypesToFilter` variable to explicitly control which user types are included in the results, making the filtering logic clearer and easier to maintain.
* When `showFirmAdmins` is true, the results are now filtered to only include `EXTERNAL_SINGLE_FIRM_ADMIN` users; otherwise, all external user types are included by default.
* For users with permission to see all users, the method now combines the filtered external user types with the `INTERNAL` user type, ensuring the correct set of users is returned based on permissions and filter flags.
* Updated all calls to `userService.getPageOfUsersByNameOrEmailAndPermissionsAndFirm` to use the new `userTypesToFilter` variable, ensuring consistent filtering across all permission scenarios.