### PR TITLE
STB-2772: Added new Internal User Viewer and External User Viewer Roles.

### DIFF
--- a/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/RoleBaseAccessEditUserRoleTest.java
+++ b/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/RoleBaseAccessEditUserRoleTest.java
@@ -77,6 +77,38 @@ public class RoleBaseAccessEditUserRoleTest extends RoleBasedAccessIntegrationTe
 
     @Test
     @Transactional
+    public void testGlobalAdminCanAssignInternalUserViewerRoleToInternalUser() throws Exception {
+        EntraUser loggedInUser = globalAdmins.getFirst();
+        EntraUser editedUser = internalUsersNoRoles.getFirst();
+        assignAuthzRoleToUser(loggedInUser, editedUser, "Internal User Viewer", true);
+    }
+
+    @Test
+    @Transactional
+    public void testGlobalAdminCannotAssignInternalUserViewerRoleToExternalUser() throws Exception {
+        EntraUser loggedInUser = globalAdmins.getFirst();
+        EntraUser editedUser = externalUsersNoRoles.getFirst();
+        assignAuthzRoleToUser(loggedInUser, editedUser, "Internal User Viewer", false);
+    }
+
+    @Test
+    @Transactional
+    public void testGlobalAdminCanAssignExternalUserViewerRoleToInternalUser() throws Exception {
+        EntraUser loggedInUser = globalAdmins.getFirst();
+        EntraUser editedUser = internalUsersNoRoles.getFirst();
+        assignAuthzRoleToUser(loggedInUser, editedUser, "External User Viewer", true);
+    }
+
+    @Test
+    @Transactional
+    public void testGlobalAdminCannotAssignExternalUserViewerRoleToExternalUser() throws Exception {
+        EntraUser loggedInUser = globalAdmins.getFirst();
+        EntraUser editedUser = externalUsersNoRoles.getFirst();
+        assignAuthzRoleToUser(loggedInUser, editedUser, "External User Viewer", false);
+    }
+
+    @Test
+    @Transactional
     public void testInternalUserManagerCanAssignInternalUserManagerRoleToInternalUser() throws Exception {
         EntraUser loggedInUser = internalUserManagers.getFirst();
         EntraUser editedUser = internalUsersNoRoles.getFirst();
@@ -89,6 +121,22 @@ public class RoleBaseAccessEditUserRoleTest extends RoleBasedAccessIntegrationTe
         EntraUser loggedInUser = internalUserManagers.getFirst();
         EntraUser editedUser = internalUsersNoRoles.getFirst();
         assignAuthzRoleToUser(loggedInUser, editedUser, "External User Manager", true);
+    }
+
+    @Test
+    @Transactional
+    public void testInternalUserManagerCanAssignInternalUserViewerRoleToInternalUser() throws Exception {
+        EntraUser loggedInUser = internalUserManagers.getFirst();
+        EntraUser editedUser = internalUsersNoRoles.getFirst();
+        assignAuthzRoleToUser(loggedInUser, editedUser, "Internal User Viewer", true);
+    }
+
+    @Test
+    @Transactional
+    public void testInternalUserManagerCanAssignExternalUserViewerRoleToInternalUser() throws Exception {
+        EntraUser loggedInUser = internalUserManagers.getFirst();
+        EntraUser editedUser = internalUsersNoRoles.getFirst();
+        assignAuthzRoleToUser(loggedInUser, editedUser, "External User Viewer", true);
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/RoleBasedAccessEditUserTest.java
+++ b/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/RoleBasedAccessEditUserTest.java
@@ -120,6 +120,26 @@ public class RoleBasedAccessEditUserTest extends RoleBasedAccessIntegrationTest 
         canOpenEditScreen(externalUserManagerFirm1, externalUserFirm1, status().isOk());
     }
 
