### PR TITLE
STB-2834 - Stop oauth null pointer due to pressing logout multiple times

### DIFF
--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/service/CustomLogoutHandlerTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/service/CustomLogoutHandlerTest.java
@@ -1,23 +1,26 @@
 package uk.gov.justice.laa.portal.landingpage.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
@@ -34,6 +37,8 @@ public class CustomLogoutHandlerTest {
     private LoginService loginService;
     @Mock
     private LogoutService logoutService;
+    @Mock
+    private OAuth2AuthorizedClient mockClient;
 
     @Test
     public void getClient() {
@@ -42,6 +47,9 @@ public class CustomLogoutHandlerTest {
                 Map.of("name", "Alice", "preferred_username", "alice@laa.gov.uk"),
                 "name");
         OAuth2AuthenticationToken realAuthToken = new OAuth2AuthenticationToken(realPrincipal, realPrincipal.getAuthorities(), "azure");
+        
+        when(clientService.loadAuthorizedClient(eq("azure"), eq("Alice"))).thenReturn(mockClient);
+        
         logoutHandler.getClient(realAuthToken);
         verify(clientService).loadAuthorizedClient(eq("azure"), eq("Alice"));
     }
@@ -56,11 +64,14 @@ public class CustomLogoutHandlerTest {
                 "name");
         OAuth2AuthenticationToken realAuthToken = new OAuth2AuthenticationToken(realPrincipal, realPrincipal.getAuthorities(), "azure");
 
+        when(clientService.loadAuthorizedClient(eq("azure"), eq("Alice"))).thenReturn(mockClient);
+
         logoutHandler.logout(request, response, realAuthToken);
         
         verify(clientService).loadAuthorizedClient(eq("azure"), eq("Alice"));
-        verify(loginService).logout(any(), any());
+        verify(loginService).logout(eq(realAuthToken), eq(mockClient));
         // Should not call LogoutService.buildAzureLogoutUrl() when azure_logout parameter is not present
+        verify(logoutService, never()).buildAzureLogoutUrl();
     }
 
     @Test
@@ -74,12 +85,13 @@ public class CustomLogoutHandlerTest {
                 "name");
         OAuth2AuthenticationToken realAuthToken = new OAuth2AuthenticationToken(realPrincipal, realPrincipal.getAuthorities(), "azure");
 
+        when(clientService.loadAuthorizedClient(eq("azure"), eq("Alice"))).thenReturn(mockClient);
         when(logoutService.buildAzureLogoutUrl()).thenReturn("https://login.microsoftonline.com/tenant-id/oauth2/v2.0/logout?post_logout_redirect_uri=http%3A//localhost%3A8080/%3Fmessage%3Dlogout");
 
         logoutHandler.logout(request, response, realAuthToken);
         
         verify(clientService).loadAuthorizedClient(eq("azure"), eq("Alice"));
-        verify(loginService).logout(any(), any());
+        verify(loginService).logout(eq(realAuthToken), eq(mockClient));
         verify(logoutService).buildAzureLogoutUrl();
     }
 
