### PR TITLE
STB-3139 - Show Revoke access for Firm managers only

### DIFF
--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
@@ -364,9 +364,14 @@ public class UserController {
         model.addAttribute("enableMultiFirmUser", enableMultiFirmUser);
         model.addAttribute("canViewAllFirmsOfMultiFirmUser", accessControlService.canViewAllFirmsOfMultiFirmUser());
 
+        // Check if this profile belongs to the logged-in user
+        boolean isOwnProfile = editorUserProfile.getId().equals(user.getId());
+
         if (isMultiFirmUser && enableMultiFirmUser) {
             // Check if user can delete the currently viewed profile (not all profiles)
-            boolean canDeleteFirmProfile = accessControlService.canDeleteFirmProfile(user.getId().toString());
+            // but not their own profile
+            boolean canDeleteFirmProfile = !isOwnProfile
+                    && accessControlService.canDeleteFirmProfile(user.getId().toString());
             model.addAttribute("canDeleteFirmProfile", canDeleteFirmProfile);
 
             // Get profile count for multi-firm users (using count query instead of fetching
@@ -375,8 +380,9 @@ public class UserController {
             model.addAttribute("profileCount", profileCount);
         } else if (enableMultiFirmUser) {
             // For non-multi-firm users, still add canDeleteFirmProfile if they have the
-            // permission
-            boolean canDeleteFirmProfile = accessControlService.canDeleteFirmProfile(user.getId().toString());
+            // permission but not their own profile
+            boolean canDeleteFirmProfile = !isOwnProfile
+                    && accessControlService.canDeleteFirmProfile(user.getId().toString());
             model.addAttribute("canDeleteFirmProfile", canDeleteFirmProfile);
 
             // Non-multi-firm users have exactly 1 profile

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/service/AccessControlService.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/service/AccessControlService.java
@@ -135,10 +135,11 @@ public class AccessControlService {
         // Check if authenticated user is internal (LAA staff)
         boolean isInternalUser = userService.isInternal(authenticatedUser.getId());
 
-        // Internal users with DELETE_EXTERNAL_USER permission can delete any firm
-        // profile
-        if (isInternalUser && userHasPermission(authenticatedUser, Permission.DELETE_EXTERNAL_USER)) {
-            return true;
+        // Only external users (provider admins/firm user managers) can delete firm
+        // profiles
+        // Internal users should not see the revoke link
+        if (isInternalUser) {
+            return false;
         }
 
         // Check if users are in the same firm
@@ -146,8 +147,7 @@ public class AccessControlService {
 
         // External users (firm admins) with DELEGATE_EXTERNAL_USER_ACCESS can only
         // delete profiles from their own firm
-        if (!isInternalUser && sameFirm
-                && userHasPermission(authenticatedUser, Permission.DELEGATE_EXTERNAL_USER_ACCESS)) {
+        if (sameFirm && userHasPermission(authenticatedUser, Permission.DELEGATE_EXTERNAL_USER_ACCESS)) {
             return true;
         }
 

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/service/AccessControlServiceTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/service/AccessControlServiceTest.java
@@ -565,7 +565,7 @@ public class AccessControlServiceTest {
     }
 
     @Test
-    public void testCanDeleteFirmProfile_InternalUserWithPermission_CanDelete() {
+    public void testCanDeleteFirmProfile_InternalUserWithPermission_CannotDelete() {
         // Setup authentication
         AnonymousAuthenticationToken authentication = Mockito.mock(AnonymousAuthenticationToken.class);
         SecurityContext securityContext = Mockito.mock(SecurityContext.class);
@@ -573,6 +573,7 @@ public class AccessControlServiceTest {
         SecurityContextHolder.setContext(securityContext);
 
         // Internal user with DELETE_EXTERNAL_USER permission
+        // Internal users should NOT be able to delete firm profiles (only provider admins can)
         UUID userId = UUID.randomUUID();
         Permission deletePermission = Permission.DELETE_EXTERNAL_USER;
         AppRole appRole = AppRole.builder().authzRole(true).permissions(Set.of(deletePermission)).build();
@@ -603,7 +604,7 @@ public class AccessControlServiceTest {
         Mockito.when(userService.isInternal(userId)).thenReturn(true);
 
         boolean result = accessControlService.canDeleteFirmProfile(targetProfileId.toString());
-        Assertions.assertThat(result).isTrue();
+        Assertions.assertThat(result).isFalse();
     }
 
     @Test


### PR DESCRIPTION
### Description :pencil:

✅ The user must be viewing a multi-firm external user's profile
✅ The logged-in user must be an external user (provider admin)
✅ The logged-in user must have the `DELEGATE_EXTERNAL_USER_ACCESS` permission (Firm User Manager role)
✅ The logged-in user must be in the same firm as the profile being viewed
✅ The profile being viewed must not be the logged-in user's own profile

---

### Changes Made :pencil:

This pull request updates user profile management permissions to ensure that users cannot delete their own profiles and that only external users (provider admins) can delete firm profiles, not internal users. It also adds and updates tests to verify these permission changes.

**Access control logic updates:**

* Updated `canDeleteFirmProfile` in `AccessControlService` to prevent internal users from deleting firm profiles, regardless of their permissions. Only external users (provider admins) can perform this action.

**User profile management behavior:**

* Modified `manageUser` in `UserController` so the "revoke" (delete) link is hidden when a user is viewing their own profile, both for multi-firm and non-multi-firm users. [[1]](diffhunk://#diff-1c3931784714b5992966f392b56dad9140ea42ba7303dfce45c2cb8533ed3885R367-R374) [[2]](diffhunk://#diff-1c3931784714b5992966f392b56dad9140ea42ba7303dfce45c2cb8533ed3885L378-R385)

**Testing and verification:**

* Added unit tests in `UserControllerTest` to verify that the "revoke" link is hidden when viewing one's own profile and visible when viewing another user's profile.
* Updated `AccessControlServiceTest` to assert that internal users cannot delete firm profiles, even if they have the relevant permission. [[1]](diffhunk://#diff-ec3dea3ad9fb5e961fe7fa207336d1f723b92e5aa2df7891cd1c4e32d784a613L568-R576) [[2]](diffhunk://#diff-ec3dea3ad9fb5e961fe7fa207336d1f723b92e5aa2df7891cd1c4e32d784a613L606-R607)
---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [ ] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [ ] I have a corresponding JIRA ticket for this change 
- [ ] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:

Please fill in.

---