### PR TITLE
STB-2770: Updated RoleType logic to use UserTypeRestriction column

### DIFF
--- a/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/RoleBaseAccessEditUserRoleTest.java
+++ b/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/RoleBaseAccessEditUserRoleTest.java
@@ -10,8 +10,8 @@ import uk.gov.justice.laa.portal.landingpage.dto.AppDto;
 import uk.gov.justice.laa.portal.landingpage.entity.App;
 import uk.gov.justice.laa.portal.landingpage.entity.AppRole;
 import uk.gov.justice.laa.portal.landingpage.entity.EntraUser;
-import uk.gov.justice.laa.portal.landingpage.entity.RoleType;
 import uk.gov.justice.laa.portal.landingpage.entity.UserProfile;
+import uk.gov.justice.laa.portal.landingpage.entity.UserType;
 import uk.gov.justice.laa.portal.landingpage.viewmodel.AppRoleViewModel;
 
 import java.util.List;
@@ -99,8 +99,7 @@ public class RoleBaseAccessEditUserRoleTest extends RoleBasedAccessIntegrationTe
 
         // Build test role
         AppRole testExternalAppRole = buildLaaAppRole(testExternalApp, "Test External App Role");
-        testExternalAppRole.setRoleType(RoleType.EXTERNAL);
-        testExternalAppRole.setUserTypeRestriction(null);
+        testExternalAppRole.setUserTypeRestriction(new UserType[] {UserType.EXTERNAL});
 
         // Persist app and role.
         testExternalApp.setAppRoles(Set.of(testExternalAppRole));
@@ -130,8 +129,7 @@ public class RoleBaseAccessEditUserRoleTest extends RoleBasedAccessIntegrationTe
 
         // Build test role
         AppRole testInternalAppRole = buildLaaAppRole(testInternalApp, "Test Internal App Role");
-        testInternalAppRole.setRoleType(RoleType.INTERNAL);
-        testInternalAppRole.setUserTypeRestriction(null);
+        testInternalAppRole.setUserTypeRestriction(new UserType[] {UserType.INTERNAL});
 
         // Persist app and role.
         testInternalApp.setAppRoles(Set.of(testInternalAppRole));
@@ -162,8 +160,7 @@ public class RoleBaseAccessEditUserRoleTest extends RoleBasedAccessIntegrationTe
 
         // Build test role
         AppRole testExternalAppRole = buildLaaAppRole(testExternalApp, "Test External App Role");
-        testExternalAppRole.setRoleType(RoleType.EXTERNAL);
-        testExternalAppRole.setUserTypeRestriction(null);
+        testExternalAppRole.setUserTypeRestriction(new UserType[] {UserType.EXTERNAL});
 
         // Persist app and role.
         testExternalApp.setAppRoles(Set.of(testExternalAppRole));
@@ -193,8 +190,7 @@ public class RoleBaseAccessEditUserRoleTest extends RoleBasedAccessIntegrationTe
 
         // Build test role
         AppRole testInternalAndExternalAppRole = buildLaaAppRole(testExternalApp, "Test External App Role");
-        testInternalAndExternalAppRole.setRoleType(RoleType.INTERNAL_AND_EXTERNAL);
-        testInternalAndExternalAppRole.setUserTypeRestriction(null);
+        testInternalAndExternalAppRole.setUserTypeRestriction(new UserType[] {UserType.INTERNAL, UserType.EXTERNAL});
 
         // Persist app and role.
         testExternalApp.setAppRoles(Set.of(testInternalAndExternalAppRole));
@@ -224,8 +220,7 @@ public class RoleBaseAccessEditUserRoleTest extends RoleBasedAccessIntegrationTe
 
         // Build test role
         AppRole testInternalAppRole = buildLaaAppRole(testInternalApp, "Test Internal App Role");
-        testInternalAppRole.setRoleType(RoleType.INTERNAL);
-        testInternalAppRole.setUserTypeRestriction(null);
+        testInternalAppRole.setUserTypeRestriction(new UserType[] {UserType.INTERNAL});
 
         // Persist app and role.
         testInternalApp.setAppRoles(Set.of(testInternalAppRole));
@@ -255,8 +250,7 @@ public class RoleBaseAccessEditUserRoleTest extends RoleBasedAccessIntegrationTe
 
         // Build test role
         AppRole testInternalAndExternalAppRole = buildLaaAppRole(testInternalApp, "Test Internal App Role");
-        testInternalAndExternalAppRole.setRoleType(RoleType.INTERNAL_AND_EXTERNAL);
-        testInternalAndExternalAppRole.setUserTypeRestriction(null);
+        testInternalAndExternalAppRole.setUserTypeRestriction(new UserType[] {UserType.INTERNAL, UserType.EXTERNAL});
 
         // Persist app and role.
         testInternalApp.setAppRoles(Set.of(testInternalAndExternalAppRole));

--- a/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/repository/BaseRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/repository/BaseRepositoryTest.java
@@ -19,7 +19,6 @@ import uk.gov.justice.laa.portal.landingpage.entity.EntraUser;
 import uk.gov.justice.laa.portal.landingpage.entity.Firm;
 import uk.gov.justice.laa.portal.landingpage.entity.FirmType;
 import uk.gov.justice.laa.portal.landingpage.entity.Office;
-import uk.gov.justice.laa.portal.landingpage.entity.RoleType;
 import uk.gov.justice.laa.portal.landingpage.entity.UserProfile;
 import uk.gov.justice.laa.portal.landingpage.entity.UserProfileStatus;
 import uk.gov.justice.laa.portal.landingpage.entity.UserStatus;
@@ -68,7 +67,7 @@ public class BaseRepositoryTest {
     }
 
     protected AppRole buildLaaAppRole(App app, String name) {
-        return AppRole.builder().name(name).roleType(RoleType.INTERNAL).description(name)
+        return AppRole.builder().name(name).description(name)
                 .userTypeRestriction(new UserType[]{UserType.INTERNAL}).app(app).build();
     }
 

--- a/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/repository/RoleAssignmentRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/repository/RoleAssignmentRepositoryTest.java
@@ -10,7 +10,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import uk.gov.justice.laa.portal.landingpage.entity.App;
 import uk.gov.justice.laa.portal.landingpage.entity.AppRole;
 import uk.gov.justice.laa.portal.landingpage.entity.RoleAssignment;
-import uk.gov.justice.laa.portal.landingpage.entity.RoleType;
+import uk.gov.justice.laa.portal.landingpage.entity.UserType;
 
 import java.util.List;
 import java.util.Optional;
