### PR TITLE
 update URLs to the latest service domain

### DIFF
--- a/pa11y-auth-test.js
+++ b/pa11y-auth-test.js
@@ -104,7 +104,7 @@ const puppeteer = require('puppeteer');
     console.log('Login flow completed successfully');
 
     // === OPTIONAL: Run Pa11y Accessibility Test ===
-    const results = await pa11y(`https://${namespace}..your-legal-aid-services.service.justice.gov.uk`, {
+    const results = await pa11y(`https://${namespace}.your-legal-aid-services.service.justice.gov.uk`, {
       browser,
       page,
     });


### PR DESCRIPTION
Updated url domains - 

`https://${namespace}.your-legal-aid-services.service.justice.gov.uk`

to

`https://${namespace}.your-legal-aid-services.service.justice.gov.uk`