### PR TITLE
STB3119 & STB-3133 - Safari styling & combining multi firm user row & actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ If a pipeline is picking up a vulnerability that you wish to add to the ignore l
 | APP_CRIME_APPLY_URL                 | URL of `Criminal Legal Aid` Application                                                                                                                              |
 | APP_PUI_DETAILS                     | Details of `CCMS` Application. The value should be in the form of app_name//app_entra_oid//app_security_group_name//app_security_group_id                            |
 | APP_PUI_NAME                        | Name of `CCMS` Application                                                                                                                                           |
-| APP_PUI_URL                         | Direct URL of `CCMS PUI` Application (used in the interstitial page to link to the actual PUI secure browser environment)                                            |
+| APP_PUI_URL                         | URL of `CCMS` Application                                            |
 | APP_SUBMIT_CRIME_FORM_DETAILS       | Details of `Submit Crime Form` Application. The value should be in the form of app_name//app_entra_oid//app_security_group_name//app_security_group_id               |
 | APP_SUBMIT_CRIME_FORM_NAME          | Name of `Submit Crime Form` Application                                                                                                                              |
 | APP_SUBMIT_CRIME_FORM_URL           | URL of `Submit Crime Form` Application                                                                                                                               |

--- a/src/main/resources/templates/manage-user.html
+++ b/src/main/resources/templates/manage-user.html
@@ -134,13 +134,12 @@
                                 <dl class="govuk-summary-list">
                                     <div class="govuk-summary-list__row">
                                         <dt class="govuk-summary-list__key">Email</dt>
-                                        <dd class="govuk-summary-list__value"
-                                            style="display:flex; justify-content: space-between; gap: 1rem; align-items: baseline;">
+                                        <dd class="govuk-summary-list__value">
                                             <span th:text="${user.entraUser.email}"></span>
+                                        </dd>
+                                        <dd class="govuk-summary-list__actions">
                                             <a th:if="${showResendVerificationLink}" class="govuk-link"
-                                                style="white-space: nowrap;"
-                                                th:href="@{/admin/user/{id}/verify(id=${user.id})}">Resend Activation
-                                                Code</a>
+                                                th:href="@{/admin/user/{id}/verify(id=${user.id})}">Resend Activation Code</a>
                                         </dd>
                                     </div>
                                     <div class="govuk-summary-list__row">
@@ -149,31 +148,14 @@
                                         </dt>
                                         <dd class="govuk-summary-list__value" th:text="${user.entraUser.firstName}">
                                         </dd>
+                                        <dd class="govuk-summary-list__actions"></dd>
                                     </div>
                                     <div class="govuk-summary-list__row">
                                         <dt class="govuk-summary-list__key">
                                             Last name
                                         </dt>
                                         <dd class="govuk-summary-list__value" th:text="${user.entraUser.lastName}"></dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row"
-                                        th:if="${enableMultiFirmUser and externalUser}">
-                                        <dt class="govuk-summary-list__key">
-                                            Multi-firm access
-                                        </dt>
-                                        <dd class="govuk-summary-list__value">
-                                            <span th:if="${user.entraUser.multiFirmUser}">
-                                                Yes
-                                            </span>
-                                            <span th:unless="${user.entraUser.multiFirmUser}">No</span>
-                                        </dd>
-                                        <dd class="govuk-summary-list__actions"
-                                            th:if="${enableMultiFirmUser != null and enableMultiFirmUser and !user.entraUser.multiFirmUser and canEditUser}">
-                                            <a class="govuk-link"
-                                                th:href="@{'/admin/users/edit/' + ${user.id} + '/convert-to-multi-firm'}">
-                                                Convert to multi-firm
-                                            </a>
-                                        </dd>
+                                        <dd class="govuk-summary-list__actions"></dd>
                                     </div>
                                     <div class="govuk-summary-list__row" th:if="${enableMultiFirmUser && canViewAllProfiles}">
                                         <dt class="govuk-summary-list__key">
@@ -182,16 +164,25 @@
                                         <dd class="govuk-summary-list__value">
                                             <span th:text="${user.firm.name}"></span> - <span th:text="${user.firm.code}"></span>
                                         </dd>