@@ -44,8 +44,8 @@ public class RoleAssignmentRepositoryTest extends BaseRepositoryTest {
         App app = App.builder().name("app").securityGroupOid("sec_grp_oid").securityGroupName("sec_grp_name").build();
         appRepository.save(app);
 
-        AppRole appRole1 = AppRole.builder().name("appRole1").description("appRole1").roleType(RoleType.EXTERNAL).app(app).build();
-        AppRole appRole2 = AppRole.builder().name("appRole2").description("appRole2").roleType(RoleType.EXTERNAL).app(app).build();
+        AppRole appRole1 = AppRole.builder().name("appRole1").description("appRole1").userTypeRestriction(new UserType[] {UserType.EXTERNAL}).app(app).build();
+        AppRole appRole2 = AppRole.builder().name("appRole2").description("appRole2").userTypeRestriction(new UserType[] {UserType.EXTERNAL}).app(app).build();
         appRoleRepository.saveAll(List.of(appRole1, appRole2));
         int oldAssignmentsSize = repository.findAll().size();
 
@@ -71,9 +71,9 @@ public class RoleAssignmentRepositoryTest extends BaseRepositoryTest {
         App app = App.builder().name("app").securityGroupOid("sec_grp_oid").securityGroupName("sec_grp_name").build();
         appRepository.save(app);
 
-        AppRole appRole1 = AppRole.builder().name("appRole1").description("appRole1").roleType(RoleType.EXTERNAL).app(app).build();
-        AppRole appRole2 = AppRole.builder().name("appRole2").description("appRole2").roleType(RoleType.EXTERNAL).app(app).build();
-        AppRole appRole3 = AppRole.builder().name("appRole3").description("appRole3").roleType(RoleType.EXTERNAL).app(app).build();
+        AppRole appRole1 = AppRole.builder().name("appRole1").description("appRole1").userTypeRestriction(new UserType[] {UserType.EXTERNAL}).app(app).build();
+        AppRole appRole2 = AppRole.builder().name("appRole2").description("appRole2").userTypeRestriction(new UserType[] {UserType.EXTERNAL}).app(app).build();
+        AppRole appRole3 = AppRole.builder().name("appRole3").description("appRole3").userTypeRestriction(new UserType[] {UserType.EXTERNAL}).app(app).build();
         appRoleRepository.saveAll(List.of(appRole1, appRole2, appRole3));
 
         // Act

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/dto/AppRoleDto.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/dto/AppRoleDto.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.jetbrains.annotations.NotNull;
-import uk.gov.justice.laa.portal.landingpage.entity.RoleType;
+import uk.gov.justice.laa.portal.landingpage.entity.UserType;
 
 @Data
 @Builder
@@ -18,7 +18,7 @@ public class AppRoleDto implements Comparable<AppRoleDto> {
     private String description;
     private String ccmsCode;
     private AppDto app;
-    private RoleType roleType;
+    private UserType[] userTypeRestriction;
 
     @Override
     public int compareTo(@NotNull AppRoleDto o) {

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/entity/AppRole.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/entity/AppRole.java
@@ -74,11 +74,6 @@ public class AppRole extends BaseEntity {
     @Builder.Default
     private Set<UserProfile> userProfiles = new HashSet<>();
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "role_type", nullable = false, length = 255)
-    @NotNull(message = "App role type must be provided")
-    private RoleType roleType;
-
     @JdbcTypeCode(SqlTypes.ARRAY)
     @Enumerated(EnumType.STRING)
     @Column(name = "user_type_restriction", nullable = true, columnDefinition = "text[]")

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/entity/RoleType.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/entity/RoleType.java
@@ -1,7 +1,0 @@
-package uk.gov.justice.laa.portal.landingpage.entity;
-
-public enum RoleType {
-    INTERNAL,
-    EXTERNAL,
-    INTERNAL_AND_EXTERNAL
-}

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/repository/AppRoleRepository.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/repository/AppRoleRepository.java
@@ -7,10 +7,11 @@ import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import uk.gov.justice.laa.portal.landingpage.entity.AppRole;
-import uk.gov.justice.laa.portal.landingpage.entity.RoleType;
+import uk.gov.justice.laa.portal.landingpage.entity.UserType;
 
 @Repository
 public interface AppRoleRepository extends JpaRepository<AppRole, UUID> {
@@ -25,7 +26,8 @@ public interface AppRoleRepository extends JpaRepository<AppRole, UUID> {
 
     Optional<AppRole> findByCcmsCode(String ccmsCode);
 
-    List<AppRole> findByRoleTypeIn(Collection<RoleType> roleTypes);
+    @Query(value = "SELECT * FROM app_role ar WHERE :userType = ANY(ar.user_type_restriction)", nativeQuery = true)
+    List<AppRole> findByUserTypeRestrictionContains(@Param("userType") String userType);
 
     List<AppRole> findAllByIdInAndAuthzRoleIs(Collection<UUID> roleIds, boolean authzRole);
 }

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/service/UserService.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/service/UserService.java
@@ -31,7 +31,6 @@ import uk.gov.justice.laa.portal.landingpage.entity.EntraUser;
 import uk.gov.justice.laa.portal.landingpage.entity.Firm;
 import uk.gov.justice.laa.portal.landingpage.entity.Office;
 import uk.gov.justice.laa.portal.landingpage.entity.Permission;
-import uk.gov.justice.laa.portal.landingpage.entity.RoleType;
 import uk.gov.justice.laa.portal.landingpage.entity.UserProfile;
 import uk.gov.justice.laa.portal.landingpage.entity.UserProfileStatus;
 import uk.gov.justice.laa.portal.landingpage.entity.UserStatus;
@@ -51,6 +50,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -141,16 +141,9 @@ public class UserService {
         if (optionalUserProfile.isPresent()) {
             UserProfile userProfile = optionalUserProfile.get();
             boolean self = userProfile.getEntraUser().getEntraOid().equals(modifierId.toString());
-            boolean isInternal = userProfile.getUserType() == UserType.INTERNAL;
             int before = roles.size();
-            Predicate<AppRole> internalUserWithInternalRole = appRole -> isInternal
-                    && appRole.getRoleType().equals(RoleType.INTERNAL);
-            Predicate<AppRole> externalUserWithExternalRole = appRole -> !isInternal
-                    && appRole.getRoleType().equals(RoleType.EXTERNAL);
             roles = roles.stream()
-                    .filter(appRole -> internalUserWithInternalRole.test(appRole)
-                            || externalUserWithExternalRole.test(appRole)
-                            || appRole.getRoleType().equals(RoleType.INTERNAL_AND_EXTERNAL))
+                    .filter(appRole -> Arrays.stream(appRole.getUserTypeRestriction()).anyMatch(userType -> userType == userProfile.getUserType()))
                     .toList();
             int after = roles.size();
             if (after < before) {
@@ -426,15 +419,8 @@ public class UserService {
     }
 
     public List<AppDto> getAppsByUserType(UserType userType) {
-        if (userType == UserType.INTERNAL) {
-            return getAppsByRoleType(RoleType.INTERNAL);
-        } else {
-            return getAppsByRoleType(RoleType.EXTERNAL);
-        }
-    }
-
-    private List<AppDto> getAppsByRoleType(RoleType roleType) {
-        return appRoleRepository.findByRoleTypeIn(List.of(roleType, RoleType.INTERNAL_AND_EXTERNAL)).stream()
+        return appRoleRepository.findByUserTypeRestrictionContains(userType.name())
+                .stream()
                 .map(AppRole::getApp)
                 .distinct()
                 .map(app -> mapper.map(app, AppDto.class))
@@ -604,10 +590,8 @@ public class UserService {
         List<AppRoleDto> appRoles = new ArrayList<>();
         if (optionalApp.isPresent()) {
             App app = optionalApp.get();
-            RoleType userRoleType = userType == UserType.INTERNAL ? RoleType.INTERNAL : RoleType.EXTERNAL;
             appRoles = app.getAppRoles().stream()
-                    .filter(appRole -> appRole.getRoleType().equals(userRoleType)
-                            || appRole.getRoleType().equals(RoleType.INTERNAL_AND_EXTERNAL))
+                    .filter(appRole -> Arrays.stream(appRole.getUserTypeRestriction()).anyMatch(roleUserType -> roleUserType == userType))
                     .map(appRole -> mapper.map(appRole, AppRoleDto.class))
                     .sorted()
                     .toList();

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/utils/DemoDataPopulator.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/utils/DemoDataPopulator.java
@@ -20,7 +20,6 @@ import uk.gov.justice.laa.portal.landingpage.entity.EntraUser;
 import uk.gov.justice.laa.portal.landingpage.entity.Firm;
 import uk.gov.justice.laa.portal.landingpage.entity.FirmType;
 import uk.gov.justice.laa.portal.landingpage.entity.Office;
-import uk.gov.justice.laa.portal.landingpage.entity.RoleType;
 import uk.gov.justice.laa.portal.landingpage.entity.UserProfile;
 import uk.gov.justice.laa.portal.landingpage.entity.UserProfileStatus;
 import uk.gov.justice.laa.portal.landingpage.entity.UserStatus;
@@ -190,8 +189,8 @@ public class DemoDataPopulator {
         return App.builder().name(name).entraAppId(entraAppOid).appRoles(HashSet.newHashSet(11)).build();
     }
 
-    protected AppRole buildLaaAppRole(App app, String name, RoleType roleType) {
-        return AppRole.builder().name(name).roleType(roleType)
+    protected AppRole buildLaaAppRole(App app, String name, UserType... types) {
+        return AppRole.builder().name(name).userTypeRestriction(types)
                 .description(name).authzRole(false).app(app).build();
     }
 
@@ -286,10 +285,10 @@ public class DemoDataPopulator {
 
                 AppRole internalRole = laaAppRoleRepository.findByName(currentAppName.toUpperCase() + "_VIEWER_INTERN")
                         .orElse(buildLaaAppRole(app, app.getName().toUpperCase() + "_VIEWER_INTERN",
-                                RoleType.INTERNAL));
+                                UserType.INTERNAL));
                 AppRole externalRole = laaAppRoleRepository.findByName(currentAppName.toUpperCase() + "_VIEWER_EXTERN")
                         .orElse(buildLaaAppRole(app, app.getName().toUpperCase() + "_VIEWER_EXTERN",
-                                RoleType.EXTERNAL));
+                                UserType.EXTERNAL));
                 laaAppRoleRepository.save(internalRole);
                 laaAppRoleRepository.save(externalRole);
 

--- a/src/main/resources/db/changelog/changesets/db.changesets-3.1.yaml
+++ b/src/main/resources/db/changelog/changesets/db.changesets-3.1.yaml
@@ -1,0 +1,21 @@
+databaseChangeLog:
+  - changeSet:
+      id: 1755695455403-1
+      author: niall.mcmahon
+      changes:
+        # Update roles with the INTERNAL role_type to have INTERNAL as their user type restriction
+        - sql:
+            dbms: postgresql
+            sql: "UPDATE app_role SET user_type_restriction = ARRAY['INTERNAL'] WHERE role_type = 'INTERNAL'"
+        # Update roles with the EXTERNAL role_type to have EXTERNAL as their user type restriction
+        - sql:
+            dbms: postgresql
+            sql: "UPDATE app_role SET user_type_restriction = ARRAY['EXTERNAL'] WHERE role_type = 'EXTERNAL'"
+        # Update roles with the INTERNAL_AND_EXTERNAL role_type to have INTERNAL and EXTERNAL as their user type restriction
+        - sql:
+            dbms: postgresql
+            sql: "UPDATE app_role SET user_type_restriction = ARRAY['INTERNAL','EXTERNAL'] WHERE role_type = 'INTERNAL_AND_EXTERNAL'"
+        # Remove unused role_type column.
+        - dropColumn:
+            columnName: role_type
+            tableName: app_role

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/UserControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/UserControllerTest.java
@@ -43,7 +43,6 @@ import uk.gov.justice.laa.portal.landingpage.entity.EntraUser;
 import uk.gov.justice.laa.portal.landingpage.entity.Firm;
 import uk.gov.justice.laa.portal.landingpage.entity.Office;
 import uk.gov.justice.laa.portal.landingpage.entity.Permission;
-import uk.gov.justice.laa.portal.landingpage.entity.RoleType;
 import uk.gov.justice.laa.portal.landingpage.entity.UserProfile;
 import uk.gov.justice.laa.portal.landingpage.entity.UserType;
 import uk.gov.justice.laa.portal.landingpage.exception.CreateUserDetailsIncompleteException;
@@ -1006,16 +1005,16 @@ class UserControllerTest {
         // Setup all available roles
         AppRoleDto testRole1 = new AppRoleDto();
         testRole1.setId("testAppRoleId1");
-        testRole1.setRoleType(RoleType.EXTERNAL);
+        testRole1.setUserTypeRestriction(new UserType[] {UserType.EXTERNAL});
         AppRoleDto testRole2 = new AppRoleDto();
         testRole2.setId("testAppRoleId2");
-        testRole2.setRoleType(RoleType.EXTERNAL);
+        testRole2.setUserTypeRestriction(new UserType[] {UserType.EXTERNAL});
         AppRoleDto testRole3 = new AppRoleDto();
         testRole3.setId("testAppRoleId3");
-        testRole3.setRoleType(RoleType.EXTERNAL);
+        testRole3.setUserTypeRestriction(new UserType[] {UserType.EXTERNAL});
         AppRoleDto testRole4 = new AppRoleDto();
         testRole4.setId("testUserAppRoleId");
-        testRole4.setRoleType(RoleType.EXTERNAL);
+        testRole4.setUserTypeRestriction(new UserType[] {UserType.EXTERNAL});
         AppDto currentApp = new AppDto();
         currentApp.setId("testAppId");
         currentApp.setName("testAppName");
@@ -1051,13 +1050,13 @@ class UserControllerTest {
         // Setup all available roles
         AppRoleDto testRole1 = new AppRoleDto();
         testRole1.setId("testAppRoleId1");
-        testRole1.setRoleType(RoleType.EXTERNAL);
+        testRole1.setUserTypeRestriction(new UserType[] {UserType.EXTERNAL});
         AppRoleDto testRole2 = new AppRoleDto();
         testRole2.setId("testAppRoleId2");
-        testRole2.setRoleType(RoleType.EXTERNAL);
+        testRole2.setUserTypeRestriction(new UserType[] {UserType.EXTERNAL});
         AppRoleDto testRole3 = new AppRoleDto();
         testRole3.setId("testAppRoleId3");
-        testRole3.setRoleType(RoleType.INTERNAL_AND_EXTERNAL);
+        testRole3.setUserTypeRestriction(new UserType[] {UserType.INTERNAL, UserType.EXTERNAL});
         AppDto currentApp = new AppDto();
         currentApp.setId("testAppId");
         currentApp.setName("testAppName");
@@ -1093,16 +1092,16 @@ class UserControllerTest {
         // Setup all available roles
         AppRoleDto testRole1 = new AppRoleDto();
         testRole1.setId("testAppRoleId1");
-        testRole1.setRoleType(RoleType.EXTERNAL);
+        testRole1.setUserTypeRestriction(new UserType[] {UserType.EXTERNAL});
         AppRoleDto testRole2 = new AppRoleDto();
         testRole2.setId("testAppRoleId2");
-        testRole2.setRoleType(RoleType.EXTERNAL);
+        testRole2.setUserTypeRestriction(new UserType[] {UserType.EXTERNAL});
         AppRoleDto testRole3 = new AppRoleDto();
         testRole3.setId("testAppRoleId3");
-        testRole3.setRoleType(RoleType.INTERNAL_AND_EXTERNAL);
+        testRole3.setUserTypeRestriction(new UserType[] {UserType.INTERNAL, UserType.EXTERNAL});
         AppRoleDto testRole4 = new AppRoleDto();
         testRole4.setId("testUserAppRoleId");
-        testRole4.setRoleType(RoleType.INTERNAL);
+        testRole4.setUserTypeRestriction(new UserType[] {UserType.INTERNAL});
         AppDto currentApp = new AppDto();
         currentApp.setId("testAppId");
         currentApp.setName("testAppName");
@@ -1768,7 +1767,7 @@ class UserControllerTest {
         currentApp.setName("App 1");
 
         AppRoleDto role = new AppRoleDto();
-        role.setRoleType(RoleType.EXTERNAL);
+        role.setUserTypeRestriction(new UserType[] {UserType.EXTERNAL});
         List<AppRoleDto> appRoles = List.of(role);
 
         final UserProfileDto userProfile = UserProfileDto.builder()
@@ -1808,15 +1807,15 @@ class UserControllerTest {
         AppDto app2 = AppDto.builder().id("app-two").name("app-two").ordinal(1).build();
         AppDto app3 = AppDto.builder().id("app-three").name("app-three").ordinal(3).build();
 
-        AppRoleDto a1r1 = AppRoleDto.builder().id("a1r1").name("a1r1").roleType(RoleType.EXTERNAL).app(app1).ordinal(3).build();
-        AppRoleDto a1r2 = AppRoleDto.builder().id("a1r2").name("a1r2").roleType(RoleType.EXTERNAL).app(app1).ordinal(4).build();
-        AppRoleDto a1r3 = AppRoleDto.builder().id("a1r3").name("a1r3").roleType(RoleType.EXTERNAL).app(app1).ordinal(1).build();
-        AppRoleDto a1r4 = AppRoleDto.builder().id("a1r4").name("a1r4").roleType(RoleType.EXTERNAL).app(app1).ordinal(2).build();
-        AppRoleDto a2r1 = AppRoleDto.builder().id("a2r1").name("a2r1").roleType(RoleType.EXTERNAL).app(app2).ordinal(2).build();
-        AppRoleDto a2r2 = AppRoleDto.builder().id("a2r2").name("a2r2").roleType(RoleType.EXTERNAL).app(app2).ordinal(3).build();
-        AppRoleDto a2r3 = AppRoleDto.builder().id("a2r3").name("a2r3").roleType(RoleType.EXTERNAL).app(app2).ordinal(1).build();
-        AppRoleDto a3r1 = AppRoleDto.builder().id("a3r1").name("a3r1").roleType(RoleType.EXTERNAL).app(app3).ordinal(1).build();
-        AppRoleDto a3r2 = AppRoleDto.builder().id("a3r2").name("a3r2").roleType(RoleType.EXTERNAL).app(app3).ordinal(2).build();
+        AppRoleDto a1r1 = AppRoleDto.builder().id("a1r1").name("a1r1").userTypeRestriction(new UserType[] {UserType.EXTERNAL}).app(app1).ordinal(3).build();
+        AppRoleDto a1r2 = AppRoleDto.builder().id("a1r2").name("a1r2").userTypeRestriction(new UserType[] {UserType.EXTERNAL}).app(app1).ordinal(4).build();
+        AppRoleDto a1r3 = AppRoleDto.builder().id("a1r3").name("a1r3").userTypeRestriction(new UserType[] {UserType.EXTERNAL}).app(app1).ordinal(1).build();
+        AppRoleDto a1r4 = AppRoleDto.builder().id("a1r4").name("a1r4").userTypeRestriction(new UserType[] {UserType.EXTERNAL}).app(app1).ordinal(2).build();
+        AppRoleDto a2r1 = AppRoleDto.builder().id("a2r1").name("a2r1").userTypeRestriction(new UserType[] {UserType.EXTERNAL}).app(app2).ordinal(2).build();
+        AppRoleDto a2r2 = AppRoleDto.builder().id("a2r2").name("a2r2").userTypeRestriction(new UserType[] {UserType.EXTERNAL}).app(app2).ordinal(3).build();
+        AppRoleDto a2r3 = AppRoleDto.builder().id("a2r3").name("a2r3").userTypeRestriction(new UserType[] {UserType.EXTERNAL}).app(app2).ordinal(1).build();
+        AppRoleDto a3r1 = AppRoleDto.builder().id("a3r1").name("a3r1").userTypeRestriction(new UserType[] {UserType.EXTERNAL}).app(app3).ordinal(1).build();
+        AppRoleDto a3r2 = AppRoleDto.builder().id("a3r2").name("a3r2").userTypeRestriction(new UserType[] {UserType.EXTERNAL}).app(app3).ordinal(2).build();
 
         Set<AppDto> userApps = new LinkedHashSet<>(Arrays.asList(app1, app2, app3));
 

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/entity/AppRoleTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/entity/AppRoleTest.java
@@ -21,7 +21,7 @@ public class AppRoleTest extends BaseEntityTest {
         assertThat(violations).isEmpty();
         assertNotNull(appRole);
         assertThat(appRole.getName()).isEqualTo("Test App Role");
-        assertThat(appRole.getRoleType()).isEqualTo(RoleType.INTERNAL);
+        assertThat(appRole.getUserTypeRestriction()).contains(UserType.INTERNAL);
     }
 
     @Test
@@ -150,32 +150,13 @@ public class AppRoleTest extends BaseEntityTest {
     @Test
     public void testAppRoleTypeExternal() {
         AppRole appRole = buildTestLaaAppRole();
-        update(appRole, f -> f.setRoleType(RoleType.EXTERNAL));
+        update(appRole, f -> f.setUserTypeRestriction(new UserType[] {UserType.EXTERNAL}));
 
         Set<ConstraintViolation<AppRole>> violations = validator.validate(appRole);
 
         assertThat(violations).isEmpty();
         assertNotNull(appRole);
         assertThat(appRole.getName()).isEqualTo("Test App Role");
-        assertThat(appRole.getRoleType()).isEqualTo(RoleType.EXTERNAL);
-    }
-
-    @Test
-    public void testAppRoleNullRoleType() {
-        AppRole appRole = buildTestLaaAppRole();
-        update(appRole, f -> f.setRoleType(null));
-
-        Set<ConstraintViolation<AppRole>> violations = validator.validate(appRole);
-
-        assertThat(violations).isNotEmpty();
-        assertThat(violations).hasSize(1);
-        assertThat(violations.iterator().next().getMessage()).isEqualTo("App role type must be provided");
-        assertThat(violations.iterator().next().getPropertyPath().toString()).isEqualTo("roleType");
-    }
-
-    @Test
-    public void testAppRoleInvalidRoleType() {
-        assertThrows(IllegalArgumentException.class, () -> AppRole.builder()
-                .roleType(RoleType.valueOf("INVALID")).build());
+        assertThat(appRole.getUserTypeRestriction()).contains(UserType.EXTERNAL);
     }
 }

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/entity/BaseEntityTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/entity/BaseEntityTest.java
@@ -49,7 +49,7 @@ public class BaseEntityTest {
 
     protected AppRole buildTestLaaAppRole() {
         return AppRole.builder().name("Test App Role").ccmsCode("ccms_code").description("App Role Description")
-                .roleType(RoleType.INTERNAL).build();
+                .userTypeRestriction(new UserType[] {UserType.INTERNAL}).build();
     }
 
     protected UserProfile buildTestLaaUserProfile() {

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/service/RoleAssignmentServiceTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/service/RoleAssignmentServiceTest.java
@@ -11,7 +11,7 @@ import uk.gov.justice.laa.portal.landingpage.dto.AppRoleDto;
 import uk.gov.justice.laa.portal.landingpage.entity.App;
 import uk.gov.justice.laa.portal.landingpage.entity.AppRole;
 import uk.gov.justice.laa.portal.landingpage.entity.RoleAssignment;
-import uk.gov.justice.laa.portal.landingpage.entity.RoleType;
+import uk.gov.justice.laa.portal.landingpage.entity.UserType;
 import uk.gov.justice.laa.portal.landingpage.repository.AppRoleRepository;
 import uk.gov.justice.laa.portal.landingpage.repository.RoleAssignmentRepository;
 
@@ -45,9 +45,9 @@ public class RoleAssignmentServiceTest {
     void setUp() {
         roleAssignmentService = new RoleAssignmentService(roleAssignmentRepository, appRoleRepository, new MapperConfig().modelMapper());
         App app = App.builder().name("app").securityGroupOid("sec_grp_oid").securityGroupName("sec_grp_name").build();
-        gbAdmin = AppRole.builder().id(gbAdminId).name("globalAdmin").description("appRole1").roleType(RoleType.EXTERNAL).app(app).authzRole(true).build();
-        exAdmin = AppRole.builder().id(exAdminId).name("externalAdmin").description("appRole2").roleType(RoleType.EXTERNAL).app(app).authzRole(true).build();
-        exMan = AppRole.builder().id(exManId).name("externalManager").description("appRole3").roleType(RoleType.EXTERNAL).app(app).authzRole(true).build();
+        gbAdmin = AppRole.builder().id(gbAdminId).name("globalAdmin").description("appRole1").userTypeRestriction(new UserType[] {UserType.EXTERNAL}).app(app).authzRole(true).build();
+        exAdmin = AppRole.builder().id(exAdminId).name("externalAdmin").description("appRole2").userTypeRestriction(new UserType[] {UserType.EXTERNAL}).app(app).authzRole(true).build();
+        exMan = AppRole.builder().id(exManId).name("externalManager").description("appRole3").userTypeRestriction(new UserType[] {UserType.EXTERNAL}).app(app).authzRole(true).build();
         RoleAssignment roleAssignment1 = RoleAssignment.builder().assigningRole(gbAdmin).assignableRole(exAdmin).build();
         RoleAssignment roleAssignment2 = RoleAssignment.builder().assigningRole(gbAdmin).assignableRole(exMan).build();
 
@@ -68,7 +68,8 @@ public class RoleAssignmentServiceTest {
         Set<AppRole> editorRoles = Set.of(gbAdmin);
         UUID viewCrimeId = UUID.randomUUID();
         App crimeApp = App.builder().name("crime").securityGroupOid("sec_grp_oid").securityGroupName("sec_grp_name").build();
-        AppRole viewCrime = AppRole.builder().id(viewCrimeId).name("View Crime Guy").description("appRole3").roleType(RoleType.EXTERNAL).app(crimeApp).authzRole(false).build();
+        AppRole viewCrime = AppRole.builder().id(viewCrimeId).name("View Crime Guy").description("appRole3")
+                .userTypeRestriction(new UserType[] {UserType.EXTERNAL}).app(crimeApp).authzRole(false).build();
         List<String> targetRoles = List.of(exAdminId.toString(), exManId.toString(), viewCrimeId.toString());
         when(appRoleRepository.findAllByIdInAndAuthzRoleIs(List.of(exAdminId, exManId, viewCrimeId), true)).thenReturn(List.of(exAdmin, exMan));
         assertThat(roleAssignmentService.canAssignRole(editorRoles, targetRoles)).isTrue();
@@ -112,7 +113,8 @@ public class RoleAssignmentServiceTest {
         exManDto.setId(gbAdminId.toString());
         UUID viewCrimeId = UUID.randomUUID();
         App crimeApp = App.builder().name("crime").securityGroupOid("sec_grp_oid").securityGroupName("sec_grp_name").build();
-        AppRole viewCrime = AppRole.builder().id(viewCrimeId).name("View Crime Guy").description("appRole3").roleType(RoleType.EXTERNAL).app(crimeApp).authzRole(false).build();
+        AppRole viewCrime = AppRole.builder().id(viewCrimeId).name("View Crime Guy").description("appRole3")
+                .userTypeRestriction(new UserType[] {UserType.EXTERNAL}).app(crimeApp).authzRole(false).build();
         AppRoleDto viewCrimeDto = new AppRoleDto();
         viewCrimeDto.setId(viewCrimeId.toString());
         List<AppRoleDto> targetRoles = List.of(exAdminDto, exManDto, viewCrimeDto);

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/service/UserServiceTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/service/UserServiceTest.java
@@ -46,7 +46,6 @@ import uk.gov.justice.laa.portal.landingpage.entity.EntraUser;
 import uk.gov.justice.laa.portal.landingpage.entity.Firm;
 import uk.gov.justice.laa.portal.landingpage.entity.Office;
 import uk.gov.justice.laa.portal.landingpage.entity.Permission;
-import uk.gov.justice.laa.portal.landingpage.entity.RoleType;
 import uk.gov.justice.laa.portal.landingpage.entity.UserProfile;
 import uk.gov.justice.laa.portal.landingpage.entity.UserProfileStatus;
 import uk.gov.justice.laa.portal.landingpage.entity.UserStatus;
@@ -936,7 +935,7 @@ class UserServiceTest {
         UUID roleId = UUID.randomUUID();
         UUID profileId = UUID.randomUUID();
         UUID entraOid = UUID.randomUUID();
-        AppRole appRole = AppRole.builder().id(roleId).roleType(RoleType.INTERNAL_AND_EXTERNAL).build();
+        AppRole appRole = AppRole.builder().id(roleId).userTypeRestriction(new UserType[] {UserType.INTERNAL, UserType.EXTERNAL}).build();
         UserProfile userProfile = UserProfile.builder().id(profileId).activeProfile(true).userProfileStatus(UserProfileStatus.COMPLETE).userType(UserType.EXTERNAL).build();
         EntraUser user = EntraUser.builder().id(userId).entraOid(entraOid.toString()).userProfiles(Set.of(userProfile)).build();
         userProfile.setEntraUser(user);
@@ -960,7 +959,7 @@ class UserServiceTest {
         UUID userProfileId = UUID.randomUUID();
         UUID roleId = UUID.randomUUID();
         UUID entraOid = UUID.randomUUID();
-        AppRole appRole = AppRole.builder().id(roleId).roleType(RoleType.EXTERNAL).build();
+        AppRole appRole = AppRole.builder().id(roleId).userTypeRestriction(new UserType[] {UserType.EXTERNAL}).build();
         UserProfile userProfile = UserProfile.builder().id(userProfileId).activeProfile(true).userType(UserType.EXTERNAL).build();
         EntraUser user = EntraUser.builder().entraOid(entraOid.toString()).userProfiles(Set.of(userProfile)).build();
         userProfile.setEntraUser(user);
@@ -982,7 +981,7 @@ class UserServiceTest {
         UUID userId = UUID.randomUUID();
         UUID roleId = UUID.randomUUID();
         UUID entraOid = UUID.randomUUID();
-        AppRole appRole = AppRole.builder().id(roleId).roleType(RoleType.INTERNAL).build();
+        AppRole appRole = AppRole.builder().id(roleId).userTypeRestriction(new UserType[] {UserType.INTERNAL}).build();
         UserProfile userProfile = UserProfile.builder().id(userId).activeProfile(true).userType(UserType.INTERNAL).build();
         EntraUser user = EntraUser.builder().entraOid(entraOid.toString()).userProfiles(Set.of(userProfile)).build();
         userProfile.setEntraUser(user);
@@ -1004,7 +1003,7 @@ class UserServiceTest {
         UUID userId = UUID.randomUUID();
         UUID roleId = UUID.randomUUID();
         UUID entraOid = UUID.randomUUID();
-        AppRole appRole = AppRole.builder().id(roleId).roleType(RoleType.INTERNAL).build();
+        AppRole appRole = AppRole.builder().id(roleId).userTypeRestriction(new UserType[] {UserType.INTERNAL}).build();
         UserProfile userProfile = UserProfile.builder().id(userId).activeProfile(true).userType(UserType.EXTERNAL).build();
         EntraUser user = EntraUser.builder().entraOid(entraOid.toString()).userProfiles(Set.of(userProfile)).build();
         userProfile.setEntraUser(user);
@@ -1082,16 +1081,14 @@ class UserServiceTest {
                 .name("Test Role")
                 .app(testApp)
                 .build();
-        when(mockAppRoleRepository.findByRoleTypeIn(anyList())).thenReturn(List.of(testAppRole));
+        when(mockAppRoleRepository.findByUserTypeRestrictionContains(any())).thenReturn(List.of(testAppRole));
         List<AppDto> apps = userService.getAppsByUserType(UserType.INTERNAL);
         Assertions.assertEquals(1, apps.size());
         Assertions.assertEquals(testApp.getName(), apps.getFirst().getName());
-        ArgumentCaptor<List<RoleType>> captor = ArgumentCaptor.forClass(List.class);
-        verify(mockAppRoleRepository).findByRoleTypeIn(captor.capture());
-        List<RoleType> roleTypes = captor.getValue();
-        Assertions.assertEquals(2, roleTypes.size());
-        Assertions.assertEquals(RoleType.INTERNAL, roleTypes.getFirst());
-        Assertions.assertEquals(RoleType.INTERNAL_AND_EXTERNAL, roleTypes.get(1));
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(mockAppRoleRepository).findByUserTypeRestrictionContains(captor.capture());
+        String userTypeString = captor.getValue();
+        Assertions.assertEquals(UserType.INTERNAL.name(), userTypeString);
     }
 
     @Test
@@ -1103,16 +1100,14 @@ class UserServiceTest {
                 .name("Test Role")
                 .app(testApp)
                 .build();
-        when(mockAppRoleRepository.findByRoleTypeIn(anyList())).thenReturn(List.of(testAppRole));
+        when(mockAppRoleRepository.findByUserTypeRestrictionContains(any())).thenReturn(List.of(testAppRole));
         List<AppDto> apps = userService.getAppsByUserType(UserType.EXTERNAL);
         Assertions.assertEquals(1, apps.size());
         Assertions.assertEquals(testApp.getName(), apps.getFirst().getName());
-        ArgumentCaptor<List<RoleType>> captor = ArgumentCaptor.forClass(List.class);
-        verify(mockAppRoleRepository).findByRoleTypeIn(captor.capture());
-        List<RoleType> roleTypes = captor.getValue();
-        Assertions.assertEquals(2, roleTypes.size());
-        Assertions.assertEquals(RoleType.EXTERNAL, roleTypes.getFirst());
-        Assertions.assertEquals(RoleType.INTERNAL_AND_EXTERNAL, roleTypes.get(1));
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(mockAppRoleRepository).findByUserTypeRestrictionContains(captor.capture());
+        String userTypeString = captor.getValue();
+        Assertions.assertEquals(UserType.EXTERNAL.name(), userTypeString);
     }
 
     @Test
@@ -1123,19 +1118,19 @@ class UserServiceTest {
         AppRole internalRole = AppRole.builder()
                 .name("Test Internal Role")
                 .ordinal(2)
-                .roleType(RoleType.INTERNAL)
+                .userTypeRestriction(new UserType[] {UserType.INTERNAL})
                 .app(testApp)
                 .build();
         AppRole externalRole = AppRole.builder()
                 .name("Test External Role")
                 .ordinal(3)
-                .roleType(RoleType.EXTERNAL)
+                .userTypeRestriction(new UserType[] {UserType.EXTERNAL})
                 .app(testApp)
                 .build();
         AppRole internalAndExternalRole = AppRole.builder()
                 .name("Test Internal And External Role")
                 .ordinal(1)
-                .roleType(RoleType.INTERNAL_AND_EXTERNAL)
+                .userTypeRestriction(new UserType[] {UserType.INTERNAL, UserType.EXTERNAL})
                 .app(testApp)
                 .build();
 
@@ -1147,7 +1142,7 @@ class UserServiceTest {
         Assertions.assertEquals(2, returnedAppRoles.size());
         // Check no external app roles in response
         Assertions
-                .assertTrue(returnedAppRoles.stream().noneMatch(role -> role.getRoleType().equals(RoleType.EXTERNAL)));
+                .assertTrue(returnedAppRoles.stream().flatMap(role -> Arrays.stream(role.getUserTypeRestriction())).anyMatch(userType -> userType == UserType.INTERNAL));
         Assertions.assertEquals(returnedAppRoles.get(0).getName(), internalAndExternalRole.getName());
         Assertions.assertEquals(returnedAppRoles.get(1).getName(), internalRole.getName());
     }
@@ -1159,19 +1154,19 @@ class UserServiceTest {
                 .build();
         AppRole internalRole = AppRole.builder()
                 .name("Test Internal Role")
-                .roleType(RoleType.INTERNAL)
+                .userTypeRestriction(new UserType[] {UserType.INTERNAL})
                 .app(testApp)
                 .ordinal(2)
                 .build();
         AppRole externalRole = AppRole.builder()
                 .name("Test External Role")
-                .roleType(RoleType.EXTERNAL)
+                .userTypeRestriction(new UserType[] {UserType.EXTERNAL})
                 .app(testApp)
                 .ordinal(3)
                 .build();
         AppRole internalAndExternalRole = AppRole.builder()
                 .name("Test Internal And External Role")
-                .roleType(RoleType.INTERNAL_AND_EXTERNAL)
+                .userTypeRestriction(new UserType[] {UserType.INTERNAL, UserType.EXTERNAL})
                 .ordinal(1)
                 .app(testApp)
                 .build();
@@ -1184,7 +1179,7 @@ class UserServiceTest {
         Assertions.assertEquals(2, returnedAppRoles.size());
         // Check no external app roles in response
         Assertions
-                .assertTrue(returnedAppRoles.stream().noneMatch(role -> role.getRoleType().equals(RoleType.INTERNAL)));
+                .assertTrue(returnedAppRoles.stream().flatMap(role -> Arrays.stream(role.getUserTypeRestriction())).anyMatch(userType -> userType == UserType.EXTERNAL));
         Assertions.assertEquals(returnedAppRoles.get(0).getName(), internalAndExternalRole.getName());
         Assertions.assertEquals(returnedAppRoles.get(1).getName(), externalRole.getName());
     }
@@ -2297,17 +2292,17 @@ class UserServiceTest {
         // Given
         AppRole appRole1 = AppRole.builder()
                 .id(UUID.randomUUID())
-                .roleType(RoleType.INTERNAL)
+                .userTypeRestriction(new UserType[] {UserType.INTERNAL})
                 .ordinal(2)
                 .app(App.builder().id(UUID.randomUUID()).name("Internal App").build())
                 .build();
         AppRole appRole2 = AppRole.builder()
                 .id(UUID.randomUUID())
-                .roleType(RoleType.INTERNAL_AND_EXTERNAL)
+                .userTypeRestriction(new UserType[] {UserType.INTERNAL, UserType.EXTERNAL})
                 .ordinal(1)
                 .app(App.builder().id(UUID.randomUUID()).name("Common App").build())
                 .build();
-        when(mockAppRoleRepository.findByRoleTypeIn(List.of(RoleType.INTERNAL, RoleType.INTERNAL_AND_EXTERNAL)))
+        when(mockAppRoleRepository.findByUserTypeRestrictionContains(UserType.INTERNAL.name()))
                 .thenReturn(List.of(appRole1, appRole2));
 
         // When
@@ -2317,7 +2312,7 @@ class UserServiceTest {
         assertThat(result).hasSize(2);
         assertThat(result.stream().map(AppDto::getName))
                 .containsExactly("Internal App", "Common App");
-        verify(mockAppRoleRepository).findByRoleTypeIn(List.of(RoleType.INTERNAL, RoleType.INTERNAL_AND_EXTERNAL));
+        verify(mockAppRoleRepository).findByUserTypeRestrictionContains(UserType.INTERNAL.name());
     }
 
     @Test
@@ -2326,16 +2321,16 @@ class UserServiceTest {
         AppRole appRole1 = AppRole.builder()
                 .id(UUID.randomUUID())
                 .ordinal(2)
-                .roleType(RoleType.EXTERNAL)
+                .userTypeRestriction(new UserType[] {UserType.EXTERNAL})
                 .app(App.builder().id(UUID.randomUUID()).name("External App").ordinal(2).build())
                 .build();
         AppRole appRole2 = AppRole.builder()
                 .id(UUID.randomUUID())
                 .ordinal(1)
-                .roleType(RoleType.INTERNAL_AND_EXTERNAL)
+                .userTypeRestriction(new UserType[] {UserType.INTERNAL, UserType.EXTERNAL})
                 .app(App.builder().id(UUID.randomUUID()).name("Common App").ordinal(1).build())
                 .build();
-        when(mockAppRoleRepository.findByRoleTypeIn(List.of(RoleType.EXTERNAL, RoleType.INTERNAL_AND_EXTERNAL)))
+        when(mockAppRoleRepository.findByUserTypeRestrictionContains(UserType.EXTERNAL.name()))
                 .thenReturn(List.of(appRole1, appRole2));
 
         // When
@@ -2347,7 +2342,7 @@ class UserServiceTest {
                 IntStream.range(0, 2)
                         .allMatch(i -> result.get(i).getName().equals(Arrays.asList("Common App", "External App").get(i))))
                 .isTrue();
-        verify(mockAppRoleRepository).findByRoleTypeIn(List.of(RoleType.EXTERNAL, RoleType.INTERNAL_AND_EXTERNAL));
+        verify(mockAppRoleRepository).findByUserTypeRestrictionContains(UserType.EXTERNAL.name());
     }
 
     @Test
@@ -2356,15 +2351,15 @@ class UserServiceTest {
         App sharedApp = App.builder().id(UUID.randomUUID()).name("Shared App").build();
         AppRole appRole1 = AppRole.builder()
                 .id(UUID.randomUUID())
-                .roleType(RoleType.INTERNAL)
+                .userTypeRestriction(new UserType[] {UserType.INTERNAL})
                 .app(sharedApp)
                 .build();
         AppRole appRole2 = AppRole.builder()
                 .id(UUID.randomUUID())
-                .roleType(RoleType.INTERNAL_AND_EXTERNAL)
+                .userTypeRestriction(new UserType[] {UserType.INTERNAL, UserType.EXTERNAL})
                 .app(sharedApp)
                 .build();
-        when(mockAppRoleRepository.findByRoleTypeIn(List.of(RoleType.INTERNAL, RoleType.INTERNAL_AND_EXTERNAL)))
+        when(mockAppRoleRepository.findByUserTypeRestrictionContains(UserType.INTERNAL.name()))
                 .thenReturn(List.of(appRole1, appRole2));
 
         // When
@@ -2373,7 +2368,7 @@ class UserServiceTest {
         // Then - Should only appear once due to distinct()
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getName()).isEqualTo("Shared App");
-        verify(mockAppRoleRepository).findByRoleTypeIn(List.of(RoleType.INTERNAL, RoleType.INTERNAL_AND_EXTERNAL));
+        verify(mockAppRoleRepository).findByUserTypeRestrictionContains(UserType.INTERNAL.name());
     }
 
     @Test
@@ -2791,7 +2786,7 @@ class UserServiceTest {
                     .description("Old Role Description")
                     .ccmsCode("CCMS_OLD")
                     .legacySync(true)
-                    .roleType(RoleType.EXTERNAL)
+                    .userTypeRestriction(new UserType[] {UserType.EXTERNAL})
                     .authzRole(false)
                     .build();
 
@@ -2801,7 +2796,7 @@ class UserServiceTest {
                     .description("New Role Description")
                     .ccmsCode("CCMS_NEW")
                     .legacySync(true)
-                    .roleType(RoleType.EXTERNAL)
+                    .userTypeRestriction(new UserType[] {UserType.EXTERNAL})
                     .authzRole(false)
                     .build();
 
@@ -2857,7 +2852,7 @@ class UserServiceTest {
                     .description("New Role Description")
                     .ccmsCode("CCMS_NEW")
                     .legacySync(true)
-                    .roleType(RoleType.EXTERNAL)
+                    .userTypeRestriction(new UserType[] {UserType.EXTERNAL})
                     .authzRole(false)
                     .build();
 
@@ -2922,7 +2917,7 @@ class UserServiceTest {
                     .id(UUID.fromString(selectedRoles.get(0)))
                     .name("NON_PUI_ROLE")
                     .legacySync(false)
-                    .roleType(RoleType.EXTERNAL)
+                    .userTypeRestriction(new UserType[] {UserType.EXTERNAL})
                     .authzRole(false)
                     .build();
 


### PR DESCRIPTION
 ### Description :pencil:

The RoleType column in our AppRole table is now obsolete after the introduction of UserTypeRestriction. Cleaning up the code base to remove RoleType and now solely use UserTypeRestriction.

### Changes Made :pencil:

- Added migrations to populate userTypeRestriction with current RoleType values.
- Removed RoleType Column.
- Changed any logic using RoleType to now use UserTypeRestriction.
-  Updated Unit and Integration tests.

---

### Checklist :pencil:

- [X] I have added the relevant Liquibase changelog files for any entity changes
- [X] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [X] I have taken into account the application runs as 3 replicas in live environments
- [X] I have created any relevant documentation for this change
- [X] I have a corresponding JIRA ticket for this change 
- [X] I have added relevant unit & integration tests where applicable

