### PR TITLE
STB-2945: Fixed bug where external users could be assigned the internal "External User Manager" role on creation

### DIFF
--- a/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/RoleBasedAccessCreateUserTest.java
+++ b/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/RoleBasedAccessCreateUserTest.java
@@ -55,7 +55,7 @@ public class RoleBasedAccessCreateUserTest extends RoleBasedAccessIntegrationTes
         assertThat(optionalCreatedUserProfile).isNotEmpty();
         UserProfile createdUserProfile = optionalCreatedUserProfile.get();
         assertThat(createdUserProfile.getAppRoles()).hasSize(1);
-        assertThat(createdUserProfile.getAppRoles().stream().findFirst().orElseThrow().getName()).isEqualTo("External User Manager");
+        assertThat(createdUserProfile.getAppRoles().stream().findFirst().orElseThrow().getName()).isEqualTo("Firm User Manager");
         EntraUser createdUser = createdUserProfile.getEntraUser();
         userProfileRepository.delete(createdUserProfile);
         entraUserRepository.delete(createdUser);
@@ -96,7 +96,7 @@ public class RoleBasedAccessCreateUserTest extends RoleBasedAccessIntegrationTes
         assertThat(optionalCreatedUserProfile).isNotEmpty();
         UserProfile createdUserProfile = optionalCreatedUserProfile.get();
         assertThat(createdUserProfile.getAppRoles()).hasSize(1);
