### PR TITLE
STB-2669 - dded firm code to org switcher

### DIFF
--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/GlobalControllerAdvice.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/GlobalControllerAdvice.java
@@ -48,7 +48,9 @@ public class GlobalControllerAdvice {
                 //have active profile
                 if (Objects.nonNull(up)) {
                     String firmName = up.getFirm().getName();
+                    String firmCode = up.getFirm().getCode();
                     firm.setName(firmName);
+                    firm.setCode(firmCode);
                     //have more than 1 firms
                     if (entraUser.getUserProfiles().size() > 1) {
                         firm.setCanChange(true);
@@ -63,7 +65,9 @@ public class GlobalControllerAdvice {
                 UserProfile up = entraUser.getUserProfiles().stream().findFirst().get();
                 if (up.getUserType().equals(UserType.EXTERNAL)) {
                     String firmName = up.getFirm().getName();
+                    String firmCode = up.getFirm().getCode();
                     firm.setName(firmName);
+                    firm.setCode(firmCode);
                     firm.setCanChange(false);
                 } else {
                     //internal

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -11,23 +11,21 @@
 <body>
     <main class="govuk-main-wrapper" id="main-content">
         <!-- Success banner for firm switch -->
-        <div th:if="${messageType == 'success' and activeFirm != null}"
-            id="firm-switch-success-banner"
-            class="govuk-notification-banner govuk-notification-banner--success"
-            role="alert"
-            th:attr="aria-labelledby='govuk-notification-banner-title'"
-            data-module="govuk-notification-banner"
+        <div th:if="${messageType == 'success' and activeFirm != null}" id="firm-switch-success-banner"
+            class="govuk-notification-banner govuk-notification-banner--success" role="alert"
+            th:attr="aria-labelledby='govuk-notification-banner-title'" data-module="govuk-notification-banner"
             style="position: relative;">
             <div class="govuk-notification-banner__header">
                 <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
                     Success
                 </h2>
             </div>
-            <div class="govuk-notification-banner__content" style="display: flex; justify-content: space-between; align-items: center;">
+            <div class="govuk-notification-banner__content"
+                style="display: flex; justify-content: space-between; align-items: center;">
                 <p class="govuk-notification-banner__heading" style="margin: 0;">
                     You are now working on behalf of <span th:text="${activeFirm.getName()}">Firm Name</span>
                 </p>
-                <button type="button" class="govuk-link" 
+                <button type="button" class="govuk-link"
                     style="background: none; border: none; cursor: pointer; text-decoration: underline; color: #1d70b8; font-size: 19px; line-height: 1.31579; margin-left: 20px; white-space: nowrap;"
                     onclick="document.getElementById('firm-switch-success-banner').style.display='none';">
                     Dismiss
@@ -61,12 +59,12 @@
                 <div th:if="${userHasNoRoles}" class="govuk-grid-row">
                     <div class="govuk-grid-column-full">
                         <div class="govuk-inset-text">
-                            <p th:if="${isInternalUser}">You cannot currently access any services. Please contact
+                            <p>Your account has been activated.</p>
+                            <p th:if="${isInternalUser}">You cannot currently access any services. Contact
                                 the
                                 MOJ Service Desk to request access.</p>
-                            <p th:unless="${isInternalUser}">You cannot currently access any services. Please
-                                contact
-                                your Firm Admin to request access.</p>
+                            <p th:unless="${isInternalUser}">You cannot currently access any services. Contact your
+                                Provider Admin to request access.</p>
                         </div>
                     </div>
                 </div>

--- a/src/main/resources/templates/layout.html
+++ b/src/main/resources/templates/layout.html
@@ -28,7 +28,7 @@
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-two-thirds">
                     <p class="govuk-body-m govuk-!-margin-bottom-0">
-                        <strong th:text="${activeFirm.getName()}"></strong>
+                        <strong th:text="${activeFirm.getName() + (activeFirm.getCode() != null ? ' - ' + activeFirm.getCode() : '')}"></strong>
                     </p>
                 </div>
                 <div class="govuk-grid-column-one-third" style="text-align: right;">


### PR DESCRIPTION
### Description :pencil:

Added firm code to org switcher

<img width="1708" height="897" alt="Screenshot 2025-10-24 at 16 48 06" src="https://github.com/user-attachments/assets/8566b075-5ccd-4bd1-92a3-7a2faa23040d" />


---

### Changes Made :pencil:

This pull request updates the way firm information is displayed and handled in both the backend and frontend, with a focus on including the firm code alongside the firm name. It also improves messaging for users with no roles, making it clearer and more relevant depending on their user type.

**Firm Information Enhancements:**

* The backend now sets both the `name` and `code` fields on the `FirmDto` object when determining the active firm, ensuring the firm code is available throughout the application. [[1]](diffhunk://#diff-4b19ec977e210b3a0c031979e99b76421b3f30d87e5e06bf7a67d71114e14981R51-R53) [[2]](diffhunk://#diff-4b19ec977e210b3a0c031979e99b76421b3f30d87e5e06bf7a67d71114e14981R68-R70)
* The frontend displays both the firm name and code together (e.g., "Firm Name - CODE") in the layout header, making it easier for users to identify the active firm.

**User Messaging Improvements:**

* The notification banner and role access messages on the home page have been updated for clarity and relevance. Internal users are now instructed to contact the MOJ Service Desk, while external users are told to contact their Provider Admin. A new message confirms account activation for users with no roles.
* Minor formatting adjustments were made to the success notification banner for consistency.
---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [ ] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [x] I have a corresponding JIRA ticket for this change 
- [x] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:

Please fill in.

---