### PR TITLE
STB-2478 - Update page titles and categories from 'Grant Access' to 'Manage Access'

### DIFF
--- a/src/main/resources/templates/grant-access-check-answers.html
+++ b/src/main/resources/templates/grant-access-check-answers.html
@@ -2,11 +2,11 @@
 <html lang="en" th:replace="~{layout :: layout(
       title=~{::title},
       mainContent=~{::#main-content},
-      pageCategory=${'grant-access'},
+      pageCategory=${'manage-access'},
       breadcrumbs=~{::#breadcrumbs})}" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.w3.org/1999/xhtml">
 
 <head>
-    <title>Grant Access - Check Your Answers</title>
+    <title>Manage Access - Check Your Answers</title>
 </head>
 
 <body>

--- a/src/main/resources/templates/grant-access-user-apps.html
+++ b/src/main/resources/templates/grant-access-user-apps.html
@@ -2,11 +2,11 @@
 <html lang="en" th:replace="~{layout :: layout(
       title=~{::title},
       mainContent=~{::#main-content},
-      pageCategory=${'grant-access'},
+      pageCategory=${'manage-access'},
       breadcrumbs=~{::#breadcrumbs})}" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.w3.org/1999/xhtml">
 
 <head>
-    <title>Grant Access - Services</title>
+    <title>Manage Access - Services</title>
 </head>
 
 <body>

--- a/src/main/resources/templates/grant-access-user-roles.html
+++ b/src/main/resources/templates/grant-access-user-roles.html
@@ -2,11 +2,11 @@
 <html lang="en" th:replace="~{layout :: layout(
       title=~{::title},
       mainContent=~{::#main-content},
-      pageCategory=${'grant-access'},
+      pageCategory=${'manage-access'},
       breadcrumbs=~{::#breadcrumbs})}" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.w3.org/1999/xhtml">
 
 <head>
-    <title>Grant Access - Roles</title>
+    <title>Manage Access - Roles</title>
 </head>
 
 <body>

--- a/src/main/resources/templates/manage-user.html
+++ b/src/main/resources/templates/manage-user.html
@@ -40,7 +40,7 @@
                             <div class="moj-button-group moj-button-group--inline">
                                 <button type="submit" class="govuk-button govuk-button--primary"
                                     data-module="govuk-button">
-                                    Grant access
+                                    Manage access
                                 </button>
                             </div>
                         </div>


### PR DESCRIPTION
Update page titles and categories from 'Grant Access' to 'Manage Access'

<img width="1723" height="905" alt="Screenshot 2025-08-29 at 11 53 23" src="https://github.com/user-attachments/assets/5e484f55-1f7b-4dc9-be01-625bfbbbbd0a" />

**UI terminology updates:**

* Updated the page title and `pageCategory` variable from "Grant Access" to "Manage Access" in the following templates: `grant-access-check-answers.html`, `grant-access-user-apps.html`, and `grant-access-user-roles.html`. [[1]](diffhunk://#diff-e754d3f165de717dfc3bbb8d91223484668b5722d1a0050d76033eac52755009L5-R9) [[2]](diffhunk://#diff-8760a4fea45f6365de3c0e9c9cfdbdf16512cf1f8a9e6bd6bfbbefa9f070b050L5-R9) [[3]](diffhunk://#diff-49e6e20271b574307572d8c7c84188ead2e7222e89125c8a44505d1085e0cc11L5-R9)
* Changed the button label from "Grant access" to "Manage access" in the `manage-user.html` template.