@@ -87,13 +99,13 @@ public class CustomLogoutHandlerTest {
     public void logoutWithAzureLogout_handlesIoException() throws IOException {
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.setParameter("azure_logout", "true");
-        MockHttpServletResponse response = new MockHttpServletResponse();
         OAuth2User realPrincipal = new DefaultOAuth2User(
                 List.of(new SimpleGrantedAuthority("ROLE_USER")),
                 Map.of("name", "Alice", "preferred_username", "alice@laa.gov.uk"),
                 "name");
         OAuth2AuthenticationToken realAuthToken = new OAuth2AuthenticationToken(realPrincipal, realPrincipal.getAuthorities(), "azure");
 
+        when(clientService.loadAuthorizedClient(eq("azure"), eq("Alice"))).thenReturn(mockClient);
         when(logoutService.buildAzureLogoutUrl()).thenReturn("https://login.microsoftonline.com/tenant-id/oauth2/v2.0/logout?post_logout_redirect_uri=http%3A//localhost%3A8080/%3Fmessage%3Dlogout");
         
         // Mock the response to throw IOException when sendRedirect is called
@@ -107,7 +119,7 @@ public class CustomLogoutHandlerTest {
         logoutHandler.logout(request, spyResponse, realAuthToken);
         
         verify(clientService).loadAuthorizedClient(eq("azure"), eq("Alice"));
-        verify(loginService).logout(any(), any());
+        verify(loginService).logout(eq(realAuthToken), eq(mockClient));
         verify(logoutService).buildAzureLogoutUrl();
         
         // Should set fallback response when IOException occurs
@@ -126,10 +138,12 @@ public class CustomLogoutHandlerTest {
                 "name");
         OAuth2AuthenticationToken realAuthToken = new OAuth2AuthenticationToken(realPrincipal, realPrincipal.getAuthorities(), "azure");
 
+        when(clientService.loadAuthorizedClient(eq("azure"), eq("Alice"))).thenReturn(mockClient);
+
         logoutHandler.logout(request, response, realAuthToken);
         
         verify(clientService).loadAuthorizedClient(eq("azure"), eq("Alice"));
-        verify(loginService).logout(any(), any());
+        verify(loginService).logout(eq(realAuthToken), eq(mockClient));
         verify(logoutService, never()).buildAzureLogoutUrl();
     }
 
@@ -144,10 +158,12 @@ public class CustomLogoutHandlerTest {
                 "name");
         OAuth2AuthenticationToken realAuthToken = new OAuth2AuthenticationToken(realPrincipal, realPrincipal.getAuthorities(), "azure");
 
+        when(clientService.loadAuthorizedClient(eq("azure"), eq("Alice"))).thenReturn(mockClient);
+
         logoutHandler.logout(request, response, realAuthToken);
         
         verify(clientService).loadAuthorizedClient(eq("azure"), eq("Alice"));
-        verify(loginService).logout(any(), any());
+        verify(loginService).logout(eq(realAuthToken), eq(mockClient));
         verify(logoutService, never()).buildAzureLogoutUrl();
     }
 
@@ -162,10 +178,12 @@ public class CustomLogoutHandlerTest {
                 "name");
         OAuth2AuthenticationToken realAuthToken = new OAuth2AuthenticationToken(realPrincipal, realPrincipal.getAuthorities(), "azure");
 
+        when(clientService.loadAuthorizedClient(eq("azure"), eq("Alice"))).thenReturn(mockClient);
+
         logoutHandler.logout(request, response, realAuthToken);
         
         verify(clientService).loadAuthorizedClient(eq("azure"), eq("Alice"));
-        verify(loginService).logout(any(), any());
+        verify(loginService).logout(eq(realAuthToken), eq(mockClient));
         verify(logoutService, never()).buildAzureLogoutUrl();
     }
 
@@ -180,11 +198,73 @@ public class CustomLogoutHandlerTest {
                 "name");
         OAuth2AuthenticationToken realAuthToken = new OAuth2AuthenticationToken(realPrincipal, realPrincipal.getAuthorities(), "azure");
 
+        when(clientService.loadAuthorizedClient(eq("azure"), eq("Alice"))).thenReturn(mockClient);
+
         logoutHandler.logout(request, response, realAuthToken);
         
         verify(clientService).loadAuthorizedClient(eq("azure"), eq("Alice"));
-        verify(loginService).logout(any(), any());
+        verify(loginService).logout(eq(realAuthToken), eq(mockClient));
         // Should not call buildAzureLogoutUrl because "TRUE" != "true"
         verify(logoutService, never()).buildAzureLogoutUrl();
