### PR TITLE
STB-2798: Fixed bug where restricted apps were appearing on the edit app screen for all users.

### DIFF
--- a/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/RoleBasedAccessAppVisibilityTest.java
+++ b/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/RoleBasedAccessAppVisibilityTest.java
@@ -1,0 +1,121 @@
+package uk.gov.justice.laa.portal.landingpage.controller;
+
+import jakarta.transaction.Transactional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MvcResult;
+import uk.gov.justice.laa.portal.landingpage.dto.AppDto;
+import uk.gov.justice.laa.portal.landingpage.entity.App;
+import uk.gov.justice.laa.portal.landingpage.entity.AppRole;
+import uk.gov.justice.laa.portal.landingpage.entity.EntraUser;
+import uk.gov.justice.laa.portal.landingpage.entity.RoleAssignment;
+import uk.gov.justice.laa.portal.landingpage.entity.UserProfile;
+import uk.gov.justice.laa.portal.landingpage.entity.UserType;
+import uk.gov.justice.laa.portal.landingpage.repository.RoleAssignmentRepository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class RoleBasedAccessAppVisibilityTest extends RoleBasedAccessIntegrationTest {
+
+    @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
+    @Autowired
+    private RoleAssignmentRepository roleAssignmentRepository;
+
+    @Test
+    public void testValidUserCanSeeRestrictedApp() throws Exception {
+        // Build test app
+        App testExternalApp = buildLaaApp("Test External App", generateEntraId(), "TestExternalAppSecurityGroupOid", "TestExternalAppSecurityGroup");
+
+        // Build test role
+        AppRole testExternalAppRole = buildLaaAppRole(testExternalApp, "Test External App Role");
+        testExternalAppRole.setUserTypeRestriction(new UserType[] {UserType.EXTERNAL});
+
+        // Persist app and role.
+        testExternalApp.setAppRoles(Set.of(testExternalAppRole));
+        testExternalApp = appRepository.saveAndFlush(testExternalApp);
+        testExternalAppRole = testExternalApp.getAppRoles().stream().findFirst().orElseThrow();
+
+        // Add restriction that test role can only be set by external user manager.
+        AppRole externalUserManager = appRoleRepository.findByName("External User Manager").orElseThrow();
+        RoleAssignment assignment = new RoleAssignment(externalUserManager, testExternalAppRole);
+        roleAssignmentRepository.saveAndFlush(assignment);
+
+        EntraUser loggedInUser = internalWithExternalOnlyUserManagers.getFirst();
+        EntraUser editedUser = externalUsersNoRoles.getFirst();
+
+        // Send GET request to edit apps endpoint
+        MvcResult result = openEditAppScreen(loggedInUser, editedUser);
+
+        Map<String, Object> model = result.getModelAndView().getModel();
+        List<AppDto> returnedApps = (List<AppDto>) model.get("apps");
+
+        final String testAppId = testExternalApp.getId().toString();
+        boolean returnedAppContainsTestApp = returnedApps.stream()
+                .map(AppDto::getId)
+                .anyMatch(testAppId::equals);
+
+        Assertions.assertThat(returnedAppContainsTestApp).isTrue();
+
+        // Teardown
+        roleAssignmentRepository.deleteAll();
+        deleteNonAuthzAppRoles(appRoleRepository);
+        deleteNonAuthzApps(appRepository);
+    }
+
+    @Test
+    public void testInvalidUserCannotSeeRestrictedApp() throws Exception {
+        // Build test app
+        App testExternalApp = buildLaaApp("Test External App", generateEntraId(), "TestExternalAppSecurityGroupOid", "TestExternalAppSecurityGroup");
+
+        // Build test role
+        AppRole testExternalAppRole = buildLaaAppRole(testExternalApp, "Test External App Role");
+        testExternalAppRole.setUserTypeRestriction(new UserType[] {UserType.EXTERNAL});
+
+        // Persist app and role.
+        testExternalApp.setAppRoles(Set.of(testExternalAppRole));
+        testExternalApp = appRepository.saveAndFlush(testExternalApp);
+        testExternalAppRole = testExternalApp.getAppRoles().stream().findFirst().orElseThrow();
+
+        // Add restriction that test role can only be set by external user manager.
+        AppRole externalUserManager = appRoleRepository.findByName("External User Manager").orElseThrow();
+        RoleAssignment assignment = new RoleAssignment(externalUserManager, testExternalAppRole);
+        roleAssignmentRepository.saveAndFlush(assignment);
+
+        EntraUser loggedInUser = globalAdmins.getFirst();
+        EntraUser editedUser = externalUsersNoRoles.getFirst();
+
+        // Send GET request to edit apps endpoint
+        MvcResult result = openEditAppScreen(loggedInUser, editedUser);
+
+        Map<String, Object> model = result.getModelAndView().getModel();
+        List<AppDto> returnedApps = (List<AppDto>) model.get("apps");
+
+        final String testAppId = testExternalApp.getId().toString();
+        boolean returnedAppContainsTestApp = returnedApps.stream()
+                .map(AppDto::getId)
+                .anyMatch(testAppId::equals);
+
+        Assertions.assertThat(returnedAppContainsTestApp).isFalse();
+
+        // Teardown
+        roleAssignmentRepository.deleteAll();
+        deleteNonAuthzAppRoles(appRoleRepository);
+        deleteNonAuthzApps(appRepository);
+    }
+
+    private MvcResult openEditAppScreen(EntraUser loggedInUser, EntraUser editedUser) throws Exception {
+        UserProfile accessedUserProfile = editedUser.getUserProfiles().stream().findFirst().orElseThrow();
+        return this.mockMvc.perform(get(String.format("/admin/users/edit/%s/apps", accessedUserProfile.getId()))
+                        .with(userOauth2Login(loggedInUser)))
+                .andExpect(status().isOk())
+                .andReturn();
+    }
+
+}

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/service/RoleAssignmentService.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/service/RoleAssignmentService.java
@@ -75,13 +75,7 @@ public class RoleAssignmentService {
         if (appOptional.isPresent()) {
             App app = appOptional.get();
 
-            if (!isAuthzApp(app)) {
-                return true;
-            }
-
-            Set<AppRole> editorRoles = userProfile.getAppRoles().stream()
-                    .filter(appRole -> appRole.getApp().getId().equals(app.getId()))
-                    .collect(Collectors.toSet());
+            Set<AppRole> editorRoles = new HashSet<>(userProfile.getAppRoles());
 
             List<UUID> assigneeRoles = app.getAppRoles().stream()
                     .map(appRole -> appRole.getId())

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/service/RoleAssignmentServiceTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/service/RoleAssignmentServiceTest.java
@@ -187,19 +187,6 @@ public class RoleAssignmentServiceTest {
     }
 
     @Test
-    void canUserAssignRolesForNonAuthzApp_ok() {
-        UserProfile userProfile = UserProfile.builder().id(UUID.randomUUID()).appRoles(Set.of(firmMan)).build();
-        App ccmsApp = App.builder().id(UUID.randomUUID()).name("ccms").securityGroupOid("sec_grp_oid")
-                .securityGroupName("sec_grp_name").build();
-        AppRole ccmsAppRole = AppRole.builder().id(UUID.randomUUID()).name("ccmsRole").description("ccmsRole")
-                .userTypeRestriction(new UserType[]{UserType.EXTERNAL}).app(ccmsApp).authzRole(false).build();
-        ccmsApp.setAppRoles(Set.of(ccmsAppRole));
-        AppDto appDto = mapper.map(ccmsApp, AppDto.class);
-        when(appRepository.findById(any())).thenReturn(java.util.Optional.of(ccmsApp));
-        assertThat(roleAssignmentService.canUserAssignRolesForApp(userProfile, appDto)).isTrue();
-    }
-
-    @Test
     void canUserAssignRolesForApp_fail_fum_to_fum() {
         app.setAppRoles(Set.of(firmMan));
         when(appRepository.findById(any())).thenReturn(java.util.Optional.of(app));


### PR DESCRIPTION
### Description :pencil:

Admin users were able to see apps on the edit app screen for which they were unable to assign any roles. This caused a scenario where the edit role screen was blank and they could not proceed.

---

### Changes Made :pencil:

- Removed logic to automatically show all non-authz apps.
- Added integration tests for this scenario
- Removed unnecessary unit test.

---

### Checklist :pencil:

- [X] I have added the relevant Liquibase changelog files for any entity changes
- [X] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [X] I have taken into account the application runs as 3 replicas in live environments
- [X] I have created any relevant documentation for this change
- [X] I have a corresponding JIRA ticket for this change 
- [X] I have added relevant unit & integration tests where applicable