-        assertThat(createdUserProfile.getAppRoles().stream().findFirst().orElseThrow().getName()).isEqualTo("External User Manager");
+        assertThat(createdUserProfile.getAppRoles().stream().findFirst().orElseThrow().getName()).isEqualTo("Firm User Manager");
         EntraUser createdUser = createdUserProfile.getEntraUser();
         userProfileRepository.delete(createdUserProfile);
         entraUserRepository.delete(createdUser);

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/service/UserService.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/service/UserService.java
@@ -218,17 +218,19 @@ public class UserService {
                 .toList();
         PageRequest pageRequest = PageRequest.of(0, 2);
         if (Objects.nonNull(firm)) {
-            Optional<AppRole> externalUserManagerRole = appRoleRepository.findByName("External User Manager");
-            if (externalUserManagerRole.isPresent()) {
-                Page<UserProfile> existingManagers = userProfileRepository.findFirmUserByAuthzRoleAndFirm(firm.getId(), "External User Manager", pageRequest);
-                boolean removeManager = removed.stream().anyMatch(role -> role.getId().equals(externalUserManagerRole.get().getId()));
+            String userManagerRoleName = internal ? "External User Manager" : "Firm User Manager";
+            Optional<AppRole> optionalUserManagerRole = appRoleRepository.findByName(userManagerRoleName);
+            if (optionalUserManagerRole.isPresent()) {
+                AppRole userManagerRole = optionalUserManagerRole.get();
+                Page<UserProfile> existingManagers = userProfileRepository.findFirmUserByAuthzRoleAndFirm(firm.getId(), userManagerRole.getName(), pageRequest);
+                boolean removeManager = removed.stream().anyMatch(role -> role.getId().equals(optionalUserManagerRole.get().getId()));
                 if (removeManager && self) {
-                    logger.warn("Attempt to remove own External User Manager, from user profile {}.", userId);
-                    return "You cannot remove your own External User Manager role";
+                    logger.warn("Attempt to remove own User Manager role, from user profile {}.", userId);
+                    return "You cannot remove your own User Manager role";
                 }
                 if (!internal && existingManagers.getTotalElements() < 2 && removeManager) {
-                    logger.warn("Attempt to remove last firm External User Manager, from user profile {}.", userId);
-                    return "External User Manager role could not be removed, this is the last External User Manager of " + firm.getName();
+                    logger.warn("Attempt to remove last firm User Manager, from user profile {}.", userId);
+                    return "User Manager role could not be removed, this is the last User Manager of " + firm.getName();
                 }
             }
         } else {
@@ -484,8 +486,8 @@ public class UserService {
         Firm firm = mapper.map(firmDto, Firm.class);
         Set<AppRole> appRoles = new HashSet<>();
         if (isUserManager) {
-            Optional<AppRole> externalUserManagerRole = appRoleRepository.findByName("External User Manager");
-            externalUserManagerRole.ifPresent(appRoles::add);
+            Optional<AppRole> firmUserManagerRole = appRoleRepository.findByName("Firm User Manager");
+            firmUserManagerRole.ifPresent(appRoles::add);
         }
         UserProfile userProfile = UserProfile.builder()
                 .activeProfile(true)

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/service/UserServiceTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/service/UserServiceTest.java
@@ -3116,7 +3116,7 @@ class UserServiceTest {
         @Test
         void roleCoverage_removeManager_not_last_not_self() {
             UUID externalUserManagerRoleId = UUID.randomUUID();
-            AppRole externalUserManagerRole = AppRole.builder().id(externalUserManagerRoleId).name("External User Manager").build();
+            AppRole externalUserManagerRole = AppRole.builder().id(externalUserManagerRoleId).name("Firm User Manager").build();
             UUID externalUserAdminRoleId = UUID.randomUUID();
             AppRole externalUserAdminRole = AppRole.builder().id(externalUserAdminRoleId).name("External User Admin").build();
             Set<AppRole> oldRoles = Set.of(externalUserManagerRole, externalUserAdminRole);
@@ -3127,12 +3127,12 @@ class UserServiceTest {
                     List.of(mock(UserProfile.class, RETURNS_DEEP_STUBS), mock(UserProfile.class, RETURNS_DEEP_STUBS)),
                     PageRequest.of(0, 2), 2
             );
-            when(mockUserProfileRepository.findFirmUserByAuthzRoleAndFirm(eq(firmId), eq("External User Manager"), any())).thenReturn(firmManagersPage);
+            when(mockUserProfileRepository.findFirmUserByAuthzRoleAndFirm(eq(firmId), eq("Firm User Manager"), any())).thenReturn(firmManagersPage);
             String userId = UUID.randomUUID().toString();
-            when(mockAppRoleRepository.findByName(eq("External User Manager"))).thenReturn(Optional.of(externalUserManagerRole));
+            when(mockAppRoleRepository.findByName(eq("Firm User Manager"))).thenReturn(Optional.of(externalUserManagerRole));
 
             userService.roleCoverage(oldRoles, Set.of(), firm, userId, false, false);
-            verify(mockAppRoleRepository, times(1)).findByName(eq("External User Manager"));
+            verify(mockAppRoleRepository, times(1)).findByName(eq("Firm User Manager"));
             verify(mockUserProfileRepository, times(1)).findFirmUserByAuthzRoleAndFirm(any(), any(), any());
             verify(mockUserProfileRepository, never()).findInternalUserByAuthzRole(any(), any());
         }
@@ -3141,7 +3141,7 @@ class UserServiceTest {
         void roleCoverage_removeManager_not_last_is_self() {
             ListAppender<ILoggingEvent> listAppender = LogMonitoring.addListAppenderToLogger(UserService.class);
             UUID externalUserManagerRoleId = UUID.randomUUID();
-            AppRole externalUserManagerRole = AppRole.builder().id(externalUserManagerRoleId).name("External User Manager").build();
+            AppRole externalUserManagerRole = AppRole.builder().id(externalUserManagerRoleId).name("Firm User Manager").build();
             UUID externalUserAdminRoleId = UUID.randomUUID();
             AppRole externalUserAdminRole = AppRole.builder().id(externalUserAdminRoleId).name("External User Admin").build();
             Set<AppRole> oldRoles = Set.of(externalUserManagerRole, externalUserAdminRole);
@@ -3152,23 +3152,23 @@ class UserServiceTest {
                     List.of(mock(UserProfile.class, RETURNS_DEEP_STUBS), mock(UserProfile.class, RETURNS_DEEP_STUBS)),
                     PageRequest.of(0, 2), 2
             );
-            when(mockUserProfileRepository.findFirmUserByAuthzRoleAndFirm(eq(firmId), eq("External User Manager"), any())).thenReturn(firmManagersPage);
+            when(mockUserProfileRepository.findFirmUserByAuthzRoleAndFirm(eq(firmId), eq("Firm User Manager"), any())).thenReturn(firmManagersPage);
             String userId = UUID.randomUUID().toString();
-            when(mockAppRoleRepository.findByName(eq("External User Manager"))).thenReturn(Optional.of(externalUserManagerRole));
+            when(mockAppRoleRepository.findByName(eq("Firm User Manager"))).thenReturn(Optional.of(externalUserManagerRole));
 
             String result = userService.roleCoverage(oldRoles, newRoles, firm, userId, true, false);
-            assertThat(result).contains("You cannot remove your own External User Manager role");
+            assertThat(result).contains("You cannot remove your own User Manager role");
             List<ILoggingEvent> warningLogs = LogMonitoring.getLogsByLevel(listAppender, Level.WARN);
             assertThat(warningLogs).isNotEmpty();
             assertThat(warningLogs.getFirst().getFormattedMessage())
-                    .contains("Attempt to remove own External User Manager, from user profile");
+                    .contains("Attempt to remove own User Manager role, from user profile");
         }
 
         @Test
         void roleCoverage_removeManager_is_last_not_self() {
             ListAppender<ILoggingEvent> listAppender = LogMonitoring.addListAppenderToLogger(UserService.class);
             UUID externalUserManagerRoleId = UUID.randomUUID();
-            AppRole externalUserManagerRole = AppRole.builder().id(externalUserManagerRoleId).name("External User Manager").build();
+            AppRole externalUserManagerRole = AppRole.builder().id(externalUserManagerRoleId).name("Firm User Manager").build();
             UUID externalUserAdminRoleId = UUID.randomUUID();
             AppRole externalUserAdminRole = AppRole.builder().id(externalUserAdminRoleId).name("External User Admin").build();
             Set<AppRole> oldRoles = Set.of(externalUserManagerRole, externalUserAdminRole);
@@ -3179,16 +3179,16 @@ class UserServiceTest {
                     List.of(mock(UserProfile.class, RETURNS_DEEP_STUBS)),
                     PageRequest.of(0, 2), 1
             );
-            when(mockUserProfileRepository.findFirmUserByAuthzRoleAndFirm(eq(firmId), eq("External User Manager"), any())).thenReturn(firmManagersPage);
+            when(mockUserProfileRepository.findFirmUserByAuthzRoleAndFirm(eq(firmId), eq("Firm User Manager"), any())).thenReturn(firmManagersPage);
             String userId = UUID.randomUUID().toString();
-            when(mockAppRoleRepository.findByName(eq("External User Manager"))).thenReturn(Optional.of(externalUserManagerRole));
+            when(mockAppRoleRepository.findByName(eq("Firm User Manager"))).thenReturn(Optional.of(externalUserManagerRole));
 
             String result = userService.roleCoverage(oldRoles, newRoles, firm, userId, false, false);
-            assertThat(result).contains("External User Manager role could not be removed, this is the last External User Manager of MyFirm");
+            assertThat(result).contains("User Manager role could not be removed, this is the last User Manager of MyFirm");
             List<ILoggingEvent> warningLogs = LogMonitoring.getLogsByLevel(listAppender, Level.WARN);
             assertThat(warningLogs).isNotEmpty();
             assertThat(warningLogs.getFirst().getFormattedMessage())
-                    .contains("Attempt to remove last firm External User Manager, from user profile");
+                    .contains("Attempt to remove last firm User Manager, from user profile");
         }
 
         @Test


### PR DESCRIPTION
### Description :pencil:

Fixed a bug where external users could be assigned the internal "External User Manager" role on creation.

---

### Changes Made :pencil:

- Changed create user logic to use the updated name.
- Change role coverage logic to ensure external users use the correct role name.
- Updated unit and integration tests.

---

### Checklist :pencil:

- [X] I have added the relevant Liquibase changelog files for any entity changes
- [X] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [X] I have taken into account the application runs as 3 replicas in live environments
- [X] I have created any relevant documentation for this change
- [X] I have a corresponding JIRA ticket for this change 
- [X] I have added relevant unit & integration tests where applicable