### PR TITLE
STB-2798: Added the ability to place restrictions on non-authz roles.

### DIFF
--- a/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/RoleBasedAccessIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/RoleBasedAccessIntegrationTest.java
@@ -165,7 +165,7 @@ public abstract class RoleBasedAccessIntegrationTest extends BaseIntegrationTest
             profile.setFirm(testFirm1);
             AppRole externalUserManagerRole = allAppRoles.stream()
                     .filter(AppRole::isAuthzRole)
-                    .filter(role -> role.getName().equals("External User Manager"))
+                    .filter(role -> role.getName().equals("Firm User Manager"))
                     .findFirst()
                     .orElseThrow(() -> new RuntimeException("Could not find app role"));
             profile.setAppRoles(Set.of(externalUserManagerRole));
@@ -255,6 +255,8 @@ public abstract class RoleBasedAccessIntegrationTest extends BaseIntegrationTest
         user.setUserProfiles(Set.of(profile));
         profile.setEntraUser(user);
         externalUserViewers.add(entraUserRepository.saveAndFlush(user));
+
+        // Set up Firm User Manager
 
 
         allUsers.addAll(internalUsersNoRoles);

--- a/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/RoleBasedAccessUserListTest.java
+++ b/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/RoleBasedAccessUserListTest.java
@@ -57,7 +57,8 @@ public class RoleBasedAccessUserListTest extends RoleBasedAccessIntegrationTest 
         int expectedSize = (int) allUsers.stream()
                 .flatMap(user -> user.getUserProfiles().stream())
                 .filter(UserProfile::isActiveProfile)
-                .filter(profile -> profile.getAppRoles().stream().anyMatch(appRole -> appRole.isAuthzRole() && appRole.getName().equals("External User Manager")))
+                .filter(profile -> profile.getAppRoles().stream()
+                        .anyMatch(appRole -> appRole.isAuthzRole() && (appRole.getName().equals("External User Manager") || appRole.getName().equals("Firm User Manager"))))
                 .count();
 
         Assertions.assertThat(users).hasSize(expectedSize);
@@ -66,7 +67,7 @@ public class RoleBasedAccessUserListTest extends RoleBasedAccessIntegrationTest 
             Set<String> authzRoleNames = userProfile.getAppRoles().stream()
                     .map(AppRoleDto::getName)
                     .collect(Collectors.toSet());
-            Assertions.assertThat(authzRoleNames).contains("External User Manager");
+            Assertions.assertThat(authzRoleNames.contains("External User Manager") || authzRoleNames.contains("Firm User Manager")).isTrue();
         }
     }
 
@@ -137,7 +138,8 @@ public class RoleBasedAccessUserListTest extends RoleBasedAccessIntegrationTest 
         int expectedSize = (int) allUsers.stream()
                 .flatMap(user -> user.getUserProfiles().stream())
                 .filter(UserProfile::isActiveProfile)
-                .filter(profile -> profile.getAppRoles().stream().anyMatch(appRole -> appRole.isAuthzRole() && appRole.getName().equals("External User Manager")))
+                .filter(profile -> profile.getAppRoles().stream()
+                        .anyMatch(appRole -> appRole.isAuthzRole() && (appRole.getName().equals("External User Manager") || appRole.getName().equals("Firm User Manager"))))
                 .count();
 
         Assertions.assertThat(users).hasSize(expectedSize);
@@ -146,7 +148,7 @@ public class RoleBasedAccessUserListTest extends RoleBasedAccessIntegrationTest 
             Set<String> authzRoleNames = userProfile.getAppRoles().stream()
                     .map(AppRoleDto::getName)
                     .collect(Collectors.toSet());
-            Assertions.assertThat(authzRoleNames).contains("External User Manager");
+            Assertions.assertThat(authzRoleNames.contains("External User Manager") || authzRoleNames.contains("Firm User Manager")).isTrue();
         }
     }
 
@@ -192,7 +194,8 @@ public class RoleBasedAccessUserListTest extends RoleBasedAccessIntegrationTest 
                 .flatMap(user -> user.getUserProfiles().stream())
                 .filter(profile -> profile.isActiveProfile() && profile.getUserType() == UserType.EXTERNAL && profile.getFirm() != null
                         && profile.getFirm().getId().equals(loggedInUserFirm.getId()))
