### PR TITLE
STB-2941: Fixed bug where firm details could be lost from creation flow while navigating

### DIFF
--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
@@ -452,6 +452,13 @@ public class UserController {
         if (existingForm != null) {
             firmSearchForm = existingForm;
             session.removeAttribute("firmSearchForm");
+        } else if (session.getAttribute("firm") != null) {
+            // Grab firm search details from session firm if coming here from the confirmation screen.
+            FirmDto firm = (FirmDto) session.getAttribute("firm");
+            firmSearchForm = FirmSearchForm.builder()
+                    .selectedFirmId(firm.getId())
+                    .firmSearch(firm.getName())
+                    .build();
         }
         int validatedCount = Math.max(10, Math.min(count, 100));
         model.addAttribute("firmSearchForm", firmSearchForm);

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/UserControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/UserControllerTest.java
@@ -4049,6 +4049,31 @@ class UserControllerTest {
     }
 
     @Test
+    void testCreateUserFirm_WithExistingFirmInSession_ShouldUseExistingFirm() {
+        // Given
+        FirmDto existingFirm = FirmDto.builder()
+                .id(UUID.randomUUID())
+                .name("Existing Firm")
+                .build();
+
+        FirmSearchForm newForm = FirmSearchForm.builder().build();
+        MockHttpSession testSession = new MockHttpSession();
+        testSession.setAttribute("firm", existingFirm);
+        Model testModel = new ExtendedModelMap();
+
+        // When
+        String view = userController.createUserFirm(newForm, testSession, testModel, 10);
+
+        // Then
+        assertThat(view).isEqualTo("add-user-firm");
+        FirmSearchForm returnedForm = (FirmSearchForm) testModel.getAttribute("firmSearchForm");
+        assertThat(returnedForm).isNotNull();
+        assertThat(returnedForm.getSelectedFirmId()).isEqualTo(existingFirm.getId());
+        assertThat(returnedForm.getFirmSearch()).isEqualTo(existingFirm.getName());
+        assertThat(testSession.getAttribute("firmSearchForm")).isNull(); // Should be removed after use
+    }
+
+    @Test
     void testSearchFirms_ShouldReturnFirmList() {
         // Given
         String query = "Test Firm";


### PR DESCRIPTION
### Description :pencil:

When navigating around the create user flow, a specific sequence of actions could cause the firm search screen to not remember the selected firm and appear blank. Added a fallback to the firm search endpoint so it can always retrieve the currently selected firm.

---

### Changes Made :pencil:

- Added a fallback to ensure any firm in session will populate the firm search screen.
- Added unit test.

---

### Checklist :pencil:

- [X] I have added the relevant Liquibase changelog files for any entity changes
- [X] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [X] I have taken into account the application runs as 3 replicas in live environments
- [X] I have created any relevant documentation for this change
- [X] I have a corresponding JIRA ticket for this change 
- [X] I have added relevant unit & integration tests where applicable

---
