### PR TITLE
STB-2865 - Assign External users with Firm User Manager where they we…

### DIFF
--- a/src/main/resources/db/changelog/changesets/db.changesets-3.4.yaml
+++ b/src/main/resources/db/changelog/changesets/db.changesets-3.4.yaml
@@ -1,0 +1,23 @@
+databaseChangeLog:
+  - changeSet:
+      id: 1755697515000-1
+      author: suresh.kavali
+      changes:
+        - sql:
+            splitStatements: false
+            stripComments: true
+            sql: |
+              UPDATE user_profile_app_role upar
+              SET app_role_id = ar2.id
+              FROM user_profile up
+                       JOIN app_role ar1 ON ar1.name = 'External User Manager'
+                       JOIN app_role ar2 ON ar2.name = 'Firm User Manager'
+              WHERE upar.user_profile_id = up.id
+                AND upar.app_role_id = ar1.id
+                AND up.user_type = 'EXTERNAL'
+                AND NOT EXISTS (
+                  SELECT 1
+                  FROM user_profile_app_role upar2
+                  WHERE upar2.user_profile_id = upar.user_profile_id
+                    AND upar2.app_role_id = ar2.id
+              );


### PR DESCRIPTION

### Description :pencil:

STB-2865 - Assign External users with Firm User Manager where they were previously assigned EUM

https://dsdmoj.atlassian.net/browse/STB-2865

Please fill in.

---

### Changes Made :pencil:

- 
- 
- 

---

### Checklist :pencil:

- [x] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [ ] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [ ] I have a corresponding JIRA ticket for this change 
- [ ] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:

Please fill in.

---