### PR TITLE
STB-2938 - Update footer links to point to the latest privacy policy and terms and terms links

### DIFF
--- a/src/main/resources/templates/partials/footer.html
+++ b/src/main/resources/templates/partials/footer.html
@@ -32,14 +32,14 @@
                     </li>
                     <li class="govuk-footer__inline-list-item">
                         <a class="govuk-footer__link"
-                            href="https://www.gov.uk/government/publications/laa-online-portal-help-and-information"
+                            href="https://assets.publishing.service.gov.uk/media/68c7f1b553f33f9d46e206a1/LAA_User_Privacy_Notice.pdf"
                             target="_blank" rel="noreferrer noopener">
                             Privacy policy
                         </a>
                     </li>
                     <li class="govuk-footer__inline-list-item">
                         <a class="govuk-footer__link"
-                            href="https://www.gov.uk/government/publications/laa-online-portal-help-and-information"
+                            href="https://assets.publishing.service.gov.uk/media/68c98f6dc6df905ce7708466/LAA_SILAS_Terms_and_Conditions.pdf"
                             target="_blank" rel="noreferrer noopener">
                             Terms and conditions
                         </a>


### PR DESCRIPTION
https://github.com/user-attachments/assets/fc48caea-5fb2-4013-b3fa-d3707b6e3d66


### Changes Made :pencil:

This pull request updates the support links in the footer to point directly to the official PDF documents for the privacy policy and terms and conditions, improving clarity and user experience.

Support links update:

* Changed the `Privacy policy` link in `footer.html` to reference the official user privacy notice PDF instead of a general help and information page.
* Changed the `Terms and conditions` link in `footer.html` to reference the official terms and conditions PDF instead of a general help and information page.


---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [ ] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [x] I have a corresponding JIRA ticket for this change 
- [ ] I have added relevant unit & integration tests where applicable

---