### PR TITLE
STB-2697 - Stop users from accessing an internal users offices via URL

### DIFF
--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
@@ -37,7 +37,6 @@ import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import software.amazon.awssdk.services.sqs.endpoints.internal.Value;
 import uk.gov.justice.laa.portal.landingpage.constants.ModelAttributes;
 import uk.gov.justice.laa.portal.landingpage.dto.AppDto;
 import uk.gov.justice.laa.portal.landingpage.dto.AppRoleDto;
@@ -45,7 +44,6 @@ import uk.gov.justice.laa.portal.landingpage.dto.CreateUserAuditEvent;
 import uk.gov.justice.laa.portal.landingpage.dto.CurrentUserDto;
 import uk.gov.justice.laa.portal.landingpage.dto.EntraUserDto;
 import uk.gov.justice.laa.portal.landingpage.dto.FirmDto;
-import uk.gov.justice.laa.portal.landingpage.dto.OfficeData;
 import uk.gov.justice.laa.portal.landingpage.dto.OfficeDto;
 import uk.gov.justice.laa.portal.landingpage.dto.UpdateUserAuditEvent;
 import uk.gov.justice.laa.portal.landingpage.dto.UserProfileDto;
@@ -76,7 +74,6 @@ import uk.gov.justice.laa.portal.landingpage.service.UserService;
 import uk.gov.justice.laa.portal.landingpage.utils.CcmsRoleGroupsUtil;
 import uk.gov.justice.laa.portal.landingpage.utils.UserUtils;
 import uk.gov.justice.laa.portal.landingpage.viewmodel.AppRoleViewModel;
-import uk.gov.justice.laa.portal.landingpage.viewmodel.AppViewModel;
 
 /**
  * User Controller
@@ -290,8 +287,12 @@ public class UserController {
         model.addAttribute("isAccessGranted", isAccessGranted);
         boolean externalUser = UserType.EXTERNAL == optionalUser.get().getUserType();
         model.addAttribute("externalUser", externalUser);
-        boolean showOfficesTab = externalUser; // Hide for internal users, show for external users
-        model.addAttribute("showOfficesTab", showOfficesTab);
+        
+        // Check if current user can manage offices - align with actual endpoint authorization
+        boolean canManageOffices = externalUser 
+                && accessControlService.authenticatedUserHasPermission(Permission.EDIT_USER_OFFICE)
+                && canEditUser;
+        model.addAttribute("showOfficesTab", canManageOffices);
 
         model.addAttribute("canEditUser", canEditUser);
         model.addAttribute(ModelAttributes.PAGE_TITLE, "Manage user - " + optionalUser.get().getFullName());


### PR DESCRIPTION
Stop users from accessing an internal users offices via URL


Improvements to authorisation logic:

* The logic for showing the "Offices" tab in `UserController` now checks both if the user is external and if the current user has the `EDIT_USER_OFFICE` permission and can edit the user, rather than just checking if the user is external. (`src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java`)

Test coverage enhancements:

* Added a new test to verify that the "Offices" tab is hidden for external users who lack the necessary permissions. (`src/test/java/uk/gov/justice/laa/portal/landingpage/controller/UserControllerTest.java`)
* Updated the test for showing the "Offices" tab to ensure both edit and office permissions are present. (`src/test/java/uk/gov/justice/laa/portal/landingpage/controller/UserControllerTest.java`)

Code cleanup:

* Removed unused imports from `UserController.java` for better maintainability. (`src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java`) [[1]](diffhunk://#diff-1c3931784714b5992966f392b56dad9140ea42ba7303dfce45c2cb8533ed3885L40-L48) [[2]](diffhunk://#diff-1c3931784714b5992966f392b56dad9140ea42ba7303dfce45c2cb8533ed3885L79)