### PR TITLE
Refactor user access management templates and navigation

### DIFF
--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/LoginController.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/LoginController.java
@@ -49,13 +49,8 @@ public class LoginController {
     }
 
     @GetMapping("/")
-    public String login(@RequestParam(value = "message", required = false) String message, Model model) {
-        if (message != null && message.equals("logout")) {
-            String successMessage = "You have been securely logged out";
-            model.addAttribute("successMessage", successMessage);
-        }
-        model.addAttribute(ModelAttributes.PAGE_TITLE, "Sign in");
-        return "index";
+    public String index() {
+        return "redirect:/home";
     }
 
     /**

--- a/src/main/resources/templates/edit-user-apps.html
+++ b/src/main/resources/templates/edit-user-apps.html
@@ -2,21 +2,17 @@
 <html lang="en" th:replace="~{layout :: layout(
       title=~{::title},
       mainContent=~{::#main-content},
-      pageCategory=${'register'},
+      pageCategory=${'edit-user'},
       breadcrumbs=~{::#breadcrumbs})}" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.w3.org/1999/xhtml">
 
 <head>
-    <title>Services</title>
+    <title>Edit - Services</title>
 </head>
 
 <body>
     <nav aria-label="Breadcrumb" class="govuk-breadcrumbs" id="breadcrumbs">
-        <ol class="govuk-breadcrumbs__list">
-            <li class="govuk-breadcrumbs__list-item">
-                <a class="govuk-breadcrumbs__link" th:href="@{'/admin/users/manage/' + ${user.id}}">
-                    < Back</a>
-            </li>
-        </ol>
+        <a class="govuk-back-link" th:href="@{'/admin/users/manage/' + ${user.id}}">
+            Back </a>
     </nav>
     <main class="govuk-main-wrapper" id="main-content">
         <form method="post" th:action="@{/admin/users/edit/{id}/apps(id=${user.id})}" th:object="${applicationsForm}">

--- a/src/main/resources/templates/edit-user-details.html
+++ b/src/main/resources/templates/edit-user-details.html
@@ -2,21 +2,17 @@
 <html lang="en" th:replace="~{layout :: layout(
       title=~{::title},
       mainContent=~{::#main-content},
-      pageCategory=${'login'},
+      pageCategory=${'edit-user'},
       breadcrumbs=~{::#breadcrumbs})}" xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/html">
 
 <head>
-    <title>User Details</title>
+    <title>Edit - User Details</title>
 </head>
 
 <body>
     <nav aria-label="Breadcrumb" class="govuk-breadcrumbs" id="breadcrumbs">
-        <ol class="govuk-breadcrumbs__list">
-            <li class="govuk-breadcrumbs__list-item">
-                <a class="govuk-breadcrumbs__link" th:href="@{'/admin/users/manage/' + ${user.id}}">
-                    < Back</a>
-            </li>
-        </ol>
+        <a class="govuk-back-link" th:href="@{'/admin/users/manage/' + ${user.id}}">
+            Back </a>
     </nav>
     <main class="govuk-main-wrapper" id="main-content">
         <fieldset class="govuk-fieldset">
@@ -52,7 +48,7 @@
                         <p th:each="err : ${#fields.errors('email')}" th:text="${err}"></p>
                     </div>
                     <input class="govuk-input govuk-!-width-one-third" name="email" th:value="*{email}" id="email"
-                        th:aria-describedby="${#fields.hasErrors('email')} ? 'email-error' : null" readonly 
+                        th:aria-describedby="${#fields.hasErrors('email')} ? 'email-error' : null" readonly
                         style="background-color: #f3f2f1; color: #505a5f; cursor: not-allowed;" />
                 </div>
                 <div class="govuk-form-group"

--- a/src/main/resources/templates/edit-user-offices.html
+++ b/src/main/resources/templates/edit-user-offices.html
@@ -2,21 +2,17 @@
 <html lang="en" th:replace="~{layout :: layout(
       title=~{::title},
       mainContent=~{::#main-content},
-      pageCategory=${'register'},
+      pageCategory=${'edit-user'},
       breadcrumbs=~{::#breadcrumbs})}" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.w3.org/1999/xhtml">
 
 <head>
-    <title>Offices</title>
+    <title>Edit - Offices</title>
 </head>
 
 <body>
     <nav aria-label="Breadcrumb" class="govuk-breadcrumbs" id="breadcrumbs">
-        <ol class="govuk-breadcrumbs__list">
-            <li class="govuk-breadcrumbs__list-item">
-                <a class="govuk-breadcrumbs__link" th:href="@{'/admin/users/manage/' + ${user.id}}">
-                    < Back</a>
-            </li>
-        </ol>
+        <a class="govuk-back-link" th:href="@{'/admin/users/manage/' + ${user.id}}">
+            Back </a>
     </nav>
     <main class="govuk-main-wrapper" id="main-content">
         <form method="post" th:action="@{/admin/users/edit/{id}/offices(id=${user.id})}" th:object="${officesForm}">

--- a/src/main/resources/templates/edit-user-roles.html
+++ b/src/main/resources/templates/edit-user-roles.html
@@ -2,31 +2,20 @@
 <html lang="en" th:replace="~{layout :: layout(
       title=~{::title},
       mainContent=~{::#main-content},
-      pageCategory=${'users'},
+      pageCategory=${'edit-user'},
       breadcrumbs=~{::#breadcrumbs})}" xmlns:th="http://www.thymeleaf.org">
 
 <head>
-    <title>Edit User Roles</title>
+    <title>Edit - User Roles</title>
 </head>
 
 <body>
     <nav aria-label="Breadcrumb" class="govuk-breadcrumbs" id="breadcrumbs">
-        <ol class="govuk-breadcrumbs__list">
-            <li class="govuk-breadcrumbs__list-item">
-                <a class="govuk-breadcrumbs__link" href="/">Home</a>
-            </li>
-            <li class="govuk-breadcrumbs__list-item">
-                <a class="govuk-breadcrumbs__link" th:href="@{'/admin/users/manage/' + ${user.id}}"><span
-                        th:text="${user.fullName}"></span></a>
-            </li>
-        </ol>
+        <a class="govuk-back-link" th:href="@{/admin/users/manage/{id}(id=${user.id})}">
+            Back </a>
     </nav>
-
     <main class="govuk-main-wrapper" id="main-content">
         <div th:if="${#authentication.isAuthenticated()}">
-            <a class="govuk-back-link govuk-!-margin-bottom-3" th:href="@{/admin/users/manage/{id}(id=${user.id})}">
-                Back
-            </a>
             <form method="post"
                 th:action="@{/admin/users/edit/{id}/roles(id=${user.id},selectedAppIndex=${editUserRolesSelectedAppIndex})}"
                 th:object="${rolesForm}" class="govuk-form">

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -11,6 +11,10 @@
 
 <body>
     <div class="govuk-width-container">
+        <nav aria-label="Breadcrumb" class="govuk-breadcrumbs" id="breadcrumbs">
+            <a class="govuk-back-link" th:href="@{/home}">
+                Back </a>
+        </nav>
         <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-two-thirds">

--- a/src/main/resources/templates/grant-access-check-answers.html
+++ b/src/main/resources/templates/grant-access-check-answers.html
@@ -2,7 +2,7 @@
 <html lang="en" th:replace="~{layout :: layout(
       title=~{::title},
       mainContent=~{::#main-content},
-      pageCategory=${'register'},
+      pageCategory=${'grant-access'},
       breadcrumbs=~{::#breadcrumbs})}" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.w3.org/1999/xhtml">
 
 <head>
@@ -11,13 +11,9 @@
 
 <body>
     <nav aria-label="Breadcrumb" class="govuk-breadcrumbs" id="breadcrumbs">
-        <ol class="govuk-breadcrumbs__list">
-            <li class="govuk-breadcrumbs__list-item">
-                <a class="govuk-back-link govuk-!-margin-bottom-3"
-                    th:href="@{/admin/users/grant-access/{id}/offices(id=${user.id})}">
-                    Back</a>
-            </li>
-        </ol>
+        <a class="govuk-back-link govuk-!-margin-bottom-3"
+            th:href="@{/admin/users/grant-access/{id}/offices(id=${user.id})}">
+            Back</a>
     </nav>
     <main class="govuk-main-wrapper" id="main-content">
         <div class="govuk-grid-row">
@@ -35,10 +31,13 @@
                             </h2>
                         </div>
                         <div class="govuk-summary-card__content">
-                            <dl class="govuk-summary-list" th:if="${groupedAppRoles != null and !groupedAppRoles.isEmpty()}">
+                            <dl class="govuk-summary-list"
+                                th:if="${groupedAppRoles != null and !groupedAppRoles.isEmpty()}">
                                 <th:block th:each="appEntry : ${groupedAppRoles}">
-                                    <div th:each="appRole, iterStat : ${appEntry.value}" class="govuk-summary-list__row">
-                                        <dt class="govuk-summary-list__key" th:text="${iterStat.first ? appEntry.key : ''}">App Name</dt>
+                                    <div th:each="appRole, iterStat : ${appEntry.value}"
+                                        class="govuk-summary-list__row">
+                                        <dt class="govuk-summary-list__key"
+                                            th:text="${iterStat.first ? appEntry.key : ''}">App Name</dt>
                                         <dd class="govuk-summary-list__value" th:text="${appRole.name}">Role Name</dd>
                                         <dd class="govuk-summary-list__actions">
                                             <a class="govuk-link"
@@ -47,7 +46,8 @@
                                     </div>
                                 </th:block>
                             </dl>
-                            <div th:if="${groupedAppRoles == null or groupedAppRoles.isEmpty()}" class="govuk-inset-text">
+                            <div th:if="${groupedAppRoles == null or groupedAppRoles.isEmpty()}"
+                                class="govuk-inset-text">
                                 No user permissions assigned
                             </div>
                         </div>
@@ -76,10 +76,12 @@
                                     <dt class="govuk-summary-list__key govuk-visually-hidden"></dt>
                                 </div>
                             </dl>
-                            <div th:if="${(userOffices == null or userOffices.isEmpty()) and externalUser}" class="govuk-inset-text">
+                            <div th:if="${(userOffices == null or userOffices.isEmpty()) and externalUser}"
+                                class="govuk-inset-text">
                                 Access to All Offices
                             </div>
-                            <div th:if="${(userOffices == null or userOffices.isEmpty()) and !externalUser}" class="govuk-inset-text">
+                            <div th:if="${(userOffices == null or userOffices.isEmpty()) and !externalUser}"
+                                class="govuk-inset-text">
                                 No offices assigned
                             </div>
                         </div>

--- a/src/main/resources/templates/grant-access-confirmation.html
+++ b/src/main/resources/templates/grant-access-confirmation.html
@@ -2,7 +2,7 @@
 <html lang="en" th:replace="~{layout :: layout(
       title=~{::title},
       mainContent=~{::#main-content},
-      pageCategory=${'register'},
+      pageCategory=${'grant-access'},
       breadcrumbs=~{::#breadcrumbs})}" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.w3.org/1999/xhtml">
 
 <head>

--- a/src/main/resources/templates/grant-access-user-apps.html
+++ b/src/main/resources/templates/grant-access-user-apps.html
@@ -2,7 +2,7 @@
 <html lang="en" th:replace="~{layout :: layout(
       title=~{::title},
       mainContent=~{::#main-content},
-      pageCategory=${'register'},
+      pageCategory=${'grant-access'},
       breadcrumbs=~{::#breadcrumbs})}" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.w3.org/1999/xhtml">
 
 <head>
@@ -11,16 +11,13 @@
 
 <body>
     <nav aria-label="Breadcrumb" class="govuk-breadcrumbs" id="breadcrumbs">
-        <ol class="govuk-breadcrumbs__list">
-            <li class="govuk-breadcrumbs__list-item">
-                <a class="govuk-back-link govuk-!-margin-bottom-3" th:href="@{'/admin/users/manage/' + ${user.id}}">
-                    Back</a>
-            </li>
-        </ol>
+        <a class="govuk-back-link govuk-!-margin-bottom-3" th:href="@{'/admin/users/manage/' + ${user.id}}">
+            Back</a>
     </nav>
     <main class="govuk-main-wrapper" id="main-content">
-        <form method="post" th:action="@{/admin/users/grant-access/{id}/apps(id=${user.id})}" th:object="${applicationsForm}">
-            
+        <form method="post" th:action="@{/admin/users/grant-access/{id}/apps(id=${user.id})}"
+            th:object="${applicationsForm}">
+
             <div th:if="${#fields.hasErrors()}">
                 <div class="govuk-error-summary" role="alert" aria-labelledby="error-summary-title"
                     aria-describedby="error-summary-description" data-module="govuk-error-summary">

--- a/src/main/resources/templates/grant-access-user-offices.html
+++ b/src/main/resources/templates/grant-access-user-offices.html
@@ -2,7 +2,7 @@
 <html lang="en" th:replace="~{layout :: layout(
       title=~{::title},
       mainContent=~{::#main-content},
-      pageCategory=${'register'},
+      pageCategory=${'grant-access'},
       breadcrumbs=~{::#breadcrumbs})}" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.w3.org/1999/xhtml">
 
 <head>
@@ -11,13 +11,9 @@
 
 <body>
     <nav aria-label="Breadcrumb" class="govuk-breadcrumbs" id="breadcrumbs">
-        <ol class="govuk-breadcrumbs__list">
-            <li class="govuk-breadcrumbs__list-item">
-                <a class="govuk-back-link govuk-!-margin-bottom-3"
-                    th:href="@{/admin/users/grant-access/{id}/apps(id=${user.id})}">
-                    Back</a>
-            </li>
-        </ol>
+        <a class="govuk-back-link govuk-!-margin-bottom-3"
+            th:href="@{/admin/users/grant-access/{id}/apps(id=${user.id})}">
+            Back</a>
     </nav>
     <main class="govuk-main-wrapper" id="main-content">
         <form method="post" th:action="@{/admin/users/grant-access/{id}/offices(id=${user.id})}"

--- a/src/main/resources/templates/grant-access-user-roles.html
+++ b/src/main/resources/templates/grant-access-user-roles.html
@@ -2,7 +2,7 @@
 <html lang="en" th:replace="~{layout :: layout(
       title=~{::title},
       mainContent=~{::#main-content},
-      pageCategory=${'register'},
+      pageCategory=${'grant-access'},
       breadcrumbs=~{::#breadcrumbs})}" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.w3.org/1999/xhtml">
 
 <head>
@@ -11,13 +11,9 @@
 
 <body>
     <nav aria-label="Breadcrumb" class="govuk-breadcrumbs" id="breadcrumbs">
-        <ol class="govuk-breadcrumbs__list">
-            <li class="govuk-breadcrumbs__list-item">
-                <a class="govuk-back-link govuk-!-margin-bottom-3"
-                    th:href="@{/admin/users/grant-access/{id}/apps(id=${user.id})}">
-                    Back </a>
-            </li>
-        </ol>
+        <a class="govuk-back-link govuk-!-margin-bottom-3"
+            th:href="@{/admin/users/grant-access/{id}/apps(id=${user.id})}">
+            Back </a>
     </nav>
     <main class="govuk-main-wrapper" id="main-content">
         <form method="post" th:action="@{/admin/users/grant-access/{id}/roles(id=${user.id})}" th:object="${rolesForm}">

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -21,9 +21,8 @@
                         <div class="govuk-grid-column-full">
                             <div class="moj-ticket-panel__content moj-ticket-panel__content--blue">
                                 <h3 class="govuk-heading-m">
-                                    <a href="/admin/users" class="govuk-link govuk-link--no-visited-state"
-                                        rel="noreferrer noopener" target="_blank">Manage your users (opens in a new
-                                        tab)</a>
+                                    <a href="/admin/users" class="govuk-link govuk-link--no-visited-state">Manage your
+                                        users</a>
                                 </h3>
                                 <p class="govuk-body">Create users and manage access and permissions</p>
                             </div>

--- a/src/main/resources/templates/manage-user.html
+++ b/src/main/resources/templates/manage-user.html
@@ -2,24 +2,17 @@
 <html lang="en" th:replace="~{layout :: layout(
       title=~{::title},
       mainContent=~{::#main-content},
-      pageCategory=${'home'},
+      pageCategory=${'manage-user'},
       breadcrumbs=~{::#breadcrumbs})}" xmlns:th="http://www.thymeleaf.org">
 
 <head>
-    <title>Homepage</title>
+    <title>Manage User</title>
 </head>
 
 <body>
     <nav aria-label="Breadcrumb" class="govuk-breadcrumbs" id="breadcrumbs">
-        <ol class="govuk-breadcrumbs__list">
-            <li class="govuk-breadcrumbs__list-item">
-                <a class="govuk-breadcrumbs__link" href="/admin/users">Home</a>
-            </li>
-            <li class="govuk-breadcrumbs__list-item">
-                <a class="govuk-breadcrumbs__link" aria-label="${user.fullName}"><span
-                        th:text="${user.fullName}"></span></a>
-            </li>
-        </ol>
+        <a class="govuk-back-link govuk-!-margin-bottom-3" href="/admin/users">
+            Back </a>
     </nav>
     <main class="govuk-main-wrapper" id="main-content">
         <div class="govuk-grid-row">
@@ -142,16 +135,21 @@
                             <div class="govuk-summary-card__content">
                                 <dl class="govuk-summary-list">
                                     <div class="govuk-summary-list__row" th:each="office : ${userOffices}">
-                                        <dt class="govuk-summary-list__key" th:text="${office.address.addressLine1}"></dt>
-                                        <dd class="govuk-summary-list__value" th:text="${office.address.addressLine1}"></dd>
-                                        <dd class="govuk-summary-list__value" th:text="${office.address.addressLine2}"></dd>
+                                        <dt class="govuk-summary-list__key" th:text="${office.address.addressLine1}">
+                                        </dt>
+                                        <dd class="govuk-summary-list__value" th:text="${office.address.addressLine1}">
+                                        </dd>
+                                        <dd class="govuk-summary-list__value" th:text="${office.address.addressLine2}">
+                                        </dd>
                                         <dd class="govuk-summary-list__value" th:text="${office.address.city}"></dd>
                                         <dd class="govuk-summary-list__value" th:text="${office.address.postcode}"></dd>
                                     </div>
-                                    <div th:if="${#lists.isEmpty(userOffices) and !isAccessGranted}" class="govuk-summary-list__row">
+                                    <div th:if="${#lists.isEmpty(userOffices) and !isAccessGranted}"
+                                        class="govuk-summary-list__row">
                                         <dd class="govuk-summary-list__value">No offices assigned</dd>
                                     </div>
-                                    <div th:if="${#lists.isEmpty(userOffices) and isAccessGranted and externalUser}" class="govuk-summary-list__row">
+                                    <div th:if="${#lists.isEmpty(userOffices) and isAccessGranted and externalUser}"
+                                        class="govuk-summary-list__row">
                                         <dd class="govuk-summary-list__value">Access to All Offices</dd>
                                     </div>
                                 </dl>

--- a/src/main/resources/templates/not-authorised.html
+++ b/src/main/resources/templates/not-authorised.html
@@ -11,6 +11,10 @@
 
 <body>
     <div class="govuk-width-container">
+        <nav aria-label="Breadcrumb" class="govuk-breadcrumbs" id="breadcrumbs">
+            <a class="govuk-back-link" href="/admin/users">
+                Back </a>
+        </nav>
         <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-two-thirds">

--- a/src/main/resources/templates/partials/header.html
+++ b/src/main/resources/templates/partials/header.html
@@ -1,7 +1,7 @@
 <header class="govuk-header" role="banner" data-module="govuk-header">
     <div class="govuk-header__container govuk-width-container">
         <div class="govuk-header__logo">
-            <a href="#" class="govuk-header__link govuk-header__link--homepage">
+            <a href="https://www.gov.uk/government/organisations/legal-aid-agency" class="govuk-header__link govuk-header__link--homepage">
                 <svg focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 324 60" height="30"
                     width="162" fill="currentColor" class="govuk-header__logotype" aria-label="GOV.UK">
                     <title>GOV.UK</title>
@@ -24,7 +24,7 @@
             </a>
         </div>
         <div class="govuk-header__content">
-            <a href="/" class="govuk-header__link govuk-header__service-name">
+            <a href="/home" class="govuk-header__link govuk-header__service-name">
                 Your legal aid services
             </a>
         </div>

--- a/src/main/resources/templates/users.html
+++ b/src/main/resources/templates/users.html
@@ -2,13 +2,19 @@
 <html lang="en" th:replace="~{layout :: layout(
       title=~{::title},
       mainContent=~{::#main-content},
-      pageCategory=${'users'})}" xmlns:th="http://www.thymeleaf.org">
+      pageCategory=${'users'},
+      breadcrumbs=~{::#breadcrumbs})}" xmlns:th="http://www.thymeleaf.org">
+
 
 <head>
     <title>Users</title>
 </head>
 
 <body>
+    <nav aria-label="Breadcrumb" class="govuk-breadcrumbs" id="breadcrumbs">
+        <a class="govuk-back-link" th:href="@{/home}">
+            Back </a>
+    </nav>
     <main class="govuk-main-wrapper" id="main-content" th:if="${#authentication.isAuthenticated()}">
         <div th:if="${successMessage}" role="region" class="moj-alert moj-alert--success moj-alert--with-heading"
             aria-label="success: User added successfully" data-module="moj-alert">
@@ -96,83 +102,73 @@
                             <thead class="govuk-table__head">
                                 <tr class="govuk-table__row">
                                     <th scope="col" class="govuk-table__header"
-                                        th:aria-sort="${sort == 'firstName' ? direction : 'none'}" style="width: 20%; min-width: 120px;">
+                                        th:aria-sort="${sort == 'firstName' ? direction : 'none'}"
+                                        style="width: 20%; min-width: 120px;">
                                         <button type="button" data-index="0"
                                             th:onclick="'window.location.href=\'' + @{/admin/users(size=${requestedPageSize ?: 10}, page=${page ?: 1}, search=${search}, sort='firstName', direction=${sort == 'firstName' and direction == 'asc' ? 'desc' : 'asc'}, usertype=${usertype}, showFirmAdmins=${showFirmAdmins})} + '\''">
                                             Name
-                                            <img th:if="${sort == 'firstName' and direction == 'asc'}" 
-                                                 th:src="@{/assets/images/sort-asc.svg}" 
-                                                 width="22" height="22" alt="">
-                                            <img th:if="${sort == 'firstName' and direction == 'desc'}" 
-                                                 th:src="@{/assets/images/sort-desc.svg}" 
-                                                 width="22" height="22" alt="">
-                                            <img th:if="${sort != 'firstName'}" 
-                                                 th:src="@{/assets/images/sort-none.svg}" 
-                                                 width="22" height="22" alt="">
+                                            <img th:if="${sort == 'firstName' and direction == 'asc'}"
+                                                th:src="@{/assets/images/sort-asc.svg}" width="22" height="22" alt="">
+                                            <img th:if="${sort == 'firstName' and direction == 'desc'}"
+                                                th:src="@{/assets/images/sort-desc.svg}" width="22" height="22" alt="">
+                                            <img th:if="${sort != 'firstName'}" th:src="@{/assets/images/sort-none.svg}"
+                                                width="22" height="22" alt="">
                                         </button>
                                     </th>
                                     <th scope="col" class="govuk-table__header"
-                                        th:aria-sort="${sort == 'firmName' ? direction : 'none'}" style="width: 20%; min-width: 120px;">
+                                        th:aria-sort="${sort == 'firmName' ? direction : 'none'}"
+                                        style="width: 20%; min-width: 120px;">
                                         <button type="button" data-index="1"
                                             th:onclick="'window.location.href=\'' + @{/admin/users(size=${requestedPageSize ?: 10}, page=${page ?: 1}, search=${search}, sort='firmName', direction=${sort == 'firmName' and direction == 'asc' ? 'desc' : 'asc'}, usertype=${usertype}, showFirmAdmins=${showFirmAdmins})} + '\''">
                                             Firm
-                                            <img th:if="${sort == 'firmName' and direction == 'asc'}" 
-                                                 th:src="@{/assets/images/sort-asc.svg}" 
-                                                 width="22" height="22" alt="">
-                                            <img th:if="${sort == 'firmName' and direction == 'desc'}" 
-                                                 th:src="@{/assets/images/sort-desc.svg}" 
-                                                 width="22" height="22" alt="">
-                                            <img th:if="${sort != 'firmName'}" 
-                                                 th:src="@{/assets/images/sort-none.svg}" 
-                                                 width="22" height="22" alt="">
+                                            <img th:if="${sort == 'firmName' and direction == 'asc'}"
+                                                th:src="@{/assets/images/sort-asc.svg}" width="22" height="22" alt="">
+                                            <img th:if="${sort == 'firmName' and direction == 'desc'}"
+                                                th:src="@{/assets/images/sort-desc.svg}" width="22" height="22" alt="">
+                                            <img th:if="${sort != 'firmName'}" th:src="@{/assets/images/sort-none.svg}"
+                                                width="22" height="22" alt="">
                                         </button>
                                     </th>
                                     <th scope="col" class="govuk-table__header"
-                                        th:aria-sort="${sort == 'email' ? direction : 'none'}" style="width: 35%; min-width: 200px;">
+                                        th:aria-sort="${sort == 'email' ? direction : 'none'}"
+                                        style="width: 35%; min-width: 200px;">
                                         <button type="button" data-index="2"
                                             th:onclick="'window.location.href=\'' + @{/admin/users(size=${requestedPageSize ?: 10}, page=${page ?: 1}, search=${search}, sort='email', direction=${sort == 'email' and direction == 'asc' ? 'desc' : 'asc'}, usertype=${usertype}, showFirmAdmins=${showFirmAdmins})} + '\''">
                                             Email
-                                            <img th:if="${sort == 'email' and direction == 'asc'}" 
-                                                 th:src="@{/assets/images/sort-asc.svg}" 
-                                                 width="22" height="22" alt="">
-                                            <img th:if="${sort == 'email' and direction == 'desc'}" 
-                                                 th:src="@{/assets/images/sort-desc.svg}" 
-                                                 width="22" height="22" alt="">
-                                            <img th:if="${sort != 'email'}" 
-                                                 th:src="@{/assets/images/sort-none.svg}" 
-                                                 width="22" height="22" alt="">
+                                            <img th:if="${sort == 'email' and direction == 'asc'}"
+                                                th:src="@{/assets/images/sort-asc.svg}" width="22" height="22" alt="">
+                                            <img th:if="${sort == 'email' and direction == 'desc'}"
+                                                th:src="@{/assets/images/sort-desc.svg}" width="22" height="22" alt="">
+                                            <img th:if="${sort != 'email'}" th:src="@{/assets/images/sort-none.svg}"
+                                                width="22" height="22" alt="">
                                         </button>
                                     </th>
                                     <th scope="col" class="govuk-table__header"
-                                        th:aria-sort="${sort == 'userType' ? direction : 'none'}" style="width: 15%; min-width: 110px;">
+                                        th:aria-sort="${sort == 'userType' ? direction : 'none'}"
+                                        style="width: 15%; min-width: 110px;">
                                         <button type="button" data-index="3"
                                             th:onclick="'window.location.href=\'' + @{/admin/users(size=${requestedPageSize ?: 10}, page=${page ?: 1}, search=${search}, sort='userType', direction=${sort == 'userType' and direction == 'asc' ? 'desc' : 'asc'}, usertype=${usertype}, showFirmAdmins=${showFirmAdmins})} + '\''">
                                             User Type
-                                            <img th:if="${sort == 'userType' and direction == 'asc'}" 
-                                                 th:src="@{/assets/images/sort-asc.svg}" 
-                                                 width="22" height="22" alt="">
-                                            <img th:if="${sort == 'userType' and direction == 'desc'}" 
-                                                 th:src="@{/assets/images/sort-desc.svg}" 
-                                                 width="22" height="22" alt="">
-                                            <img th:if="${sort != 'userType'}" 
-                                                 th:src="@{/assets/images/sort-none.svg}" 
-                                                 width="22" height="22" alt="">
+                                            <img th:if="${sort == 'userType' and direction == 'asc'}"
+                                                th:src="@{/assets/images/sort-asc.svg}" width="22" height="22" alt="">
+                                            <img th:if="${sort == 'userType' and direction == 'desc'}"
+                                                th:src="@{/assets/images/sort-desc.svg}" width="22" height="22" alt="">
+                                            <img th:if="${sort != 'userType'}" th:src="@{/assets/images/sort-none.svg}"
+                                                width="22" height="22" alt="">
                                         </button>
                                     </th>
                                     <th scope="col" class="govuk-table__header"
-                                        th:aria-sort="${sort == 'userStatus' ? direction : 'none'}" style="width: 10%; min-width: 90px;">
+                                        th:aria-sort="${sort == 'userStatus' ? direction : 'none'}"
+                                        style="width: 10%; min-width: 90px;">
                                         <button type="button" data-index="4"
                                             th:onclick="'window.location.href=\'' + @{/admin/users(size=${requestedPageSize ?: 10}, page=${page ?: 1}, search=${search}, sort='userStatus', direction=${sort == 'userStatus' and direction == 'asc' ? 'desc' : 'asc'}, usertype=${usertype}, showFirmAdmins=${showFirmAdmins})} + '\''">
                                             Status
-                                            <img th:if="${sort == 'userStatus' and direction == 'asc'}" 
-                                                 th:src="@{/assets/images/sort-asc.svg}" 
-                                                 width="22" height="22" alt="">
-                                            <img th:if="${sort == 'userStatus' and direction == 'desc'}" 
-                                                 th:src="@{/assets/images/sort-desc.svg}" 
-                                                 width="22" height="22" alt="">
-                                            <img th:if="${sort != 'userStatus'}" 
-                                                 th:src="@{/assets/images/sort-none.svg}" 
-                                                 width="22" height="22" alt="">
+                                            <img th:if="${sort == 'userStatus' and direction == 'asc'}"
+                                                th:src="@{/assets/images/sort-asc.svg}" width="22" height="22" alt="">
+                                            <img th:if="${sort == 'userStatus' and direction == 'desc'}"
+                                                th:src="@{/assets/images/sort-desc.svg}" width="22" height="22" alt="">
+                                            <img th:if="${sort != 'userStatus'}"
+                                                th:src="@{/assets/images/sort-none.svg}" width="22" height="22" alt="">
                                         </button>
                                     </th>
                                 </tr>
@@ -180,15 +176,19 @@
 
                             <tbody class="govuk-table__body">
                                 <tr class="govuk-table__row" th:each="user : ${users}">
-                                    <td class="govuk-table__cell" style="word-wrap: break-word; overflow-wrap: break-word;">
+                                    <td class="govuk-table__cell"
+                                        style="word-wrap: break-word; overflow-wrap: break-word;">
                                         <a class="govuk-link" th:href="@{/admin/users/manage/{id}(id=${user.id})}"
                                             th:text="${user.fullName}"></a>
                                     </td>
-                                    <td class="govuk-table__cell" style="word-wrap: break-word; overflow-wrap: break-word;"
+                                    <td class="govuk-table__cell"
+                                        style="word-wrap: break-word; overflow-wrap: break-word;"
                                         th:text="${user.firm != null ? user.firm.name : ''}"></td>
-                                    <td class="govuk-table__cell" style="word-wrap: break-word; overflow-wrap: break-word;"
+                                    <td class="govuk-table__cell"
+                                        style="word-wrap: break-word; overflow-wrap: break-word;"
                                         th:text="${user.entraUser.email}"></td>
-                                    <td class="govuk-table__cell" style="word-wrap: break-word; overflow-wrap: break-word;">
+                                    <td class="govuk-table__cell"
+                                        style="word-wrap: break-word; overflow-wrap: break-word;">
                                         <span th:switch="${#strings.trim(user.userType)}">
                                             <span th:case="'INTERNAL'">Internal</span>
                                             <span th:case="'EXTERNAL_SINGLE_FIRM_ADMIN'">Firm Admin</span>
@@ -210,11 +210,15 @@
                 </form>
                 <nav class="govuk-pagination" aria-label="Pagination">
                     <div class="govuk-pagination__prev" th:if="${page > 1}">
-                        <a class="govuk-link govuk-pagination__link" 
-                           th:href="@{/admin/users(size=${requestedPageSize}, page=${page - 1}, search=${search}, sort=${sort}, direction=${direction}, usertype=${usertype}, showFirmAdmins=${showFirmAdmins})}" 
-                           rel="prev">
-                            <svg class="govuk-pagination__icon govuk-pagination__icon--prev" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
-                                <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
+                        <a class="govuk-link govuk-pagination__link"
+                            th:href="@{/admin/users(size=${requestedPageSize}, page=${page - 1}, search=${search}, sort=${sort}, direction=${direction}, usertype=${usertype}, showFirmAdmins=${showFirmAdmins})}"
+                            rel="prev">
+                            <svg class="govuk-pagination__icon govuk-pagination__icon--prev"
+                                xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true"
+                                focusable="false" viewBox="0 0 15 13">
+                                <path
+                                    d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z">
+                                </path>
                             </svg>
                             <span class="govuk-pagination__link-title">
                                 Previous<span class="govuk-visually-hidden"> page</span>
@@ -224,14 +228,14 @@
 
                     <ul class="govuk-pagination__list">
                         <!-- First page -->
-                        <li class="govuk-pagination__item" th:if="${totalPages > 0}" 
+                        <li class="govuk-pagination__item" th:if="${totalPages > 0}"
                             th:classappend="${page == 1 ? 'govuk-pagination__item--current' : ''}">
                             <a class="govuk-link govuk-pagination__link" th:if="${page != 1}"
-                               th:href="@{/admin/users(size=${requestedPageSize}, page=1, search=${search}, sort=${search}, direction=${direction}, usertype=${usertype}, showFirmAdmins=${showFirmAdmins})}"
-                               th:aria-label="'Page 1'">1</a>
+                                th:href="@{/admin/users(size=${requestedPageSize}, page=1, search=${search}, sort=${sort}, direction=${direction}, usertype=${usertype}, showFirmAdmins=${showFirmAdmins})}"
+                                th:aria-label="'Page 1'">1</a>
                             <a class="govuk-link govuk-pagination__link" th:if="${page == 1}"
-                               th:href="@{/admin/users(size=${requestedPageSize}, page=1, search=${search}, sort=${sort}, direction=${direction}, usertype=${usertype}, showFirmAdmins=${showFirmAdmins})}"
-                               th:aria-label="'Page 1'" aria-current="page">1</a>
+                                th:href="@{/admin/users(size=${requestedPageSize}, page=1, search=${search}, sort=${sort}, direction=${direction}, usertype=${usertype}, showFirmAdmins=${showFirmAdmins})}"
+                                th:aria-label="'Page 1'" aria-current="page">1</a>
                         </li>
 
                         <!-- Left ellipses if needed -->
@@ -240,44 +244,50 @@
                         </li>
 
                         <!-- Pages around current page -->
-                        <th:block th:each="i : ${#numbers.sequence(T(java.lang.Math).max(2, page - 2), T(java.lang.Math).min(totalPages - 1, page + 2))}">
-                            <li class="govuk-pagination__item" th:if="${i > 1 and i < totalPages}" 
+                        <th:block
+                            th:each="i : ${#numbers.sequence(T(java.lang.Math).max(2, page - 2), T(java.lang.Math).min(totalPages - 1, page + 2))}">
+                            <li class="govuk-pagination__item" th:if="${i > 1 and i < totalPages}"
                                 th:classappend="${i == page ? 'govuk-pagination__item--current' : ''}">
                                 <a class="govuk-link govuk-pagination__link" th:if="${i != page}"
-                                   th:href="@{/admin/users(size=${requestedPageSize}, page=${i}, search=${search}, sort=${sort}, direction=${direction}, usertype=${usertype}, showFirmAdmins=${showFirmAdmins})}"
-                                   th:aria-label="'Page ' + ${i}" th:text="${i}"></a>
+                                    th:href="@{/admin/users(size=${requestedPageSize}, page=${i}, search=${search}, sort=${sort}, direction=${direction}, usertype=${usertype}, showFirmAdmins=${showFirmAdmins})}"
+                                    th:aria-label="'Page ' + ${i}" th:text="${i}"></a>
                                 <a class="govuk-link govuk-pagination__link" th:if="${i == page}"
-                                   th:href="@{/admin/users(size=${requestedPageSize}, page=${i}, search=${search}, sort=${sort}, direction=${direction}, usertype=${usertype}, showFirmAdmins=${showFirmAdmins})}"
-                                   th:aria-label="'Page ' + ${i}" aria-current="page" th:text="${i}"></a>
+                                    th:href="@{/admin/users(size=${requestedPageSize}, page=${i}, search=${search}, sort=${sort}, direction=${direction}, usertype=${usertype}, showFirmAdmins=${showFirmAdmins})}"
+                                    th:aria-label="'Page ' + ${i}" aria-current="page" th:text="${i}"></a>
                             </li>
                         </th:block>
 
                         <!-- Right ellipses if needed -->
-                        <li class="govuk-pagination__item govuk-pagination__item--ellipses" th:if="${page < totalPages - 3}">
+                        <li class="govuk-pagination__item govuk-pagination__item--ellipses"
+                            th:if="${page < totalPages - 3}">
                             &ctdot;
                         </li>
 
                         <!-- Last page -->
-                        <li class="govuk-pagination__item" th:if="${totalPages > 1}" 
+                        <li class="govuk-pagination__item" th:if="${totalPages > 1}"
                             th:classappend="${page == totalPages ? 'govuk-pagination__item--current' : ''}">
                             <a class="govuk-link govuk-pagination__link" th:if="${page != totalPages}"
-                               th:href="@{/admin/users(size=${requestedPageSize}, page=${totalPages}, search=${search}, sort=${sort}, direction=${direction}, usertype=${usertype}, showFirmAdmins=${showFirmAdmins})}"
-                               th:aria-label="'Page ' + ${totalPages}" th:text="${totalPages}"></a>
+                                th:href="@{/admin/users(size=${requestedPageSize}, page=${totalPages}, search=${search}, sort=${sort}, direction=${direction}, usertype=${usertype}, showFirmAdmins=${showFirmAdmins})}"
+                                th:aria-label="'Page ' + ${totalPages}" th:text="${totalPages}"></a>
                             <a class="govuk-link govuk-pagination__link" th:if="${page == totalPages}"
-                               th:href="@{/admin/users(size=${requestedPageSize}, page=${totalPages}, search=${search}, sort=${sort}, direction=${direction}, usertype=${usertype}, showFirmAdmins=${showFirmAdmins})}"
-                               th:aria-label="'Page ' + ${totalPages}" aria-current="page" th:text="${totalPages}"></a>
+                                th:href="@{/admin/users(size=${requestedPageSize}, page=${totalPages}, search=${search}, sort=${sort}, direction=${direction}, usertype=${usertype}, showFirmAdmins=${showFirmAdmins})}"
+                                th:aria-label="'Page ' + ${totalPages}" aria-current="page" th:text="${totalPages}"></a>
                         </li>
                     </ul>
 
                     <div class="govuk-pagination__next" th:if="${page < totalPages}">
                         <a class="govuk-link govuk-pagination__link"
-                           th:href="@{/admin/users(size=${requestedPageSize}, page=${page + 1}, search=${search}, sort=${sort}, direction=${direction}, usertype=${usertype}, showFirmAdmins=${showFirmAdmins})}"
-                           rel="next">
+                            th:href="@{/admin/users(size=${requestedPageSize}, page=${page + 1}, search=${search}, sort=${sort}, direction=${direction}, usertype=${usertype}, showFirmAdmins=${showFirmAdmins})}"
+                            rel="next">
                             <span class="govuk-pagination__link-title">
                                 Next<span class="govuk-visually-hidden"> page</span>
                             </span>
-                            <svg class="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
-                                <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
+                            <svg class="govuk-pagination__icon govuk-pagination__icon--next"
+                                xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true"
+                                focusable="false" viewBox="0 0 15 13">
+                                <path
+                                    d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z">
+                                </path>
                             </svg>
                         </a>
                     </div>
@@ -285,13 +295,18 @@
                 <style>
                     /* Prevent visited link styling on pagination */
                     .govuk-pagination__link:visited {
-                        color: #1d70b8; /* Same as unvisited govuk-link color */
+                        color: #1d70b8;
+                        /* Same as unvisited govuk-link color */
                     }
+
                     .govuk-pagination__link:visited:hover {
-                        color: #003078; /* Same as unvisited govuk-link hover color */
+                        color: #003078;
+                        /* Same as unvisited govuk-link hover color */
                     }
+
                     .govuk-pagination__link:visited:focus {
-                        color: #0b0c0c; /* Same as unvisited govuk-link focus color */
+                        color: #0b0c0c;
+                        /* Same as unvisited govuk-link focus color */
                     }
                 </style>
                 <p class="moj-pagination__results">Showing <b

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/LoginControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/LoginControllerTest.java
@@ -64,10 +64,10 @@ class LoginControllerTest {
         Model model = new ConcurrentModel();
 
         // Act
-        String viewIndex = controller.login(null, model);
+        String viewIndex = controller.index();
 
         // Assert
-        assertThat(viewIndex).isEqualTo("index");
+        assertThat(viewIndex).isEqualTo("redirect:/home");
         assertThat(model.getAttribute("successMessage")).isNull();
     }
 
@@ -78,11 +78,12 @@ class LoginControllerTest {
         Model model = new ConcurrentModel();
 
         // Act
-        String viewIndex = controller.login("logout", model);
+        String viewIndex = controller.index();
 
         // Assert
-        assertThat(viewIndex).isEqualTo("index");
-        assertThat(model.getAttribute("successMessage")).isEqualTo("You have been securely logged out");
+        assertThat(viewIndex).isEqualTo("redirect:/home");
+        // Since we're redirecting to home, no model attributes are set in the index method
+        assertThat(model.getAttribute("successMessage")).isNull();
     }
 
     @Test
@@ -96,7 +97,8 @@ class LoginControllerTest {
 
         // Assert
         assertThat(result.getUrl()).isEqualTo("/");
-        assertThat(attrs.getFlashAttributes().get("errorMessage")).isEqualTo("An incorrect Username or Password was specified");
+        assertThat(attrs.getFlashAttributes().get("errorMessage"))
+                .isEqualTo("An incorrect Username or Password was specified");
     }
 
     @Test
@@ -110,7 +112,8 @@ class LoginControllerTest {
 
         // Assert
         assertThat(result.getUrl()).isEqualTo("/");
-        assertThat(attrs.getFlashAttributes().get("errorMessage")).isEqualTo("An incorrect Username or Password was specified");
+        assertThat(attrs.getFlashAttributes().get("errorMessage"))
+                .isEqualTo("An incorrect Username or Password was specified");
     }
 
     @Test
@@ -154,7 +157,8 @@ class LoginControllerTest {
         UserSessionData mockSessionData = UserSessionData.builder()
                 .name("Test User")
                 .build();
-        when(loginService.processUserSession(any(Authentication.class), any(OAuth2AuthorizedClient.class), any(HttpSession.class)))
+        when(loginService.processUserSession(any(Authentication.class), any(OAuth2AuthorizedClient.class),
+                any(HttpSession.class)))
                 .thenReturn(mockSessionData);
 
         // Act
@@ -177,7 +181,8 @@ class LoginControllerTest {
                 .name("Test User")
                 .user(user)
                 .build();
-        when(loginService.processUserSession(any(Authentication.class), any(OAuth2AuthorizedClient.class), any(HttpSession.class)))
+        when(loginService.processUserSession(any(Authentication.class), any(OAuth2AuthorizedClient.class),
+                any(HttpSession.class)))
                 .thenReturn(mockSessionData);
         when(userService.getUserPermissionsByUserId(user.getId())).thenReturn(Set.of(Permission.VIEW_EXTERNAL_USER));
 
@@ -202,7 +207,8 @@ class LoginControllerTest {
                 .name("Test User")
                 .user(user)
                 .build();
-        when(loginService.processUserSession(any(Authentication.class), any(OAuth2AuthorizedClient.class), any(HttpSession.class)))
+        when(loginService.processUserSession(any(Authentication.class), any(OAuth2AuthorizedClient.class),
+                any(HttpSession.class)))
                 .thenReturn(mockSessionData);
         when(userService.getUserPermissionsByUserId(user.getId())).thenReturn(Set.of());
 
@@ -225,7 +231,8 @@ class LoginControllerTest {
         UserSessionData mockSessionData = UserSessionData.builder()
                 .name("Test User")
                 .build();
-        when(loginService.processUserSession(any(Authentication.class), any(OAuth2AuthorizedClient.class), any(HttpSession.class)))
+        when(loginService.processUserSession(any(Authentication.class), any(OAuth2AuthorizedClient.class),
+                any(HttpSession.class)))
                 .thenReturn(mockSessionData);
 
         // Act
@@ -243,7 +250,8 @@ class LoginControllerTest {
 
         // Arrange
         Model model = new ConcurrentModel();
-        when(loginService.processUserSession(any(Authentication.class), any(OAuth2AuthorizedClient.class), any(HttpSession.class)))
+        when(loginService.processUserSession(any(Authentication.class), any(OAuth2AuthorizedClient.class),
+                any(HttpSession.class)))
                 .thenReturn(null);
 
         // Act
@@ -260,7 +268,8 @@ class LoginControllerTest {
 
         // Arrange
         Model model = new ConcurrentModel();
-        when(loginService.processUserSession(any(Authentication.class), any(OAuth2AuthorizedClient.class), any(HttpSession.class)))
+        when(loginService.processUserSession(any(Authentication.class), any(OAuth2AuthorizedClient.class),
+                any(HttpSession.class)))
                 .thenThrow(new RuntimeException("Error processing session"));
 
         // Act
@@ -284,7 +293,8 @@ class LoginControllerTest {
     @Test
     void switchFirm_get_active() {
         UUID firmId = UUID.randomUUID();
-        UserProfile up = UserProfile.builder().activeProfile(true).userProfileStatus(UserProfileStatus.COMPLETE).firm(Firm.builder().id(firmId).name("name").build()).build();
+        UserProfile up = UserProfile.builder().activeProfile(true).userProfileStatus(UserProfileStatus.COMPLETE)
+                .firm(Firm.builder().id(firmId).name("name").build()).build();
         when(loginService.getCurrentEntraUser(any())).thenReturn(EntraUser.builder().userProfiles(Set.of(up)).build());
         when(firmService.getUserAllFirms(any()))
                 .thenReturn(List.of(FirmDto.builder().id(firmId).name("name").build()));
@@ -299,7 +309,8 @@ class LoginControllerTest {
     @Test
     void switchFirm_get_no_active() {
         UUID firmId = UUID.randomUUID();
-        UserProfile up = UserProfile.builder().activeProfile(false).userProfileStatus(UserProfileStatus.COMPLETE).firm(Firm.builder().id(firmId).name("name").build()).build();
+        UserProfile up = UserProfile.builder().activeProfile(false).userProfileStatus(UserProfileStatus.COMPLETE)
+                .firm(Firm.builder().id(firmId).name("name").build()).build();
         when(loginService.getCurrentEntraUser(any())).thenReturn(EntraUser.builder().userProfiles(Set.of(up)).build());
         when(firmService.getUserAllFirms(any()))
                 .thenReturn(List.of(FirmDto.builder().id(firmId).name("name").build()));
@@ -314,9 +325,9 @@ class LoginControllerTest {
     @Test
     void switchFirm_post() throws IOException {
         String firmId = UUID.randomUUID().toString();
-        
+
         RedirectView view = controller.switchFirm(firmId, authentication, session, authClient);
-        
+
         verify(loginService).getCurrentEntraUser(any());
         verify(userService).setDefaultActiveProfile(any(), any());
         assertThat(view.getUrl()).isEqualTo("/logout?azure_logout=true");


### PR DESCRIPTION
- Updated breadcrumb navigation across various templates to improve user experience.
- Changed pageCategory from 'register' to 'grant-access' in grant access related templates.
- Simplified breadcrumb structure by removing unnecessary list elements.
- Adjusted header links to point to the correct home page.
- Enhanced error and not-authorised pages with consistent navigation.
- Modified home page link to remove target="_blank" for better usability.
- Updated manage user template to reflect correct page title and navigation.
- Improved pagination structure and styling in users template for better clarity.
- Refactored LoginControllerTest to ensure proper redirection and model attribute handling.

**Navigation and Breadcrumb Improvements:**

* Replaced breadcrumb lists with consistent "Back" links across multiple templates (e.g., `edit-user-apps.html`, `edit-user-details.html`, `edit-user-offices.html`, `edit-user-roles.html`, `grant-access-check-answers.html`, `grant-access-user-apps.html`, `grant-access-user-offices.html`, `grant-access-user-roles.html`, `manage-user.html`, `error.html`, `not-authorised.html`) for a simpler and more accessible navigation experience. [[1]](diffhunk://#diff-48c519552d23e02bc74c546f46e34c738810dc95b35851929928f96dbf1a1b29L5-R15) [[2]](diffhunk://#diff-74f5555adea7f86842466a2789f5e0c3c2e9588d82de78b5110c9252d9839277L5-R15) [[3]](diffhunk://#diff-b84ef58fc3d5b9858ebd6d9b887bcc2ec2c19fef7a6fa138b4474ba0596d0f9aL5-R15) [[4]](diffhunk://#diff-3ffbb9b888cb915b27b6a66567778680fa1f2b9829913d8b19a5c2de08ac3f32L5-L29) [[5]](diffhunk://#diff-e754d3f165de717dfc3bbb8d91223484668b5722d1a0050d76033eac52755009L14-L20) [[6]](diffhunk://#diff-8760a4fea45f6365de3c0e9c9cfdbdf16512cf1f8a9e6bd6bfbbefa9f070b050L14-R19) [[7]](diffhunk://#diff-df6e154a4edcb883c4a38700219709ccb3c12f2c91b1c829f3b3768fcaad2175L14-L20) [[8]](diffhunk://#diff-49e6e20271b574307572d8c7c84188ead2e7222e89125c8a44505d1085e0cc11L14-L20) [[9]](diffhunk://#diff-e687d7fb36c1e4429780d9d4c1569e1332afd69837e881337c296ff589df4c15L5-R15) [[10]](diffhunk://#diff-de0c0f072682a1ae3362b3834caba000adffa55425e0233afd9b8b2e31b4844aR14-R17) [[11]](diffhunk://#diff-8645ba00a74632c80b7206f16513a12c889fd7061c603f489264a825ef8b6c9fR14-R17)

**Page Metadata and Category Updates:**

* Updated `pageCategory` and `<title>` values in several templates to accurately reflect the current page context, such as using `'edit-user'` or `'grant-access'` where appropriate, and clarified page titles for edit and grant access flows. [[1]](diffhunk://#diff-48c519552d23e02bc74c546f46e34c738810dc95b35851929928f96dbf1a1b29L5-R15) [[2]](diffhunk://#diff-74f5555adea7f86842466a2789f5e0c3c2e9588d82de78b5110c9252d9839277L5-R15) [[3]](diffhunk://#diff-b84ef58fc3d5b9858ebd6d9b887bcc2ec2c19fef7a6fa138b4474ba0596d0f9aL5-R15) [[4]](diffhunk://#diff-3ffbb9b888cb915b27b6a66567778680fa1f2b9829913d8b19a5c2de08ac3f32L5-L29) [[5]](diffhunk://#diff-e754d3f165de717dfc3bbb8d91223484668b5722d1a0050d76033eac52755009L5-R5) [[6]](diffhunk://#diff-0b1be08d24e76524151a5aa3e038e14146b1704989b87a6ae8cd67fbf3cb1eedL5-R5) [[7]](diffhunk://#diff-8760a4fea45f6365de3c0e9c9cfdbdf16512cf1f8a9e6bd6bfbbefa9f070b050L5-R5) [[8]](diffhunk://#diff-df6e154a4edcb883c4a38700219709ccb3c12f2c91b1c829f3b3768fcaad2175L5-R5) [[9]](diffhunk://#diff-49e6e20271b574307572d8c7c84188ead2e7222e89125c8a44505d1085e0cc11L5-R5) [[10]](diffhunk://#diff-e687d7fb36c1e4429780d9d4c1569e1332afd69837e881337c296ff589df4c15L5-R15)

**User Flow and Redirection:**

* Changed the root login route in `LoginController.java` to redirect users directly to `/home` instead of rendering the login page, streamlining the login flow.

**Content and Layout Consistency:**

* Improved the display of user details, office addresses, and permissions by clarifying conditional messages and formatting in summary sections (e.g., handling empty office lists, showing "Access to All Offices" for external users). [[1]](diffhunk://#diff-e754d3f165de717dfc3bbb8d91223484668b5722d1a0050d76033eac52755009L38-R40) [[2]](diffhunk://#diff-e754d3f165de717dfc3bbb8d91223484668b5722d1a0050d76033eac52755009L50-R50) [[3]](diffhunk://#diff-e754d3f165de717dfc3bbb8d91223484668b5722d1a0050d76033eac52755009L79-R84) [[4]](diffhunk://#diff-e687d7fb36c1e4429780d9d4c1569e1332afd69837e881337c296ff589df4c15L145-R152)
* Updated the "Manage your users" link on the home page to open in the same tab, removing the "opens in a new tab" note for consistency.

These changes collectively enhance the usability, clarity, and consistency of the user management and access control features.