### PR TITLE
Excluded commons-logging from classpath to avoid logger conflicts.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,9 @@ sourceSets {
 configurations {
     playwrightImplementation.extendsFrom testImplementation
     playwrightRuntimeOnly.extendsFrom testRuntimeOnly
+    configureEach {
+        exclude group: 'commons-logging', module: 'commons-logging'
+    }
 }
 
 dependencies {


### PR DESCRIPTION
The following log message was seen when testing the prod JWT decoder:

`Standard Commons Logging discovery in action with spring-jcl: please remove commons-logging.jar from classpath in order to avoid potential conflicts`

We've been seeing logs being disabled in our test environments, exploring the removal of this jar from the classpath as a potential fix.