-                .filter(profile -> profile.getAppRoles().stream().anyMatch(appRole -> appRole.isAuthzRole() && appRole.getName().equals("External User Manager")))
+                .filter(profile -> profile.getAppRoles().stream()
+                        .anyMatch(appRole -> appRole.isAuthzRole() && (appRole.getName().equals("External User Manager") || appRole.getName().equals("Firm User Manager"))))
                 .count();
 
         Assertions.assertThat(users).hasSize(expectedSize);
@@ -201,7 +204,7 @@ public class RoleBasedAccessUserListTest extends RoleBasedAccessIntegrationTest 
             Set<String> authzRoleNames = userProfile.getAppRoles().stream()
                     .map(AppRoleDto::getName)
                     .collect(Collectors.toSet());
-            Assertions.assertThat(authzRoleNames).contains("External User Manager");
+            Assertions.assertThat(authzRoleNames.contains("External User Manager") || authzRoleNames.contains("Firm User Manager")).isTrue();
         }
     }
 
@@ -238,7 +241,8 @@ public class RoleBasedAccessUserListTest extends RoleBasedAccessIntegrationTest 
                 .flatMap(user -> user.getUserProfiles().stream())
                 .filter(UserProfile::isActiveProfile)
                 .filter(profile -> UserType.EXTERNAL == profile.getUserType())
-                .filter(profile -> profile.getAppRoles().stream().anyMatch(appRole -> appRole.isAuthzRole() && appRole.getName().equals("External User Manager")))
+                .filter(profile -> profile.getAppRoles().stream()
+                        .anyMatch(appRole -> appRole.isAuthzRole() && (appRole.getName().equals("External User Manager") || appRole.getName().equals("Firm User Manager"))))
                 .count();
         Assertions.assertThat(users).hasSize(expectedSize);
         for (UserProfileDto userProfile : users) {
@@ -246,7 +250,7 @@ public class RoleBasedAccessUserListTest extends RoleBasedAccessIntegrationTest 
             Set<String> authzRoleNames = userProfile.getAppRoles().stream()
                     .map(AppRoleDto::getName)
                     .collect(Collectors.toSet());
-            Assertions.assertThat(authzRoleNames).contains("External User Manager");
+            Assertions.assertThat(authzRoleNames.contains("External User Manager") || authzRoleNames.contains("Firm User Manager")).isTrue();
         }
     }
 

