### PR TITLE
STB-2791: Test single line logging on live environments

### DIFF
--- a/.github/workflows/check_env_vars.yml
+++ b/.github/workflows/check_env_vars.yml
@@ -38,6 +38,7 @@ jobs:
             "POSTGRES_PASSWORD"
             "POSTGRES_USERNAME"
             "INTERNAL_USER_SECURITY_GROUP"
+            "CONSOLE_LOG_PATTERN"
           )
           # --------------------------------------------------------------------------
 

--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,9 @@ dependencies {
     // Validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    // Logging
+    implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
+
     // Spring Retry for declarative retry logic
     implementation 'org.springframework.retry:spring-retry'
     implementation 'org.springframework:spring-aspects'

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <springProperty scope="context" name="LOG_LEVEL" source="logging.level.root" defaultValue="INFO"/>
+
+    <appender name="CONSOLE_PLAIN" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="CONSOLE_JSON" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
+    </appender>
+
+    <springProfile name="local">
+        <root level="${LOG_LEVEL}">
+            <appender-ref ref="CONSOLE_PLAIN" />
+        </root>
+    </springProfile>
+
+    <springProfile name="!local">
+        <root level="${LOG_LEVEL}">
+            <appender-ref ref="CONSOLE_JSON" />
+        </root>
+    </springProfile>
+
+</configuration>


### PR DESCRIPTION
### Description :pencil:

Currently it is very hard to look at logs in OpenSearch due to stack traces being printed line by line - this change makes it so things are printed as a one line JSON instead when on a live environment.

I am unsure how OpenSearch will react so need to deploy this to test it.

---

### Changes Made :pencil:

- Logs are now printed as JSON in live environments

---

### Checklist :pencil:

- [x] I have added the relevant Liquibase changelog files for any entity changes
- [x] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [x] I have taken into account the application runs as 3 replicas in live environments
- [x] I have created any relevant documentation for this change
- [x] I have a corresponding JIRA ticket for this change 
- [x] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:

Please fill in.

---