+    @Test
+    public void testInternalUserViewerCannotOpenInternalUserAppsToEdit() throws Exception {
+        canOpenEditScreen(internalUserViewers.getFirst(), internalUsersNoRoles.getFirst(), status().is3xxRedirection());
+    }
+
+    @Test
+    public void testInternalUserViewerCannotOpenExternalUserAppsToEdit() throws Exception {
+        canOpenEditScreen(internalUserViewers.getFirst(), externalUsersNoRoles.getFirst(), status().is3xxRedirection());
+    }
+
+    @Test
+    public void testExternalUserViewerCannotOpenInternalUserAppsToEdit() throws Exception {
+        canOpenEditScreen(externalUserViewers.getFirst(), internalUsersNoRoles.getFirst(), status().is3xxRedirection());
+    }
+
+    @Test
+    public void testExternalUserViewerCannotOpenExternalUserAppsToEdit() throws Exception {
+        canOpenEditScreen(externalUserViewers.getFirst(), externalUsersNoRoles.getFirst(), status().is3xxRedirection());
+    }
+
 
     private void canOpenEditScreen(EntraUser loggedInUser, EntraUser editedUser, ResultMatcher expectedResult) throws Exception {
         UserProfile accessedUserProfile = editedUser.getUserProfiles().stream().findFirst().orElseThrow();

--- a/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/RoleBasedAccessGrantAccessTest.java
+++ b/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/RoleBasedAccessGrantAccessTest.java
@@ -118,6 +118,26 @@ public class RoleBasedAccessGrantAccessTest extends RoleBasedAccessIntegrationTe
         canOpenGrantAccessScreen(externalUserManagerFirm1, externalUserFirm1, status().isOk());
     }
 
+    @Test
+    public void testInternalUserViewerCannotOpenInternalUserAppsToGrantAccess() throws Exception {
+        canOpenGrantAccessScreen(internalUserViewers.getFirst(), internalUsersNoRoles.getFirst(), status().is3xxRedirection());
+    }
+
+    @Test
+    public void testInternalUserViewerCannotOpenExternalUserAppsToGrantAccess() throws Exception {
+        canOpenGrantAccessScreen(internalUserViewers.getFirst(), externalUsersNoRoles.getFirst(), status().is3xxRedirection());
+    }
+
+    @Test
+    public void testExternalUserViewerCannotOpenInternalUserAppsToGrantAccess() throws Exception {
+        canOpenGrantAccessScreen(externalUserViewers.getFirst(), internalUsersNoRoles.getFirst(), status().is3xxRedirection());
+    }
+
+    @Test
+    public void testExternalUserViewerCannotOpenExternalUserAppsToGrantAccess() throws Exception {
+        canOpenGrantAccessScreen(externalUserViewers.getFirst(), externalUsersNoRoles.getFirst(), status().is3xxRedirection());
+    }
+
 
     private void canOpenGrantAccessScreen(EntraUser loggedInUser, EntraUser editedUser, ResultMatcher expectedResult) throws Exception {
         UserProfile accessedUserProfile = editedUser.getUserProfiles().stream().findFirst().orElseThrow();

--- a/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/RoleBasedAccessIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/RoleBasedAccessIntegrationTest.java
@@ -57,6 +57,8 @@ public abstract class RoleBasedAccessIntegrationTest extends BaseIntegrationTest
     protected List<EntraUser> externalOnlyUserManagers = new ArrayList<>();
     protected List<EntraUser> externalUsersNoRoles = new ArrayList<>();
     protected List<EntraUser> externalUserAdmins = new ArrayList<>();
+    protected List<EntraUser> internalUserViewers = new ArrayList<>();
+    protected List<EntraUser> externalUserViewers = new ArrayList<>();
     protected List<EntraUser> globalAdmins = new ArrayList<>();
     protected List<EntraUser> allUsers = new ArrayList<>();
 
@@ -228,6 +230,33 @@ public abstract class RoleBasedAccessIntegrationTest extends BaseIntegrationTest
         profile.setEntraUser(user);
         globalAdmins.add(entraUserRepository.saveAndFlush(user));
 
+        // Set up Internal User Viewer
+        user = buildEntraUser(UUID.randomUUID().toString(), String.format("test%d@test.com", emailIndex++), "Internal", "UserViewer");
+        profile = buildLaaUserProfile(user, UserType.INTERNAL, true);
+        appRole = allAppRoles.stream()
+                .filter(AppRole::isAuthzRole)
+                .filter(role -> role.getName().equals("Internal User Viewer"))
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("Could not find app role"));
+        profile.setAppRoles(Set.of(appRole));
+        user.setUserProfiles(Set.of(profile));
+        profile.setEntraUser(user);
+        internalUserViewers.add(entraUserRepository.saveAndFlush(user));
+
+        // Set up External User Viewer
+        user = buildEntraUser(UUID.randomUUID().toString(), String.format("test%d@test.com", emailIndex++), "External", "UserViewer");
+        profile = buildLaaUserProfile(user, UserType.INTERNAL, true);
+        appRole = allAppRoles.stream()
+                .filter(AppRole::isAuthzRole)
+                .filter(role -> role.getName().equals("External User Viewer"))
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("Could not find app role"));
+        profile.setAppRoles(Set.of(appRole));
+        user.setUserProfiles(Set.of(profile));
+        profile.setEntraUser(user);
+        externalUserViewers.add(entraUserRepository.saveAndFlush(user));
+
+
         allUsers.addAll(internalUsersNoRoles);
         allUsers.addAll(internalUserManagers);
         allUsers.addAll(internalAndExternalUserManagers);