+    }
+
+    @Test
+    public void getClient_withNullAuthentication_shouldReturnNull() {
+        assertThat(logoutHandler.getClient(null)).isNull();
+        verify(clientService, never()).loadAuthorizedClient(any(), any());
+    }
+
+    @Test
+    public void getClient_withNonOAuth2Authentication_shouldReturnNull() {
+        UsernamePasswordAuthenticationToken nonOAuthToken = new UsernamePasswordAuthenticationToken("user", "password");
+        
+        assertThat(logoutHandler.getClient(nonOAuthToken)).isNull();
+        verify(clientService, never()).loadAuthorizedClient(any(), any());
+    }
+
+    @Test
+    public void logout_withNullAuthentication_shouldNotCauseNPE() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        // This should not throw any exception
+        logoutHandler.logout(request, response, null);
+        
+        // Should not attempt to call any logout services when authentication is null
+        verify(clientService, never()).loadAuthorizedClient(any(), any());
+        verify(loginService, never()).logout(any(), any());
+    }
+
+    @Test
+    public void logout_withNonOAuth2Authentication_shouldNotCauseNPE() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        UsernamePasswordAuthenticationToken nonOAuthToken = new UsernamePasswordAuthenticationToken("user", "password");
+
+        // This should not throw any exception
+        logoutHandler.logout(request, response, nonOAuthToken);
+        
+        // Should not attempt to call any logout services when authentication is not OAuth2
+        verify(clientService, never()).loadAuthorizedClient(any(), any());
+        verify(loginService, never()).logout(any(), any());
+    }
+
+    @Test
+    public void logout_withNullAuthenticationAndAzureLogout_shouldStillRedirect() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setParameter("azure_logout", "true");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        
+        when(logoutService.buildAzureLogoutUrl()).thenReturn("https://login.microsoftonline.com/tenant-id/oauth2/v2.0/logout?post_logout_redirect_uri=http%3A//localhost%3A8080/%3Fmessage%3Dlogout");
+
+        // This should not throw any exception and should still handle Azure logout
+        logoutHandler.logout(request, response, null);
+        
+        // Should not attempt to call logout services for null authentication
+        verify(clientService, never()).loadAuthorizedClient(any(), any());
+        verify(loginService, never()).logout(any(), any());
+        
+        // But should still handle Azure logout redirect
+        verify(logoutService).buildAzureLogoutUrl();
     }
 }


### PR DESCRIPTION
Stops oauth null exception due to excessive logout spamming.

https://github.com/user-attachments/assets/8c0c72d4-c34c-40bc-aef5-5698db61491a

**Authentication and logout logic improvements:**

* Updated `logout` and `getClient` methods in `CustomLogoutHandler` to check for `null` and ensure authentication is of type `OAuth2AuthenticationToken` before proceeding, preventing unnecessary or unsafe logout operations. [[1]](diffhunk://#diff-e96ddc122fc7b6b658fd63d5bd26bfaeaf37dd32276b6b14c3c0b3f93af204a9R31-R38) [[2]](diffhunk://#diff-e96ddc122fc7b6b658fd63d5bd26bfaeaf37dd32276b6b14c3c0b3f93af204a9R57-R60)

**Unit test enhancements:**

* Added mock setup for `OAuth2AuthorizedClient` and refined verification in tests to ensure `loginService.logout` is called only with correct arguments, and never called for invalid authentication types. [[1]](diffhunk://#diff-32eec55d5ab950f67689c26ad044820ab0dc1caf77ed2d85bbc7f284866d038aR40-R41) [[2]](diffhunk://#diff-32eec55d5ab950f67689c26ad044820ab0dc1caf77ed2d85bbc7f284866d038aR50-R52) [[3]](diffhunk://#diff-32eec55d5ab950f67689c26ad044820ab0dc1caf77ed2d85bbc7f284866d038aR67-R74) [[4]](diffhunk://#diff-32eec55d5ab950f67689c26ad044820ab0dc1caf77ed2d85bbc7f284866d038aR88-R108) [[5]](diffhunk://#diff-32eec55d5ab950f67689c26ad044820ab0dc1caf77ed2d85bbc7f284866d038aL110-R122) [[6]](diffhunk://#diff-32eec55d5ab950f67689c26ad044820ab0dc1caf77ed2d85bbc7f284866d038aR141-R146) [[7]](diffhunk://#diff-32eec55d5ab950f67689c26ad044820ab0dc1caf77ed2d85bbc7f284866d038aR161-R166) [[8]](diffhunk://#diff-32eec55d5ab950f67689c26ad044820ab0dc1caf77ed2d85bbc7f284866d038aR181-R186) [[9]](diffhunk://#diff-32eec55d5ab950f67689c26ad044820ab0dc1caf77ed2d85bbc7f284866d038aR201-R269)

* Added new tests to verify that `getClient` and `logout` methods handle `null` and non-OAuth2 authentication gracefully, without triggering service calls or causing exceptions.

* Ensured that Azure logout redirection is still handled correctly even when authentication is `null`, maintaining expected user experience for explicit logout requests.