### PR TITLE
STB-2782: Add OpenTelemetry to Sentry for DB exports

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'uk.gov.laa.ccms.springboot.laa-ccms-spring-boot-gradle-plugin' version '0.0.32'
-    id "io.sentry.jvm.gradle" version "5.5.0"
+    id "io.sentry.jvm.gradle" version "5.11.0"
 }
 
 ext {
@@ -30,6 +30,7 @@ sentry {
   authToken = System.getenv("SENTRY_AUTH_TOKEN")
 
   autoInstallation {
+    sentryVersion = "8.16.0"
     enabled = true
   }
 }
@@ -56,6 +57,7 @@ configurations {
 }
 
 dependencies {
+    implementation 'io.sentry:sentry-opentelemetry-agentless-spring:8.16.0'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -84,6 +84,11 @@ sentry.enabled=${SENTRY_ENABLED:true}
 sentry.environment=${SENTRY_ENVIRONMENT:local}
 sentry.traces-sample-rate=${SENTRY_SAMPLE_RATE:0.05}
 
+# Turn off standard OTEL exporters - only Sentry is needed
+otel.logs.exporter=none
+otel.traces.exporter=none
+otel.metrics.exporter=none
+
 # Expose prometheus metrics endpoint
 management.endpoints.web.exposure.include=health,prometheus
 


### PR DESCRIPTION
### Description :pencil:

Add OpenTelemetry to Sentry to allow DB exports

---

### Changes Made :pencil:

- Add OpenTelemetry to Sentry to allow DB exports


---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [ ] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [ ] I have a corresponding JIRA ticket for this change 
- [ ] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:

Please fill in.

---