@@ -236,6 +265,8 @@ public abstract class RoleBasedAccessIntegrationTest extends BaseIntegrationTest
         allUsers.addAll(externalUsersNoRoles);
         allUsers.addAll(externalUserAdmins);
         allUsers.addAll(globalAdmins);
+        allUsers.addAll(internalUserViewers);
+        allUsers.addAll(externalUserViewers);
     }
 
     protected void clearRepositories() {

--- a/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/RoleBasedAccessUserListTest.java
+++ b/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/RoleBasedAccessUserListTest.java
@@ -270,4 +270,42 @@ public class RoleBasedAccessUserListTest extends RoleBasedAccessIntegrationTest 
         }
     }
 
+    @Test
+    public void testInternalUserViewerCanSeeAllInternalUsers() throws Exception {
+        EntraUser loggedInUser = internalUserViewers.getFirst();
+        MvcResult result = this.mockMvc.perform(get("/admin/users?size=100")
+                        .with(userOauth2Login(loggedInUser)))
+                .andExpect(status().isOk())
+                .andExpect(view().name("users"))
+                .andReturn();
+        ModelAndView modelAndView = result.getModelAndView();
+        List<UserProfileDto> users = (List<UserProfileDto>) modelAndView.getModel().get("users");
+        int expectedSize = (int) allUsers.stream()
+                .filter(user -> user.getUserProfiles().stream().findFirst().orElseThrow().getUserType() == UserType.INTERNAL)
+                .count();
+        Assertions.assertThat(users).hasSize(expectedSize);
+        for (UserProfileDto userProfile : users) {
+            Assertions.assertThat(userProfile.getUserType()).isEqualTo(UserType.INTERNAL);
+        }
+    }
+
+    @Test
+    public void testExternalUserViewerCanSeeAllExternalUsers() throws Exception {
+        EntraUser loggedInUser = externalUserViewers.getFirst();
+        MvcResult result = this.mockMvc.perform(get("/admin/users?size=100")
+                        .with(userOauth2Login(loggedInUser)))
+                .andExpect(status().isOk())
+                .andExpect(view().name("users"))
+                .andReturn();
+        ModelAndView modelAndView = result.getModelAndView();
+        List<UserProfileDto> users = (List<UserProfileDto>) modelAndView.getModel().get("users");
+        int expectedSize = (int) allUsers.stream()
+                .filter(user -> user.getUserProfiles().stream().findFirst().orElseThrow().getUserType() == UserType.EXTERNAL)
+                .count();
+        Assertions.assertThat(users).hasSize(expectedSize);
+        for (UserProfileDto userProfile : users) {
+            Assertions.assertThat(userProfile.getUserType()).isEqualTo(UserType.EXTERNAL);
+        }
+    }
+
 }

--- a/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/RoleBasedAccessViewCreateUserPageTest.java
+++ b/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/RoleBasedAccessViewCreateUserPageTest.java
@@ -50,6 +50,20 @@ public class RoleBasedAccessViewCreateUserPageTest extends RoleBasedAccessIntegr
     }
 
     @Test
+    public void testInternalUserViewerCannotAccessCreateUserPage() throws Exception {
+        MvcResult result = accessCreateUserScreen(internalUserViewers.getFirst(), status().is3xxRedirection());
+        assertThat(result.getResponse()).isNotNull();
+        assertThat(result.getResponse().getRedirectedUrl()).isEqualTo("/not-authorised");
+    }
+
+    @Test
+    public void testExternalUserViewerCannotAccessCreateUserPage() throws Exception {
+        MvcResult result = accessCreateUserScreen(externalUserViewers.getFirst(), status().is3xxRedirection());
+        assertThat(result.getResponse()).isNotNull();
+        assertThat(result.getResponse().getRedirectedUrl()).isEqualTo("/not-authorised");
+    }
+
+    @Test
     public void testInternalUserWithNoRolesCannotAccessCreateUserPage() throws Exception {
         accessCreateUserScreen(internalUsersNoRoles.getFirst(), status().isForbidden());
     }

