### PR TITLE
STB-3088

### DIFF
--- a/src/main/resources/templates/layout.html
+++ b/src/main/resources/templates/layout.html
@@ -24,7 +24,7 @@
             </p>
         </div>
         <div class="govuk-!-padding-top-2 govuk-!-padding-bottom-2" style="border-bottom: 1px solid #b1b4b6;"
-            th:if="${enableMultiFirmUser != null and enableMultiFirmUser and activeFirm != null and pageCategory == 'home'}">
+            th:if="${activeFirm != null and isExternal}">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-two-thirds">
                     <p class="govuk-body-m govuk-!-margin-bottom-0">
@@ -32,7 +32,7 @@
                     </p>
                 </div>
                 <div class="govuk-grid-column-one-third" style="text-align: right;">
-                    <a href="/switch-firm" class="govuk-link govuk-body-m" th:if="${activeFirm.isCanChange()}">Switch firm</a>
+                    <a href="/switch-firm" class="govuk-link govuk-body-m" th:if="${enableMultiFirmUser and activeFirm.isCanChange() and pageCategory == 'home'}">Switch firm</a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
https://github.com/user-attachments/assets/e762e15c-186a-4b56-9ce2-95915fbc8da6

### Description :pencil:

- Show Firm name + code for multi firm user.
- Only show Firm name + Code AND Switch firm link on /home

---

### Changes Made :pencil:

This pull request updates the conditional display logic for the active firm section in `layout.html`, refining when the firm details and "Switch firm" link are shown.

Changes to conditional rendering of firm information:

* The firm details section now displays only if `activeFirm` is not null and the user is external, instead of relying on multiple conditions involving `enableMultiFirmUser` and `pageCategory`.
* The "Switch firm" link is now shown only if multi-firm user functionality is enabled, the active firm can be changed, and the current page is the home page.

---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [ ] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [x] I have a corresponding JIRA ticket for this change 
- [x] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:

Please fill in.

---