### PR TITLE
Refactor users.html: Clean up search form card and adjust styling for user listing (prevent horizontal scroll on full screen)

### DIFF
--- a/src/main/resources/templates/users.html
+++ b/src/main/resources/templates/users.html
@@ -97,7 +97,9 @@
                                                                 aria-describedby="firm-hint"
                                                                 aria-owns="firmSearch__listbox" role="combobox"
                                                                 th:value="${firmSearch.firmSearch}">
-                                                            <input type="hidden" id="selectedFirmId" name="selectedFirmId" th:value="${firmSearch.selectedFirmId}"/>
+                                                            <input type="hidden" id="selectedFirmId"
+                                                                name="selectedFirmId"
+                                                                th:value="${firmSearch.selectedFirmId}" />
                                                             <div id="firmSearch__assistiveHint"
                                                                 class="govuk-hint govuk-visually-hidden" role="status">
                                                                 When autocomplete results are available, use up and down
@@ -128,39 +130,39 @@
                                             </div>
                                         </div>
                                     </form>
+
+                                    <!-- Show firm admins checkbox -->
+                                    <div >
+                                        <form method="get" th:action="@{/admin/users}" role="search">
+                                            <!-- Hidden inputs to preserve current search state -->
+                                            <input type="hidden" name="search" th:value="${search}">
+                                            <input type="hidden" name="firmSearch" th:value="${firmSearch.firmSearch}">
+                                            <input type="hidden" name="selectedFirmId" th:value="${firmSearch.selectedFirmId}">
+                                            <input type="hidden" name="sort" th:value="${sort}">
+                                            <input type="hidden" name="direction" th:value="${direction}">
+                                            <input type="hidden" name="page" th:value="${page}">
+                                            <input type="hidden" name="size" th:value="${requestedPageSize}">
+
+                                            <div class="govuk-form-group">
+                                                <fieldset class="govuk-fieldset">
+                                                    <div class="govuk-checkboxes govuk-checkboxes--small"
+                                                        data-module="govuk-checkboxes">
+                                                        <div class="govuk-checkboxes__item">
+                                                            <input class="govuk-checkboxes__input" id="showFirmAdmins"
+                                                                name="showFirmAdmins" type="checkbox" value="true"
+                                                                onchange="this.form.submit();" th:checked="${showFirmAdmins}">
+                                                            <label class="govuk-label govuk-checkboxes__label"
+                                                                for="show-firm-admins">
+                                                                Show firm admins
+                                                            </label>
+                                                        </div>
+                                                    </div>
+                                                </fieldset>
+                                            </div>
+                                        </form>
+                                    </div>
                                 </fieldset>
                             </div>
-                        </div>
-
-                        <!-- Show firm admins checkbox -->
-                        <div class="govuk-!-margin-top-4">
-                            <form method="get" th:action="@{/admin/users}" role="search">
-                                <!-- Hidden inputs to preserve current search state -->
-                                <input type="hidden" name="search" th:value="${search}">
-                                <input type="hidden" name="firmSearch" th:value="${firmSearch.firmSearch}">
-                                <input type="hidden" name="selectedFirmId" th:value="${firmSearch.selectedFirmId}">
-                                <input type="hidden" name="sort" th:value="${sort}">
-                                <input type="hidden" name="direction" th:value="${direction}">
-                                <input type="hidden" name="page" th:value="${page}">
-                                <input type="hidden" name="size" th:value="${requestedPageSize}">
-
-                                <div class="govuk-form-group">
-                                    <fieldset class="govuk-fieldset">
-                                        <div class="govuk-checkboxes govuk-checkboxes--small"
-                                            data-module="govuk-checkboxes">
-                                            <div class="govuk-checkboxes__item">
-                                                <input class="govuk-checkboxes__input" id="showFirmAdmins"
-                                                    name="showFirmAdmins" type="checkbox" value="true"
-                                                    onchange="this.form.submit();" th:checked="${showFirmAdmins}">
-                                                <label class="govuk-label govuk-checkboxes__label"
-                                                    for="show-firm-admins">
-                                                    Show firm admins
-                                                </label>
-                                            </div>
-                                        </div>
-                                    </fieldset>
-                                </div>
-                            </form>
                         </div>
                     </div>
                 </div>
@@ -287,10 +289,8 @@
                     /* Search card styling */
                     .search-card {
                         padding: 20px 20px 0px 20px;
-                        /* Reduced bottom padding */
                         border-radius: 0;
-                        background-color: #f3f2f1;
-                        /* govuk-colour("light-grey") */
+                        border-bottom: 1px solid #0b0c0c;
                     }
 
                     .search-card .govuk-fieldset__legend {
@@ -600,7 +600,7 @@
                             </th>
                             <th scope="col" class="govuk-table__header"
                                 th:aria-sort="${sort == 'email' ? direction : 'none'}"
-                                style="width: 35%; min-width: 200px;">
+                                style="width: 30%; min-width: 200px;">
                                 <button type="button" data-index="2"
                                     th:onclick="'window.location.href=\'' + @{/admin/users(size=${requestedPageSize ?: 10}, page=${page ?: 1}, search=${search}, sort='email', direction=${sort == 'email' and direction == 'asc' ? 'desc' : 'asc'}, usertype=${usertype}, showFirmAdmins=${showFirmAdmins}, firmSearch=${firmSearch.firmSearch}, selectedFirmId=${firmSearch.selectedFirmId})} + '\''">
                                     Email
@@ -628,7 +628,7 @@
                             </th>
                             <th scope="col" class="govuk-table__header"
                                 th:aria-sort="${sort == 'userStatus' ? direction : 'none'}"
-                                style="width: 10%; min-width: 90px;">
+                                style="width: 15%; min-width: 90px;">
                                 <button type="button" data-index="4"
                                     th:onclick="'window.location.href=\'' + @{/admin/users(size=${requestedPageSize ?: 10}, page=${page ?: 1}, search=${search}, sort='userStatus', direction=${sort == 'userStatus' and direction == 'asc' ? 'desc' : 'asc'}, usertype=${usertype}, showFirmAdmins=${showFirmAdmins}, firmSearch=${firmSearch.firmSearch}, selectedFirmId=${firmSearch.selectedFirmId})} + '\''">
                                     Status


### PR DESCRIPTION

<img width="1913" height="968" alt="Screenshot 2025-09-01 at 11 11 20" src="https://github.com/user-attachments/assets/a5bf099b-7e3d-4c10-bd51-bc6de0a42f32" />


**Template structure and markup:**
* Moved the closing tags for `fieldset`, `.govuk-!-margin-top-4`, and associated `div`s to ensure proper nesting and semantic structure of the form and its controls. This improves maintainability and accessibility. [[1]](diffhunk://#diff-5706460a5d76531ccf89d49fc69ba9783f296fd514786f7fa47ba80966473bd1L131-R135) [[2]](diffhunk://#diff-5706460a5d76531ccf89d49fc69ba9783f296fd514786f7fa47ba80966473bd1R164-R166)
* Reformatted the `selectedFirmId` hidden input for better readability, splitting it across multiple lines.

**Visual and layout adjustments:**
* Updated the `.search-card` styling by removing the background color and adding a bottom border for a cleaner visual separation.

**Table column sizing:**
* Adjusted the width of the "Email" column from 35% to 30% to allow more space for other columns.
* Increased the width of the "Status" column from 10% to 15% for better readability.