--- a/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/RoleBasedAccessViewUserTest.java
+++ b/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/RoleBasedAccessViewUserTest.java
@@ -200,6 +200,27 @@ public class RoleBasedAccessViewUserTest extends RoleBasedAccessIntegrationTest 
         testCanAccessUser(loggedInUser, accessedUserFirmTwo, status().isOk());
     }
 
+    @Test
+    public void testInternalUserViewerCanAccessInternalUserProfile() throws Exception {
+        testCanAccessUser(internalUserViewers.getFirst(), internalUsersNoRoles.getFirst(), status().isOk());
+    }
+
+    @Test
+    public void testInternalUserViewerCannotAccessExternalUserProfile() throws Exception {
+        testCanAccessUser(internalUserViewers.getFirst(), externalUsersNoRoles.getFirst(), status().is3xxRedirection());
+    }
+
+    @Test
+    public void testExternalUserViewerCanAccessExternalUserProfile() throws Exception {
+        testCanAccessUser(externalUserViewers.getFirst(), externalUsersNoRoles.getFirst(), status().isOk());
+    }
+
+    @Test
+    public void testExternalUserViewerCannotAccessInternalUserProfile() throws Exception {
+        testCanAccessUser(externalUserViewers.getFirst(), internalUsersNoRoles.getFirst(), status().is3xxRedirection());
+    }
+
+
 
     public void testCanAccessUser(EntraUser loggedInUser, EntraUser accessedUser, ResultMatcher expectedResult) throws Exception {
         UserProfile accessedUserProfile = accessedUser.getUserProfiles().stream().findFirst().get();

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
@@ -37,6 +37,7 @@ import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import software.amazon.awssdk.services.sqs.endpoints.internal.Value;
 import uk.gov.justice.laa.portal.landingpage.constants.ModelAttributes;
 import uk.gov.justice.laa.portal.landingpage.dto.AppDto;
 import uk.gov.justice.laa.portal.landingpage.dto.AppRoleDto;
@@ -282,6 +283,7 @@ public class UserController {
                 .collect(Collectors.toList());
         List<OfficeDto> userOffices = optionalUser.get().getOffices();
         final Boolean isAccessGranted = userService.isAccessGranted(optionalUser.get().getId().toString());
+        final Boolean canEditUser = accessControlService.canEditUser(optionalUser.get().getId().toString());
         optionalUser.ifPresent(user -> model.addAttribute("user", user));
         model.addAttribute("userAppRoles", userAppRoles);
         model.addAttribute("userOffices", userOffices);
@@ -290,7 +292,8 @@ public class UserController {
         model.addAttribute("externalUser", externalUser);
         boolean showOfficesTab = externalUser; // Hide for internal users, show for external users
         model.addAttribute("showOfficesTab", showOfficesTab);
-        
+
+        model.addAttribute("canEditUser", canEditUser);
         model.addAttribute(ModelAttributes.PAGE_TITLE, "Manage user - " + optionalUser.get().getFullName());
 
         // Add filter state to model for "Back to search results" link

--- a/src/main/resources/db/changelog/changesets/db.changesets-3.2.yaml
+++ b/src/main/resources/db/changelog/changesets/db.changesets-3.2.yaml
@@ -1,0 +1,34 @@
+databaseChangeLog:
+  - changeSet:
+      id: 1755695455405-1
+      author: niall.mcmahon
+      changes:
+        # Insert new internal and external user viewer roles into app role table.
+        - sql:
+            dbms: postgresql
+            sql: "INSERT INTO app_role (app_id, id, name, description, user_type_restriction, authz_role) VALUES ((SELECT id from app WHERE name = 'Manage Your Users'), gen_random_uuid(), 'Internal User Viewer', 'An internal user able to view details about internal users', ARRAY['INTERNAL'], true)"
+        - sql:
+            dbms: postgresql
+            sql: "INSERT INTO app_role (app_id, id, name, description, user_type_restriction, authz_role) VALUES ((SELECT id from app WHERE name = 'Manage Your Users'), gen_random_uuid(), 'External User Viewer', 'An internal user able to view details about external users', ARRAY['INTERNAL'], true)"
+        # Give internal user viewer the VIEW_INTERNAL_USER permission
+        - sql:
+            dbms: postgresql
+            sql: "INSERT INTO role_permission (app_role_id, permission) VALUES ((SELECT id FROM app_role WHERE name = 'Internal User Viewer'), 'VIEW_INTERNAL_USER')"
+        # Give external user viewer the VIEW_EXTERNAL_USER permission
+        - sql:
+            dbms: postgresql
+            sql: "INSERT INTO role_permission (app_role_id, permission) VALUES ((SELECT id FROM app_role WHERE name = 'External User Viewer'), 'VIEW_EXTERNAL_USER')"
+        # Give Global Admin the ability to assign the Internal User Viewer and External User Viewer roles.
+        - sql:
+            dbms: postgresql
+            sql: "INSERT INTO role_assignment (assignable_role_id, assigning_role_id) VALUES ((SELECT id FROM app_role WHERE name = 'Internal User Viewer'), (SELECT id FROM app_role WHERE name = 'Global Admin'))"
+        - sql:
+            dbms: postgresql
+            sql: "INSERT INTO role_assignment (assignable_role_id, assigning_role_id) VALUES ((SELECT id FROM app_role WHERE name = 'External User Viewer'), (SELECT id FROM app_role WHERE name = 'Global Admin'))"
+        # Give Internal User Manager the ability to assign the Internal User Viewer and External User Viewer roles.
+        - sql:
+            dbms: postgresql
+            sql: "INSERT INTO role_assignment (assignable_role_id, assigning_role_id) VALUES ((SELECT id FROM app_role WHERE name = 'Internal User Viewer'), (SELECT id FROM app_role WHERE name = 'Internal User Manager'))"
+        - sql:
+            dbms: postgresql
+            sql: "INSERT INTO role_assignment (assignable_role_id, assigning_role_id) VALUES ((SELECT id FROM app_role WHERE name = 'External User Viewer'), (SELECT id FROM app_role WHERE name = 'Internal User Manager'))"

--- a/src/main/resources/templates/manage-user.html
+++ b/src/main/resources/templates/manage-user.html
@@ -39,7 +39,7 @@
                         <strong th:if="${isAccessGranted}"
                             class="govuk-tag govuk-tag--green govuk-!-font-weight-bold govuk-!-margin-top-1">COMPLETE</strong>
                     </div>
-                    <form class="form" th:if="${!isAccessGranted}"
+                    <form class="form" th:if="${!isAccessGranted and canEditUser}"
                         th:action="@{'/admin/users/manage/' + ${user.id} + '/grant-access'}" method="post">
                         <div class="moj-page-header-actions__actions">
                             <div class="moj-button-group moj-button-group--inline">
@@ -111,7 +111,7 @@
                                 <h2 class="govuk-summary-card__title">
                                     Services
                                 </h2>
-                                <ul th:if="${isAccessGranted}" class="govuk-summary-card__actions">
+                                <ul th:if="${isAccessGranted and canEditUser}" class="govuk-summary-card__actions">
                                     <li class="govuk-summary-card__action">
                                         <a class="govuk-link"
                                             th:href="@{'/admin/users/edit/' + ${user.id} + '/apps'}">Change</a>
@@ -137,7 +137,7 @@
                                 <h2 class="govuk-summary-card__title">
                                     Offices
                                 </h2>
-                                <ul th:if="${isAccessGranted}" class="govuk-summary-card__actions">
+                                <ul th:if="${isAccessGranted and canEditUser}" class="govuk-summary-card__actions">
                                     <li class="govuk-summary-card__action">
                                         <a class="govuk-link"
                                             th:href="@{'/admin/users/edit/' + ${user.id} + '/offices'}">Change</a>


### PR DESCRIPTION
### Description :pencil:

New roles were added to our database that can allow internal users to view internal and external users without being able to edit them.

---

### Changes Made :pencil:

- Changed manage user page to only display the "manage user" and "change" if the logged in user is able to edit the accessed user.
- Added DB migrations to add the new roles and their relevant permissions.
- Added integration tests to test new role permissions.

---

### Checklist :pencil:

- [X] I have added the relevant Liquibase changelog files for any entity changes
- [X] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [X] I have taken into account the application runs as 3 replicas in live environments
- [X] I have created any relevant documentation for this change
- [X] I have a corresponding JIRA ticket for this change 
- [X] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:


---