### PR TITLE
STB-3168: Added condition to displaying offices tab

### DIFF
--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
@@ -329,8 +329,12 @@ public class UserController {
         boolean canManageOffices = hasEditOfficePermission && canEditUser;
 
         boolean showOfficesTab = hasViewOfficePermission || canManageOffices;
+
+        boolean isInternalUser = userService.isInternal(user.getEntraUser().getId());
+
         model.addAttribute("showOfficesTab", showOfficesTab);
         model.addAttribute("canManageOffices", canManageOffices);
+        model.addAttribute("isInternalUser", isInternalUser);
 
         model.addAttribute("canEditUser", canEditUser);
         model.addAttribute(ModelAttributes.PAGE_TITLE, "Manage user - " + user.getFullName());

--- a/src/main/resources/templates/manage-user.html
+++ b/src/main/resources/templates/manage-user.html
@@ -111,7 +111,7 @@
                                 Services
                             </a>
                         </li>
-                        <li th:if="${showOfficesTab}" class="govuk-tabs__list-item">
+                        <li th:if="${showOfficesTab and !isInternalUser}" class="govuk-tabs__list-item">
                             <a class="govuk-tabs__tab" href="#offices">
                                 Offices
                             </a>


### PR DESCRIPTION
### Description :pencil:

https://dsdmoj.atlassian.net/browse/STB-3168 

---

### Changes Made :pencil:

- Added new boolean to model into manage-user.html
- Added condition to thyme leaf to conditionally render tab if user is not type internal

---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [ ] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [ ] I have a corresponding JIRA ticket for this change 
- [ ] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:
Internal user
<img width="1326" height="744" alt="image" src="https://github.com/user-attachments/assets/724b0b2b-9888-4034-a0fb-d1d25cf7c96c" />
External User
<img width="1182" height="640" alt="image" src="https://github.com/user-attachments/assets/d394280c-08a7-4c6a-840f-c2aa82cd1775" />


---