+                                        <dd class="govuk-summary-list__actions"></dd>
                                     </div>
-                                    <div class="govuk-summary-list__row" th:if="${enableMultiFirmUser && canViewAllProfiles}">
+                                    <div class="govuk-summary-list__row"
+                                        th:if="${enableMultiFirmUser and externalUser}">
                                         <dt class="govuk-summary-list__key">
                                             Multi-firm access
                                         </dt>
-                                        <dd class="govuk-summary-list__value" style="display:flex; justify-content: space-between; gap: 1rem; align-items: baseline;">
+                                        <dd class="govuk-summary-list__value">
                                             <span th:text="${user.entraUser.multiFirmUser} ? 'Yes' : 'No'"></span>
-                                            <a th:if="${user.entraUser.multiFirmUser}"
-                                               class="govuk-link" style="white-space: nowrap;"
+                                        </dd>
+                                        <dd class="govuk-summary-list__actions">
+                                            <a th:if="${user.entraUser.multiFirmUser && canViewAllProfiles}"
+                                               class="govuk-link"
                                                th:href="@{/admin/users (search=${user.entraUser.email})}">View all firms for <span th:text="${user.entraUser.fullName}"></span></a>
+                                            <a th:if="${enableMultiFirmUser != null and enableMultiFirmUser and !user.entraUser.multiFirmUser and canEditUser}"
+                                               class="govuk-link"
+                                               th:href="@{'/admin/users/edit/' + ${user.id} + '/convert-to-multi-firm'}">
+                                                Convert to multi-firm
+                                            </a>
                                         </dd>
                                     </div>
                                 </dl>


### PR DESCRIPTION
- Fixed Safari styling issues to match Chrome
- Combined Multi-firm access & actions to be on 1 row
- Reverted README entry to previous version

### Description :pencil:

### Chrome
<img width="1914" height="1055" alt="Screenshot 2025-11-04 at 10 49 44" src="https://github.com/user-attachments/assets/29a7beaf-83e8-436d-b427-77788a16bdeb" />

**convert to multi firm user**

<img width="1917" height="1053" alt="Screenshot 2025-11-04 at 10 50 28" src="https://github.com/user-attachments/assets/5c20f98c-ed0f-4ebe-8342-1049ecb1ec78" />


### Safari
<img width="1895" height="1042" alt="Screenshot 2025-11-04 at 10 50 10" src="https://github.com/user-attachments/assets/51c31fd8-164f-4ed9-9278-db63d75e6dec" />

**convert to multi firm user**

<img width="1898" height="1037" alt="Screenshot 2025-11-04 at 10 50 46" src="https://github.com/user-attachments/assets/2a50b495-f2a5-4cf7-975d-0f192d31f833" />


### Changes Made :pencil:

This pull request updates the user management UI and documentation for application environment variables. The main focus is on improving the layout and logic of the user details summary card, particularly around multi-firm access, and clarifying the documentation for environment variables.

**User details summary card improvements:**

* Refactored the `Email`, `First name`, `Last name`, and `Firm` fields in `manage-user.html` to use separate summary list action cells, improving clarity and consistency in the UI. [[1]](diffhunk://#diff-e687d7fb36c1e4429780d9d4c1569e1332afd69837e881337c296ff589df4c15L137-R142) [[2]](diffhunk://#diff-e687d7fb36c1e4429780d9d4c1569e1332afd69837e881337c296ff589df4c15R151-R158) [[3]](diffhunk://#diff-e687d7fb36c1e4429780d9d4c1569e1332afd69837e881337c296ff589df4c15R167-R185)
* Updated the logic for displaying multi-firm access: now the row appears when both `enableMultiFirmUser` and `externalUser` are true, and the actions cell provides links to view all firms or convert to multi-firm as appropriate.

**Documentation update:**

* Simplified the description for the `APP_PUI_URL` environment variable in `README.md` to clarify that it is the URL of the CCMS application.

---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [ ] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [x] I have a corresponding JIRA ticket for this change 
- [ ] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:

Please fill in.

---