### PR TITLE
STB-3112 - Add delete user action to user details card

### DIFF
--- a/src/main/resources/templates/manage-user.html
+++ b/src/main/resources/templates/manage-user.html
@@ -119,9 +119,13 @@
                         <div class="govuk-summary-card">
                             <div class="govuk-summary-card__title-wrapper" style="align-items: center;">
                                 <h2 class="govuk-summary-card__title">User details</h2>
-                                <ul class="govuk-summary-card__actions" th:if="${canDeleteFirmProfile}">
-                                    <li class="govuk-summary-card__action">
-                                        <a class="govuk-link govuk-!-font-weight-regular" style="font-weight: normal;" 
+                                <ul class="govuk-summary-card__actions">
+                                    <li th:if="${canDeleteUser}" class="govuk-summary-card__action">
+                                        <a class="govuk-link govuk-!-font-weight-regular" style="font-weight: normal;"
+                                           th:href="@{'/admin/users/manage/' + ${user.id} + '/delete'}">Delete user</a>
+                                    </li>
+                                    <li th:if="${canDeleteFirmProfile}" class="govuk-summary-card__action">
+                                        <a class="govuk-link govuk-!-font-weight-regular" style="font-weight: normal;"
                                            th:href="@{/admin/multi-firm/user/delete-profile/{id}(id=${user.id})}">Revoke access</a>
                                     </li>
                                 </ul>


### PR DESCRIPTION
### Description :pencil:

Re-added Delete button to manage user profile

https://github.com/user-attachments/assets/1f5ae6cb-c7aa-45cf-bad6-dd4dd18aadc8

---

### Changes Made :pencil:

This pull request makes a minor update to the user management interface. The main change is that the "Delete user" action is now conditionally displayed based on the `canDeleteUser` variable, in addition to the existing "Revoke access" option.

* Added a "Delete user" link to the user details card, shown only when `canDeleteUser` is true, and updated the conditional logic for displaying action links.
---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [ ] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [ ] I have a corresponding JIRA ticket for this change 
- [ ] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:

Please fill in.

---