### PR TITLE
Always force Azure logout

### DIFF
--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/LoginController.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/LoginController.java
@@ -123,8 +123,8 @@ public class LoginController {
         EntraUser user = loginService.getCurrentEntraUser(authentication);
         userService.setDefaultActiveProfile(user, UUID.fromString(firmId));
         
-        // For switchFirm, we want to do full Azure logout, so redirect to logout with Azure logout parameter
-        return new RedirectView("/logout?azure_logout=true");
+        // Redirect to logout
+        return new RedirectView("/logout");
     }
 
     @GetMapping("/switchfirm")

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/service/CustomLogoutHandler.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/service/CustomLogoutHandler.java
@@ -31,20 +31,14 @@ public class CustomLogoutHandler implements LogoutHandler {
         // First, revoke the Graph API sessions
         loginService.logout(authentication, getClient(authentication));
         
-        // Only redirect to Azure logout if this is not a test environment or if explicitly requested
-        // Check if the request has a parameter indicating Azure logout is needed
-        String azureLogout = request.getParameter("azure_logout");
-        if ("true".equals(azureLogout)) {
-            try {
-                String logoutUrl = logoutService.buildAzureLogoutUrl();
-                response.sendRedirect(logoutUrl);
-            } catch (IOException e) {
-                // If redirect fails, let Spring Security handle the logout normally
-                response.setStatus(HttpServletResponse.SC_FOUND);
-                response.setHeader("Location", "/?message=logout");
-            }
+        try {
+            String logoutUrl = logoutService.buildAzureLogoutUrl();
+            response.sendRedirect(logoutUrl);
+        } catch (IOException e) {
+            // If redirect fails, let Spring Security handle the logout normally
+            response.setStatus(HttpServletResponse.SC_FOUND);
+            response.setHeader("Location", "/?message=logout");
         }
-        // If no Azure logout is requested, let Spring Security handle the normal logout flow
     }
 
     protected OAuth2AuthorizedClient getClient(Authentication authentication) {

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/LoginControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/LoginControllerTest.java
@@ -319,6 +319,6 @@ class LoginControllerTest {
         
         verify(loginService).getCurrentEntraUser(any());
         verify(userService).setDefaultActiveProfile(any(), any());
-        assertThat(view.getUrl()).isEqualTo("/logout?azure_logout=true");
+        assertThat(view.getUrl()).isEqualTo("/logout");
     }
 }

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/service/CustomLogoutHandlerTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/service/CustomLogoutHandlerTest.java
@@ -11,7 +11,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -47,26 +46,8 @@ public class CustomLogoutHandlerTest {
     }
 
     @Test
-    public void logout() {
+    public void logout_alwaysRedirectsToAzure() {
         MockHttpServletRequest request = new MockHttpServletRequest();
-        MockHttpServletResponse response = new MockHttpServletResponse();
-        OAuth2User realPrincipal = new DefaultOAuth2User(
-                List.of(new SimpleGrantedAuthority("ROLE_USER")),
-                Map.of("name", "Alice", "preferred_username", "alice@laa.gov.uk"),
-                "name");
-        OAuth2AuthenticationToken realAuthToken = new OAuth2AuthenticationToken(realPrincipal, realPrincipal.getAuthorities(), "azure");
-
-        logoutHandler.logout(request, response, realAuthToken);
-        
-        verify(clientService).loadAuthorizedClient(eq("azure"), eq("Alice"));
-        verify(loginService).logout(any(), any());
-        // Should not call LogoutService.buildAzureLogoutUrl() when azure_logout parameter is not present
-    }
-
-    @Test
-    public void logoutWithAzureLogout() {
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setParameter("azure_logout", "true");
         MockHttpServletResponse response = new MockHttpServletResponse();
         OAuth2User realPrincipal = new DefaultOAuth2User(
                 List.of(new SimpleGrantedAuthority("ROLE_USER")),
@@ -84,9 +65,8 @@ public class CustomLogoutHandlerTest {
     }
 
     @Test
-    public void logoutWithAzureLogout_handlesIoException() throws IOException {
+    public void logout_handlesIoException() throws IOException {
         MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setParameter("azure_logout", "true");
         MockHttpServletResponse response = new MockHttpServletResponse();
         OAuth2User realPrincipal = new DefaultOAuth2User(
                 List.of(new SimpleGrantedAuthority("ROLE_USER")),
@@ -113,78 +93,5 @@ public class CustomLogoutHandlerTest {
         // Should set fallback response when IOException occurs
         assertThat(spyResponse.getStatus()).isEqualTo(302); // SC_FOUND
         assertThat(spyResponse.getHeader("Location")).isEqualTo("/?message=logout");
-    }
-
-    @Test
-    public void logoutWithAzureLogoutParameterFalse_shouldNotRedirect() {
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setParameter("azure_logout", "false");
-        MockHttpServletResponse response = new MockHttpServletResponse();
-        OAuth2User realPrincipal = new DefaultOAuth2User(
-                List.of(new SimpleGrantedAuthority("ROLE_USER")),
-                Map.of("name", "Alice", "preferred_username", "alice@laa.gov.uk"),
-                "name");
-        OAuth2AuthenticationToken realAuthToken = new OAuth2AuthenticationToken(realPrincipal, realPrincipal.getAuthorities(), "azure");
-
-        logoutHandler.logout(request, response, realAuthToken);
-        
-        verify(clientService).loadAuthorizedClient(eq("azure"), eq("Alice"));
-        verify(loginService).logout(any(), any());
-        verify(logoutService, never()).buildAzureLogoutUrl();
-    }
-
-    @Test
-    public void logoutWithNullAzureLogoutParameter_shouldNotRedirect() {
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        // Don't set the parameter at all to test null case
-        MockHttpServletResponse response = new MockHttpServletResponse();
-        OAuth2User realPrincipal = new DefaultOAuth2User(
-                List.of(new SimpleGrantedAuthority("ROLE_USER")),
-                Map.of("name", "Alice", "preferred_username", "alice@laa.gov.uk"),
-                "name");
-        OAuth2AuthenticationToken realAuthToken = new OAuth2AuthenticationToken(realPrincipal, realPrincipal.getAuthorities(), "azure");
-
-        logoutHandler.logout(request, response, realAuthToken);
-        
-        verify(clientService).loadAuthorizedClient(eq("azure"), eq("Alice"));
-        verify(loginService).logout(any(), any());
-        verify(logoutService, never()).buildAzureLogoutUrl();
-    }
-
-    @Test
-    public void logoutWithEmptyAzureLogoutParameter_shouldNotRedirect() {
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setParameter("azure_logout", "");
-        MockHttpServletResponse response = new MockHttpServletResponse();
-        OAuth2User realPrincipal = new DefaultOAuth2User(
-                List.of(new SimpleGrantedAuthority("ROLE_USER")),
-                Map.of("name", "Alice", "preferred_username", "alice@laa.gov.uk"),
-                "name");
-        OAuth2AuthenticationToken realAuthToken = new OAuth2AuthenticationToken(realPrincipal, realPrincipal.getAuthorities(), "azure");
-
-        logoutHandler.logout(request, response, realAuthToken);
-        
-        verify(clientService).loadAuthorizedClient(eq("azure"), eq("Alice"));
-        verify(loginService).logout(any(), any());
-        verify(logoutService, never()).buildAzureLogoutUrl();
-    }
-
-    @Test
-    public void logoutWithCaseInsensitiveAzureLogoutParameter_shouldOnlyWorkWithExactTrue() {
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setParameter("azure_logout", "TRUE"); // uppercase
-        MockHttpServletResponse response = new MockHttpServletResponse();
-        OAuth2User realPrincipal = new DefaultOAuth2User(
-                List.of(new SimpleGrantedAuthority("ROLE_USER")),
-                Map.of("name", "Alice", "preferred_username", "alice@laa.gov.uk"),
-                "name");
-        OAuth2AuthenticationToken realAuthToken = new OAuth2AuthenticationToken(realPrincipal, realPrincipal.getAuthorities(), "azure");
-
-        logoutHandler.logout(request, response, realAuthToken);
-        
-        verify(clientService).loadAuthorizedClient(eq("azure"), eq("Alice"));
-        verify(loginService).logout(any(), any());
-        // Should not call buildAzureLogoutUrl because "TRUE" != "true"
-        verify(logoutService, never()).buildAzureLogoutUrl();
     }
 }


### PR DESCRIPTION
I followed the flow through and am unsure why there is an `azure_logout` flag, it looks like this flag dictates whether you use Spring to sign out or Entra to sign out and the only thing that currently uses the Entra option is  `/switchFirm` which I can't find any usages for.

Is there actually a scenario where we do not want to clear the Entra session - I am not sure what that achieves as we are using SSO, it will just log back in to any service connected to the same tenant won't it? I believe this may be the behaviour we are currently seeing.

I think what may be happening is the following:

**Why it works locally**

1.  Entra Sandbox doesn't have SSO configured properly
2. We default to letting Spring sign the user out
3. The mixture of these two things means that it works locally because Spring handles the session/identity.

**Why it doesn't work in deployed environments**

1. Entra Dev/NLE/Prod do have SSO configured properly
2. We default to letting Spring sign the user out
3. The mixture of these two things means that it doesn't work because Entra handles the session outside of the application scope.

I cannot be confident that this is the case but sign-out does seem to be working now, the following things need to be checked:

1. Does this sign out all Entra sessions? e.g. LAA Apps - if it doesn't is that a showstopper? Do we actually want it to do that?
2. This currently degrades the UX experience due to having to go through an Entra managed sign out page - can we force it to default to the current sessions user?
3. Are there any other requirements this solution doesn't cater to? 