--- a/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/repository/RoleCoverageIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/repository/RoleCoverageIntegrationTest.java
@@ -19,7 +19,7 @@ public class RoleCoverageIntegrationTest extends RoleBasedAccessIntegrationTest 
     @Test
     void findFirmExternalUserManagers() {
         PageRequest pageRequest = PageRequest.of(0, 20);
-        Page<UserProfile> firm1ExternalManager = userProfileRepository.findFirmUserByAuthzRoleAndFirm(testFirm1.getId(), "External User Manager", pageRequest);
+        Page<UserProfile> firm1ExternalManager = userProfileRepository.findFirmUserByAuthzRoleAndFirm(testFirm1.getId(), "Firm User Manager", pageRequest);
         Assertions.assertThat(firm1ExternalManager).hasSize(5);
     }
 }

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
@@ -819,7 +819,7 @@ public class UserController {
         List<AppRoleDto> roles = userService.getAppRolesByAppIdAndUserType(selectedApps.get(currentSelectedAppIndex),
                 user.getUserType());
         UserProfile editorProfile = loginService.getCurrentProfile(authentication);
-        roles = roleAssignmentService.filterRoles(editorProfile.getAppRoles(), roles);
+        roles = roleAssignmentService.filterRoles(editorProfile.getAppRoles(), roles.stream().map(role -> UUID.fromString(role.getId())).toList());
         List<AppRoleDto> userRoles = userService.getUserAppRolesByUserId(id);
         @SuppressWarnings("unchecked")
         Map<Integer, List<String>> editUserAllSelectedRoles = (Map<Integer, List<String>>) session.getAttribute("editUserAllSelectedRoles");
@@ -1382,7 +1382,7 @@ public class UserController {
         List<AppRoleDto> roles = userService.getAppRolesByAppIdAndUserType(selectedApps.get(currentSelectedAppIndex),
                 user.getUserType());
         UserProfile editorProfile = loginService.getCurrentProfile(authentication);
-        roles = roleAssignmentService.filterRoles(editorProfile.getAppRoles(), roles);
+        roles = roleAssignmentService.filterRoles(editorProfile.getAppRoles(), roles.stream().map(role -> UUID.fromString(role.getId())).toList());
         List<AppRoleDto> userRoles = userService.getUserAppRolesByUserId(id);
 
         AppDto currentApp = userService.getAppByAppId(selectedApps.get(currentSelectedAppIndex)).orElseThrow();

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/repository/RoleAssignmentRepository.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/repository/RoleAssignmentRepository.java
@@ -13,4 +13,6 @@ import java.util.UUID;
 public interface RoleAssignmentRepository extends JpaRepository<RoleAssignment, RoleAssignmentId> {
 
     List<RoleAssignment> findByAssigningRole_IdIn(Collection<UUID> ids);
+
+    List<RoleAssignment> findByAssignableRole_Id(UUID id);
 }

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/service/RoleAssignmentService.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/service/RoleAssignmentService.java
@@ -33,42 +33,41 @@ public class RoleAssignmentService {
     private final ModelMapper mapper;
 
     public boolean canAssignRole(Set<AppRole> editorRoles, List<String> targetRoles) {
-        List<UUID> editorRoleIds = editorRoles.stream().map(AppRole::getId).toList();
         List<UUID> targetRoleIds = targetRoles.stream().map(UUID::fromString).distinct().toList();
-        List<AppRole> authzRoles = appRoleRepository.findAllByIdInAndAuthzRoleIs(targetRoleIds, true);
-        List<UUID> authzRoleIds = authzRoles.stream().map(AppRole::getId).toList();
-        Set<UUID> roles = new HashSet<>();
-        List<RoleAssignment>  roleAssignments = roleAssignmentRepository.findByAssigningRole_IdIn(editorRoleIds);
-        for (RoleAssignment roleAssignment : roleAssignments) {
-            if (authzRoleIds.contains(roleAssignment.getAssignableRole().getId())) {
-                roles.add(roleAssignment.getAssignableRole().getId());
-            }
-        }
-        if (roles.size() < authzRoles.size()) {
-            Set<UUID> targetSet = new HashSet<>(authzRoleIds);
-            targetSet.removeAll(roles);
-            String ids = targetSet.stream().map(UUID::toString).collect(Collectors.joining(","));
-            log.warn("Following roles can not be assigned : {}", ids);
+        List<AppRoleDto> validRoles = filterRoles(editorRoles, targetRoleIds);
+        if (validRoles.size() < targetRoles.size()) {
+            Set<String> targetSet = new HashSet<>(targetRoles);
+            targetSet.removeAll(validRoles.stream().map(AppRoleDto::getId).collect(Collectors.toSet()));
+            log.warn("Following roles can not be assigned : {}", targetSet);
             return false;
         }
         return true;
     }
 
-    public List<AppRoleDto> filterRoles(Set<AppRole> editorRoles, List<AppRoleDto> targetRoles) {
+    public List<AppRoleDto> filterRoles(Set<AppRole> editorRoles, List<UUID> targetRoleIds) {
         List<UUID> editorRoleIds = editorRoles.stream().map(AppRole::getId).toList();
-        List<UUID> targetRoleIds = targetRoles.stream().map(appRoleDto -> UUID.fromString(appRoleDto.getId())).distinct().toList();
-        Set<AppRoleDto> roles = new HashSet<>();
+        List<AppRole> authzRoles = appRoleRepository.findAllByIdInAndAuthzRoleIs(targetRoleIds, true);
+        List<UUID> authzRoleIds = authzRoles.stream().map(AppRole::getId).toList();
+        Set<AppRoleDto> validRoles = new HashSet<>();
         List<RoleAssignment>  roleAssignments = roleAssignmentRepository.findByAssigningRole_IdIn(editorRoleIds);
         for (RoleAssignment roleAssignment : roleAssignments) {
-            if (targetRoleIds.contains(roleAssignment.getAssignableRole().getId())) {
-                roles.add(mapper.map(roleAssignment.getAssignableRole(), AppRoleDto.class));
+            if (authzRoleIds.contains(roleAssignment.getAssignableRole().getId())) {
+                validRoles.add(mapper.map(roleAssignment.getAssignableRole(), AppRoleDto.class));
             }
         }
         List<AppRole> nonAuthzRoles = appRoleRepository.findAllByIdInAndAuthzRoleIs(targetRoleIds, false);
-        if (!nonAuthzRoles.isEmpty()) {
-            roles.addAll(nonAuthzRoles.stream().map(r -> mapper.map(r, AppRoleDto.class)).toList());
+        for (AppRole appRole : nonAuthzRoles) {
+            List<RoleAssignment> assignments = roleAssignmentRepository.findByAssignableRole_Id(appRole.getId());
+            if (!assignments.isEmpty()) {
+                List<AppRole> assigningRoles = assignments.stream().map(RoleAssignment::getAssigningRole).toList();
+                if (editorRoles.stream().anyMatch(assigningRoles::contains)) {
+                    validRoles.add(mapper.map(appRole, AppRoleDto.class));
+                }
+            } else {
+                validRoles.add(mapper.map(appRole, AppRoleDto.class));
+            }
         }
-        return new ArrayList<>(roles);
+        return new ArrayList<>(validRoles);
     }
 
     private boolean canAssignAnyAppRole(Set<AppRole> editorRoles, List<String> targetRoles) {

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/UserControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/UserControllerTest.java
@@ -803,16 +803,16 @@ class UserControllerTest {
         when(userService.getUserAppRolesByUserId(userId)).thenReturn(testUserRoles);
         // Setup all available roles
         AppRoleDto testRole1 = new AppRoleDto();
-        testRole1.setId("testAppRoleId1");
+        testRole1.setId(UUID.randomUUID().toString());
         testRole1.setUserTypeRestriction(new UserType[] {UserType.EXTERNAL});
         AppRoleDto testRole2 = new AppRoleDto();
-        testRole2.setId("testAppRoleId2");
+        testRole2.setId(UUID.randomUUID().toString());
         testRole2.setUserTypeRestriction(new UserType[] {UserType.EXTERNAL});
         AppRoleDto testRole3 = new AppRoleDto();
-        testRole3.setId("testAppRoleId3");
+        testRole3.setId(UUID.randomUUID().toString());
         testRole3.setUserTypeRestriction(new UserType[] {UserType.EXTERNAL});
         AppRoleDto testRole4 = new AppRoleDto();
-        testRole4.setId("testUserAppRoleId");
+        testRole4.setId(UUID.randomUUID().toString());
         testRole4.setUserTypeRestriction(new UserType[] {UserType.EXTERNAL});
         AppDto currentApp = new AppDto();
         currentApp.setId("testAppId");
@@ -848,13 +848,13 @@ class UserControllerTest {
         when(userService.getUserAppRolesByUserId(userId)).thenReturn(testUserRoles);
         // Setup all available roles
         AppRoleDto testRole1 = new AppRoleDto();
-        testRole1.setId("testAppRoleId1");
+        testRole1.setId(UUID.randomUUID().toString());
         testRole1.setUserTypeRestriction(new UserType[] {UserType.EXTERNAL});
         AppRoleDto testRole2 = new AppRoleDto();
-        testRole2.setId("testAppRoleId2");
+        testRole2.setId(UUID.randomUUID().toString());
         testRole2.setUserTypeRestriction(new UserType[] {UserType.EXTERNAL});
         AppRoleDto testRole3 = new AppRoleDto();
-        testRole3.setId("testAppRoleId3");
+        testRole3.setId(UUID.randomUUID().toString());
         testRole3.setUserTypeRestriction(new UserType[] {UserType.INTERNAL, UserType.EXTERNAL});
         AppDto currentApp = new AppDto();
         currentApp.setId("testAppId");
@@ -886,24 +886,24 @@ class UserControllerTest {
         when(userService.getUserProfileById(userId)).thenReturn(Optional.of(testUserProfile));
         // Setup test user roles
         AppRoleDto testUserRole = new AppRoleDto();
-        testUserRole.setId("testUserAppRoleId");
+        testUserRole.setId(UUID.randomUUID().toString());
         List<AppRoleDto> testUserRoles = List.of(testUserRole);
         when(userService.getUserAppRolesByUserId(userId)).thenReturn(testUserRoles);
         // Setup all available roles
         AppRoleDto testRole1 = new AppRoleDto();
-        testRole1.setId("testAppRoleId1");
+        testRole1.setId(UUID.randomUUID().toString());
         testRole1.setUserTypeRestriction(new UserType[] {UserType.EXTERNAL});
         AppRoleDto testRole2 = new AppRoleDto();
-        testRole2.setId("testAppRoleId2");
+        testRole2.setId(UUID.randomUUID().toString());
         testRole2.setUserTypeRestriction(new UserType[] {UserType.EXTERNAL});
         AppRoleDto testRole3 = new AppRoleDto();
-        testRole3.setId("testAppRoleId3");
+        testRole3.setId(UUID.randomUUID().toString());
         testRole3.setUserTypeRestriction(new UserType[] {UserType.INTERNAL, UserType.EXTERNAL});
         AppRoleDto testRole4 = new AppRoleDto();
-        testRole4.setId("testUserAppRoleId");
+        testRole4.setId(UUID.randomUUID().toString());
         testRole4.setUserTypeRestriction(new UserType[] {UserType.INTERNAL});
         AppDto currentApp = new AppDto();
-        currentApp.setId("testAppId");
+        currentApp.setId(UUID.randomUUID().toString());
         currentApp.setName("testAppName");
         List<String> selectedApps = List.of(currentApp.getId());
         MockHttpSession testSession = new MockHttpSession();
@@ -1901,6 +1901,7 @@ class UserControllerTest {
         currentApp.setName("App 1");
 
         AppRoleDto role = new AppRoleDto();
+        role.setId(UUID.randomUUID().toString());
         role.setUserTypeRestriction(new UserType[] {UserType.EXTERNAL});
         List<AppRoleDto> appRoles = List.of(role);
 
@@ -1941,13 +1942,13 @@ class UserControllerTest {
         AppDto app2 = AppDto.builder().id("app-two").name("app-two").ordinal(1).build();
         AppDto app3 = AppDto.builder().id("app-three").name("app-three").ordinal(3).build();
 
-        AppRoleDto a1r1 = AppRoleDto.builder().id("a1r1").name("a1r1").userTypeRestriction(new UserType[] {UserType.EXTERNAL}).app(app1).ordinal(3).build();
-        AppRoleDto a1r2 = AppRoleDto.builder().id("a1r2").name("a1r2").userTypeRestriction(new UserType[] {UserType.EXTERNAL}).app(app1).ordinal(4).build();
-        AppRoleDto a1r3 = AppRoleDto.builder().id("a1r3").name("a1r3").userTypeRestriction(new UserType[] {UserType.EXTERNAL}).app(app1).ordinal(1).build();
-        AppRoleDto a1r4 = AppRoleDto.builder().id("a1r4").name("a1r4").userTypeRestriction(new UserType[] {UserType.EXTERNAL}).app(app1).ordinal(2).build();
-        AppRoleDto a2r1 = AppRoleDto.builder().id("a2r1").name("a2r1").userTypeRestriction(new UserType[] {UserType.EXTERNAL}).app(app2).ordinal(2).build();
-        AppRoleDto a2r2 = AppRoleDto.builder().id("a2r2").name("a2r2").userTypeRestriction(new UserType[] {UserType.EXTERNAL}).app(app2).ordinal(3).build();
-        AppRoleDto a2r3 = AppRoleDto.builder().id("a2r3").name("a2r3").userTypeRestriction(new UserType[] {UserType.EXTERNAL}).app(app2).ordinal(1).build();
+        AppRoleDto a1r1 = AppRoleDto.builder().id(UUID.randomUUID().toString()).name("a1r1").userTypeRestriction(new UserType[] {UserType.EXTERNAL}).app(app1).ordinal(3).build();
+        AppRoleDto a1r2 = AppRoleDto.builder().id(UUID.randomUUID().toString()).name("a1r2").userTypeRestriction(new UserType[] {UserType.EXTERNAL}).app(app1).ordinal(4).build();
+        AppRoleDto a1r3 = AppRoleDto.builder().id(UUID.randomUUID().toString()).name("a1r3").userTypeRestriction(new UserType[] {UserType.EXTERNAL}).app(app1).ordinal(1).build();
+        AppRoleDto a1r4 = AppRoleDto.builder().id(UUID.randomUUID().toString()).name("a1r4").userTypeRestriction(new UserType[] {UserType.EXTERNAL}).app(app1).ordinal(2).build();
+        AppRoleDto a2r1 = AppRoleDto.builder().id(UUID.randomUUID().toString()).name("a2r1").userTypeRestriction(new UserType[] {UserType.EXTERNAL}).app(app2).ordinal(2).build();
+        AppRoleDto a2r2 = AppRoleDto.builder().id(UUID.randomUUID().toString()).name("a2r2").userTypeRestriction(new UserType[] {UserType.EXTERNAL}).app(app2).ordinal(3).build();
+        AppRoleDto a2r3 = AppRoleDto.builder().id(UUID.randomUUID().toString()).name("a2r3").userTypeRestriction(new UserType[] {UserType.EXTERNAL}).app(app2).ordinal(1).build();
 
         Set<AppDto> userApps = new LinkedHashSet<>(Arrays.asList(app1, app2, app3));
 
@@ -2977,7 +2978,7 @@ class UserControllerTest {
         currentApp.setName("App 1");
 
         AppRoleDto role1 = new AppRoleDto();
-        role1.setId("role1");
+        role1.setId(UUID.randomUUID().toString());
         role1.setName("Role 1");
         final List<AppRoleDto> roles = List.of(role1);
 
@@ -3327,7 +3328,7 @@ class UserControllerTest {
         ccmsApp.setName("CCMS Application"); // Contains "CCMS" in name
 
         AppRoleDto normalRole = new AppRoleDto();
-        normalRole.setId("role1");
+        normalRole.setId(UUID.randomUUID().toString());
         normalRole.setCcmsCode("NORMAL_ROLE");
 
         final List<AppRoleDto> roles = List.of(normalRole);
@@ -3364,7 +3365,7 @@ class UserControllerTest {
         regularApp.setName("Regular Application"); // Doesn't contain "CCMS"
 
         AppRoleDto ccmsRole = new AppRoleDto();
-        ccmsRole.setId("role1");
+        ccmsRole.setId(UUID.randomUUID().toString());
         ccmsRole.setCcmsCode("XXCCMS_FIRM_ADMIN"); // CCMS role code
 
         final List<AppRoleDto> roles = List.of(ccmsRole);
@@ -3403,22 +3404,22 @@ class UserControllerTest {
 
         // Create roles for different CCMS sections
         AppRoleDto providerRole = new AppRoleDto();
-        providerRole.setId("provider1");
+        providerRole.setId(UUID.randomUUID().toString());
         providerRole.setCcmsCode("XXCCMS_FIRM_ADMIN");
         providerRole.setApp(ccmsApp);
 
         AppRoleDto chambersRole = new AppRoleDto();
-        chambersRole.setId("chambers1");
+        chambersRole.setId(UUID.randomUUID().toString());
         chambersRole.setCcmsCode("XXCCMS_CHAMBERS_ADMIN");
         chambersRole.setApp(ccmsApp);
 
         AppRoleDto advocateRole = new AppRoleDto();
-        advocateRole.setId("advocate1");
+        advocateRole.setId(UUID.randomUUID().toString());
         advocateRole.setCcmsCode("XXCCMS_ADVOCATE");
         advocateRole.setApp(ccmsApp);
 
         AppRoleDto otherRole = new AppRoleDto();
-        otherRole.setId("other1");
+        otherRole.setId(UUID.randomUUID().toString());
         otherRole.setCcmsCode("XXCCMS_UNKNOWN_TYPE");
         otherRole.setApp(ccmsApp);
 
@@ -3461,7 +3462,7 @@ class UserControllerTest {
         regularApp.setName("Regular Application");
 
         AppRoleDto regularRole = new AppRoleDto();
-        regularRole.setId("role1");
+        regularRole.setId(UUID.randomUUID().toString());
         regularRole.setCcmsCode("REGULAR_ROLE"); // Not a CCMS role
 
         final List<AppRoleDto> roles = List.of(regularRole);
@@ -3496,7 +3497,7 @@ class UserControllerTest {
         regularApp.setName("CCMS case transfer requests");
 
         AppRoleDto regularRole = new AppRoleDto();
-        regularRole.setId("role1");
+        regularRole.setId(UUID.randomUUID().toString());
         regularRole.setCcmsCode("REQUESTS TO TRANSFER CCMS CASES_VIEWER_EXTERN"); // Not a CCMS role
 
         final List<AppRoleDto> roles = List.of(regularRole);
@@ -3531,11 +3532,11 @@ class UserControllerTest {
         mixedApp.setName("Mixed App");
 
         AppRoleDto ccmsRole = new AppRoleDto();
-        ccmsRole.setId("ccms1");
+        ccmsRole.setId(UUID.randomUUID().toString());
         ccmsRole.setCcmsCode("XXCCMS_FIRM_ADMIN");
 
         AppRoleDto regularRole = new AppRoleDto();
-        regularRole.setId("regular1");
+        regularRole.setId(UUID.randomUUID().toString());
         regularRole.setCcmsCode("REGULAR_ROLE");
 
         final List<AppRoleDto> roles = List.of(ccmsRole, regularRole);
@@ -3579,7 +3580,7 @@ class UserControllerTest {
         ccmsApp.setName("CCMS Application");
 
         AppRoleDto normalRole = new AppRoleDto();
-        normalRole.setId("role1");
+        normalRole.setId(UUID.randomUUID().toString());
         normalRole.setCcmsCode("NORMAL_ROLE");
 
         final List<AppRoleDto> roles = List.of(normalRole);
@@ -3614,7 +3615,7 @@ class UserControllerTest {
         regularApp.setName("Regular Application");
 
         AppRoleDto ccmsRole = new AppRoleDto();
-        ccmsRole.setId("role1");
+        ccmsRole.setId(UUID.randomUUID().toString());
         ccmsRole.setCcmsCode("XXCCMS_OFFICE_ADMIN");
 
         final List<AppRoleDto> roles = List.of(ccmsRole);
@@ -3653,32 +3654,32 @@ class UserControllerTest {
 
         // Create comprehensive CCMS roles for testing organization
         AppRoleDto firmRole = new AppRoleDto();
-        firmRole.setId("firm1");
+        firmRole.setId(UUID.randomUUID().toString());
         firmRole.setCcmsCode("XXCCMS_FIRM_USER");
         firmRole.setApp(ccmsApp);
 
         AppRoleDto officeRole = new AppRoleDto();
-        officeRole.setId("office1");
+        officeRole.setId(UUID.randomUUID().toString());
         officeRole.setCcmsCode("XXCCMS_OFFICE_MANAGER");
         officeRole.setApp(ccmsApp);
 
         AppRoleDto crossOfficeRole = new AppRoleDto();
-        crossOfficeRole.setId("cross1");
+        crossOfficeRole.setId(UUID.randomUUID().toString());
         crossOfficeRole.setCcmsCode("XXCCMS_CROSS_OFFICE");
         crossOfficeRole.setApp(ccmsApp);
 
         AppRoleDto chambersRole = new AppRoleDto();
-        chambersRole.setId("chambers1");
+        chambersRole.setId(UUID.randomUUID().toString());
         chambersRole.setCcmsCode("XXCCMS_CHAMBERS_USER");
         chambersRole.setApp(ccmsApp);
 
         AppRoleDto counselRole = new AppRoleDto();
-        counselRole.setId("counsel1");
+        counselRole.setId(UUID.randomUUID().toString());
         counselRole.setCcmsCode("XXCCMS_COUNSEL");
         counselRole.setApp(ccmsApp);
 
         AppRoleDto advocateRole = new AppRoleDto();
-        advocateRole.setId("advocate1");
+        advocateRole.setId(UUID.randomUUID().toString());
         advocateRole.setCcmsCode("XXCCMS_ADVOCATE");
         advocateRole.setApp(ccmsApp);
 
@@ -3726,7 +3727,7 @@ class UserControllerTest {
         regularApp.setName("Regular Grant Access App");
 
         AppRoleDto regularRole = new AppRoleDto();
-        regularRole.setId("role1");
+        regularRole.setId(UUID.randomUUID().toString());
         regularRole.setCcmsCode("REGULAR_ROLE");
 
         final List<AppRoleDto> roles = List.of(regularRole);
@@ -3761,7 +3762,7 @@ class UserControllerTest {
         ccmsApp.setName("CCMS App 2");
 
         AppRoleDto ccmsRole = new AppRoleDto();
-        ccmsRole.setId("role1");
+        ccmsRole.setId(UUID.randomUUID().toString());
         ccmsRole.setCcmsCode("XXCCMS_CASE_MANAGER");
 
         final List<AppRoleDto> roles = List.of(ccmsRole);

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/service/RoleAssignmentServiceTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/service/RoleAssignmentServiceTest.java
@@ -86,6 +86,7 @@ public class RoleAssignmentServiceTest {
         UUID viewCrimeId = UUID.randomUUID();
         List<String> targetRoles = List.of(exAdminId.toString(), exManId.toString(), viewCrimeId.toString());
         when(appRoleRepository.findAllByIdInAndAuthzRoleIs(List.of(exAdminId, exManId, viewCrimeId), true)).thenReturn(List.of(exAdmin, exMan));
+        when(appRoleRepository.findAllByIdInAndAuthzRoleIs(List.of(exAdminId, exManId, viewCrimeId), false)).thenReturn(List.of(viewCrime));
         assertThat(roleAssignmentService.canAssignRole(editorRoles, targetRoles)).isTrue();
     }
 
@@ -99,12 +100,13 @@ public class RoleAssignmentServiceTest {
 
     @Test
     void filterRoles_globalAdmin() {
-        Set<AppRole> editorRoles = Set.of(gbAdmin);
         AppRoleDto exAdminDto = new AppRoleDto();
         exAdminDto.setId(exAdminId.toString());
         AppRoleDto exManDto = new AppRoleDto();
         exManDto.setId(exManId.toString());
-        List<AppRoleDto> targetRoles = List.of(exAdminDto, exManDto);
+        List<UUID> targetRoles = List.of(exAdminId, exManId);
+        Set<AppRole> editorRoles = Set.of(gbAdmin);
+        when(appRoleRepository.findAllByIdInAndAuthzRoleIs(targetRoles, true)).thenReturn(List.of(exAdmin, exMan));
         assertThat(roleAssignmentService.filterRoles(editorRoles, targetRoles)).hasSize(2);
     }
 
@@ -115,7 +117,7 @@ public class RoleAssignmentServiceTest {
         exAdminDto.setId(exAdminId.toString());
         AppRoleDto exManDto = new AppRoleDto();
         exManDto.setId(gbAdminId.toString());
-        List<AppRoleDto> targetRoles = List.of(exAdminDto, exManDto);
+        List<UUID> targetRoles = List.of(exAdminId, exManId);
         assertThat(roleAssignmentService.filterRoles(editorRoles, targetRoles)).hasSize(0);
     }
 
@@ -131,9 +133,10 @@ public class RoleAssignmentServiceTest {
                 .userTypeRestriction(new UserType[] {UserType.EXTERNAL}).app(crimeApp).authzRole(false).build();
         AppRoleDto viewCrimeDto = new AppRoleDto();
         viewCrimeDto.setId(viewCrimeId.toString());
-        List<AppRoleDto> targetRoles = List.of(exAdminDto, exManDto, viewCrimeDto);
+        List<UUID> targetRoles = List.of(exAdminId, exManId, viewCrimeId);
         Set<AppRole> editorRoles = Set.of(exMan);
-        when(appRoleRepository.findAllByIdInAndAuthzRoleIs(List.of(exAdminId, gbAdminId, viewCrimeId), false)).thenReturn(List.of(viewCrime));
+        when(appRoleRepository.findAllByIdInAndAuthzRoleIs(targetRoles, true)).thenReturn(List.of(exAdmin, exMan));
+        when(appRoleRepository.findAllByIdInAndAuthzRoleIs(targetRoles, false)).thenReturn(List.of(viewCrime));
         assertThat(roleAssignmentService.filterRoles(editorRoles, targetRoles)).hasSize(1);
     }
 


### PR DESCRIPTION
### Description :pencil:

Previously we only used the role assignment table for authZ roles. Added the ability to add restrictions to non-authz roles.

---

### Changes Made :pencil:

- Refactored role assignment logic to also account for non-authz roles.
- Added integration tests.
- Updated unit tests.

---

### Checklist :pencil:

- [X] I have added the relevant Liquibase changelog files for any entity changes
- [X] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [X] I have taken into account the application runs as 3 replicas in live environments
- [X] I have created any relevant documentation for this change
- [X] I have a corresponding JIRA ticket for this change 
- [X] I have added relevant unit & integration tests where applicable
