### PR TITLE
STB-2928 only validate non-empty email

### DIFF
--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
@@ -399,15 +399,17 @@ public class UserController {
         if (Objects.isNull(user)) {
             user = new EntraUserDto();
         }
+        if (Objects.nonNull(userDetailsForm.getEmail()) && !userDetailsForm.getEmail().isEmpty()) {
+            if (userService.userExistsByEmail(userDetailsForm.getEmail())) {
+                result.rejectValue("email", "error.email", "Email address already exists");
+            }
 
-        if (userService.userExistsByEmail(userDetailsForm.getEmail())) {
-            result.rejectValue("email", "error.email", "Email address already exists");
+            if (!emailValidationService.isValidEmailDomain(userDetailsForm.getEmail())) {
+                result.rejectValue("email", "email.invalidDomain",
+                        "The email address domain is not valid or cannot receive emails.");
+            }
         }
 
-        if (!emailValidationService.isValidEmailDomain(userDetailsForm.getEmail())) {
-            result.rejectValue("email", "email.invalidDomain",
-                    "The email address domain is not valid or cannot receive emails.");
-        }
 
         if (result.hasErrors()) {
             log.debug("Validation errors occurred while creating user: {}", result.getAllErrors());

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/UserControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/UserControllerTest.java
@@ -2728,8 +2728,8 @@ class UserControllerTest {
         String result = userController.postUser(userDetailsForm, bindingResult, testSession, model);
 
         // Then
-        // EmailValidationService should still be called even with empty email
-        verify(emailValidationService).isValidEmailDomain("");
+        // EmailValidationService should not be called even with empty email
+        verify(emailValidationService, never()).isValidEmailDomain(any());
         assertThat(result).isEqualTo("add-user-details");
     }
 


### PR DESCRIPTION
### Description :pencil:

Please fill in.
https://dsdmoj.atlassian.net/browse/STB-2928
email check service will only verify not empty email value, the empty or null check will be handled by form validation 
---

### Changes Made :pencil:

- 
- 
- 

---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [ ] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [ ] I have a corresponding JIRA ticket for this change 
- [ ] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:

Please fill in.

---