### PR TITLE
Add user role checks and custom messages for users without roles

### DIFF
--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/LoginController.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/LoginController.java
@@ -101,6 +101,16 @@ public class LoginController {
                             || permissions.contains(Permission.VIEW_INTERNAL_USER);
                 }
                 model.addAttribute("isAdminUser", isAdmin);
+                
+                // Check if user has no roles assigned and determine user type for custom message
+                if (userSessionData.getUser() != null 
+                    && (userSessionData.getLaaApplications() == null || userSessionData.getLaaApplications().isEmpty())) {
+                    boolean isInternal = userService.isInternal(userSessionData.getUser().getId());
+                    model.addAttribute("userHasNoRoles", true);
+                    model.addAttribute("isInternalUser", isInternal);
+                } else {
+                    model.addAttribute("userHasNoRoles", false);
+                }
             } else {
                 logger.info("No access token found");
             }

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -32,16 +32,27 @@
 
                 <h2 class="govuk-heading-l">Legal aid services</h2>
 
-                <div th:each="app : ${laaApplications}">
-                    <div class="govuk-grid-row">
-                        <div class="govuk-grid-column-full">
-                            <div class="moj-ticket-panel__content moj-ticket-panel__content--blue">
-                                <h3 class="govuk-heading-m">
-                                    <a th:href="${app.getUrl()}" class="govuk-link govuk-link--no-visited-state"
-                                        rel="noreferrer noopener" target="_blank"
-                                        th:text="${app.getTitle() + ' (opens in a new tab)'}"></a>
-                                </h3>
-                                <p class="govuk-body" th:text="${app.getDescription()}"></p>
+                <div th:if="${userHasNoRoles}" class="govuk-grid-row">
+                    <div class="govuk-grid-column-full">
+                        <div class="govuk-inset-text">
+                            <p th:if="${isInternalUser}">You cannot currently access any services. Please contact the MOJ Service Desk to request access.</p>
+                            <p th:unless="${isInternalUser}">You cannot currently access any services. Please contact your Firm Admin to request access.</p>
+                        </div>
+                    </div>
+                </div>
+
+                <div th:unless="${userHasNoRoles}">
+                    <div th:each="app : ${laaApplications}">
+                        <div class="govuk-grid-row">
+                            <div class="govuk-grid-column-full">
+                                <div class="moj-ticket-panel__content moj-ticket-panel__content--blue">
+                                    <h3 class="govuk-heading-m">
+                                        <a th:href="${app.getUrl()}" class="govuk-link govuk-link--no-visited-state"
+                                            rel="noreferrer noopener" target="_blank"
+                                            th:text="${app.getTitle() + ' (opens in a new tab)'}"></a>
+                                    </h3>
+                                    <p class="govuk-body" th:text="${app.getDescription()}"></p>
+                                </div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Add user role checks and custom messages for users without roles

**EXTERNAL**
<img width="1726" height="960" alt="Screenshot 2025-08-29 at 11 20 49" src="https://github.com/user-attachments/assets/cec06d6f-9d87-46a3-bbc6-a74e4b37e4c7" />

**INTERNAL**
<img width="864" height="453" alt="Screenshot 2025-08-29 at 11 24 54" src="https://github.com/user-attachments/assets/aa4f1d6d-f3e3-4fb7-a588-08a48c2b8e04" />


User experience improvements:

* The `home` method in `LoginController.java` now checks if a user has no roles assigned and determines if the user is internal or external, setting new model attributes `userHasNoRoles` and `isInternalUser` accordingly. This enables conditional display of custom messages.
* The `home.html` template displays a custom inset message when a user has no roles, instructing internal users to contact the MOJ Service Desk and external users to contact their Firm Admin. If the user has roles, the usual application list is shown. [[1]](diffhunk://#diff-52f0dda0be57fa81112f251bcbc39bf2da14185ed79da901061cc07d17742b6aR35-R44) [[2]](diffhunk://#diff-52f0dda0be57fa81112f251bcbc39bf2da14185ed79da901061cc07d17742b6aR61)

Testing enhancements:

* New tests in `LoginControllerTest.java` verify that the correct flags and messages are set for users with no roles (both internal and external), as well as for users with roles.