### PR TITLE
STB-3127: Restrict audit table access to GA and Information & Assurance

### DIFF
--- a/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/RoleBasedAccessAuditTableTest.java
+++ b/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/RoleBasedAccessAuditTableTest.java
@@ -1,0 +1,114 @@
+package uk.gov.justice.laa.portal.landingpage.controller;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultMatcher;
+import org.springframework.web.servlet.ModelAndView;
+import uk.gov.justice.laa.portal.landingpage.entity.EntraUser;
+import java.util.Map;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class RoleBasedAccessAuditTableTest extends RoleBasedAccessIntegrationTest {
+
+    @Test
+    public void testGlobalAdminCanAccessAuditTableAndSeeLink() throws Exception {
+        EntraUser globalAdmin = globalAdmins.getFirst();
+        testCanAccessAuditTable(globalAdmin, status().isOk());
+        testCanSeeAuditLink(globalAdmin, true);
+    }
+
+    @Test
+    public void testInformationAndAssuranceCanAccessAuditTableAndSeeLink() throws Exception {
+        EntraUser informationAndAssuranceUser = informationAndAssuranceUsers.getFirst();
+        testCanAccessAuditTable(informationAndAssuranceUser, status().isOk());
+        testCanSeeAuditLink(informationAndAssuranceUser, true);
+    }
+
+    @Test
+    public void testInternalUserManagerCannotAccessAuditTableAndCannotSeeLink() throws Exception {
+        EntraUser internalUserManager = internalUserManagers.getFirst();
+        testCanAccessAuditTable(internalUserManager, status().is4xxClientError());
+        testCanSeeAuditLink(internalUserManager, false);
+    }
+
+    @Test
+    public void testInternalUserWithExternalUserManagerCannotAccessAuditTableAndCannotSeeLink() throws Exception {
+        EntraUser internalUserWithExternalUserManager = internalWithExternalOnlyUserManagers.getFirst();
+        testCanAccessAuditTable(internalUserWithExternalUserManager, status().is4xxClientError());
+        testCanSeeAuditLink(internalUserWithExternalUserManager, false);
+    }
+
+    @Test
+    public void testInternalUserWithInternalAndExternalUserManagerCannotAccessAuditTableAndCannotSeeLink() throws Exception {
+        EntraUser internalUserWithInternalAndExternalUserManager = internalAndExternalUserManagers.getFirst();
+        testCanAccessAuditTable(internalUserWithInternalAndExternalUserManager, status().is4xxClientError());
+        testCanSeeAuditLink(internalUserWithInternalAndExternalUserManager, false);
+    }
+
+    @Test
+    public void testInternalUserViewerCannotAccessAuditTableAndCannotSeeLink() throws Exception {
+        EntraUser internalUserViewer = internalUserViewers.getFirst();
+        testCanAccessAuditTable(internalUserViewer, status().is4xxClientError());
+        testCanSeeAuditLink(internalUserViewer, false);
+    }
+
+    @Test
+    public void testExternalUserViewerCannotAccessAuditTableAndCannotSeeLink() throws Exception {
+        EntraUser externalUserViewer = externalUserViewers.getFirst();
+        testCanAccessAuditTable(externalUserViewer, status().is4xxClientError());
+        testCanSeeAuditLink(externalUserViewer, false);
+    }
+
+    @Test
+    public void testExternalUserAdminCannotAccessAuditTableAndCannotSeeLink() throws Exception {
+        EntraUser externalUserAdmin = externalUserAdmins.getFirst();
+        testCanAccessAuditTable(externalUserAdmin, status().is4xxClientError());
+        testCanSeeAuditLink(externalUserAdmin, false);
+    }
+
+    @Test
+    public void testInternalUserNoRolesCannotAccessAuditTableAndCannotSeeLink() throws Exception {
+        EntraUser internalUserNoRoles = internalUsersNoRoles.getFirst();
+        testCanAccessAuditTable(internalUserNoRoles, status().is4xxClientError());
+        testCanSeeAuditLink(internalUserNoRoles, false);
+    }
+
+    @Test
+    public void testExternalUserNoRolesCannotAccessAuditTableAndCannotSeeLink() throws Exception {
+        EntraUser externalUserNoRoles = externalUsersNoRoles.getFirst();
+        testCanAccessAuditTable(externalUserNoRoles, status().is4xxClientError());
+        testCanSeeAuditLink(externalUserNoRoles, false);
+    }
+
+
+
+    @Test
+    public void testFirmUserManagerCannotAccessAuditTableAndCannotSeeLink() throws Exception {
+        EntraUser firmUserManager = externalOnlyUserManagers.getFirst();
+        testCanAccessAuditTable(firmUserManager, status().is4xxClientError());
+        testCanSeeAuditLink(firmUserManager, false);
+    }
+
+
+
+    public void testCanAccessAuditTable(EntraUser loggedInUser, ResultMatcher expectedResult) throws Exception {
+        this.mockMvc.perform(get("/admin/users/audit")
+                        .with(userOauth2Login(loggedInUser)))
+                .andExpect(expectedResult);
+    }
+
+    public void testCanSeeAuditLink(EntraUser loggedInUser, boolean canSeeLink) throws Exception {
+        MvcResult result = this.mockMvc.perform(get("/home")
+                        .with(userOauth2Login(loggedInUser))).andReturn();
+        ModelAndView modelAndView = result.getModelAndView();
+        if (modelAndView == null) {
+            Assertions.fail();
+        }
+        Map<String, Object> model = modelAndView.getModel();
+        boolean canViewAuditTable = (boolean) model.get("canViewAuditTable");
+        Assertions.assertEquals(canSeeLink, canViewAuditTable);
+    }
+}

--- a/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/RoleBasedAccessIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/RoleBasedAccessIntegrationTest.java
@@ -62,6 +62,7 @@ public abstract class RoleBasedAccessIntegrationTest extends BaseIntegrationTest
     protected List<EntraUser> multiFirmUsers = new ArrayList<>();
     protected List<EntraUser> globalAdmins = new ArrayList<>();
     protected List<EntraUser> firmUserManagers = new ArrayList<>();
+    protected List<EntraUser> informationAndAssuranceUsers = new ArrayList<>();
     protected List<EntraUser> allUsers = new ArrayList<>();
 
     @BeforeAll
@@ -283,6 +284,19 @@ public abstract class RoleBasedAccessIntegrationTest extends BaseIntegrationTest
         profile.setEntraUser(user);
         multiFirmUsers.add(entraUserRepository.saveAndFlush(user));
 
+        // Set up Information & Assurance User
+        user = buildEntraUser(UUID.randomUUID().toString(), String.format("test%d@test.com", emailIndex++), "Internal", "InformationAndAssuranceUser");
+        profile = buildLaaUserProfile(user, UserType.INTERNAL, true);
+        AppRole informationAndAssuranceRole = allAppRoles.stream()
+                .filter(AppRole::isAuthzRole)
+                .filter(role -> role.getName().equals("Information & Assurance"))
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("Could not find app role"));
+        profile.setAppRoles(Set.of(informationAndAssuranceRole));
+        user.setUserProfiles(Set.of(profile));
+        profile.setEntraUser(user);
+        informationAndAssuranceUsers.add(entraUserRepository.saveAndFlush(user));
+
 
         allUsers.addAll(internalUsersNoRoles);
         allUsers.addAll(internalUserManagers);
@@ -296,6 +310,7 @@ public abstract class RoleBasedAccessIntegrationTest extends BaseIntegrationTest
         allUsers.addAll(internalUserViewers);
         allUsers.addAll(externalUserViewers);
         allUsers.addAll(multiFirmUsers);
+        allUsers.addAll(informationAndAssuranceUsers);
     }
 
     protected void clearRepositories() {

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/AuditController.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/AuditController.java
@@ -35,8 +35,7 @@ public class AuditController {
      */
     @GetMapping("/users/audit")
     @PreAuthorize("@accessControlService.authenticatedUserHasAnyGivenPermissions("
-            + "T(uk.gov.justice.laa.portal.landingpage.entity.Permission).VIEW_INTERNAL_USER, "
-            + "T(uk.gov.justice.laa.portal.landingpage.entity.Permission).VIEW_EXTERNAL_USER)")
+            + "T(uk.gov.justice.laa.portal.landingpage.entity.Permission).VIEW_AUDIT_TABLE)")
     public String displayAuditTable(
             @RequestParam(name = "size", defaultValue = "10") int size,
             @RequestParam(name = "page", defaultValue = "1") int page,
@@ -70,9 +69,6 @@ public class AuditController {
         firmSearchForm.setFirmSearch(firmSearch);
         firmSearchForm.setSelectedFirmId(firmId);
 
-        // Get all SiLAS roles for dropdown filter
-        final List<AppRoleDto> silasRoles = userService.getAllSilasRoles();
-
         // Add attributes to model
         model.addAttribute("users", paginatedUsers.getUsers());
         model.addAttribute("requestedPageSize", size);
@@ -82,6 +78,8 @@ public class AuditController {
         model.addAttribute("totalPages", paginatedUsers.getTotalPages());
         model.addAttribute("search", search);
         model.addAttribute("firmSearch", firmSearchForm);
+        // Get all SiLAS roles for dropdown filter
+        List<AppRoleDto> silasRoles = userService.getAllSilasRoles();
         model.addAttribute("silasRoles", silasRoles);
         model.addAttribute("selectedSilasRole", silasRole != null ? silasRole : "");
         model.addAttribute("sort", sort);

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/LoginController.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/LoginController.java
@@ -83,13 +83,16 @@ public class LoginController {
                 model.addAttribute("lastLogin", "N/A");
                 model.addAttribute("laaApplications", userSessionData.getLaaApplications());
                 boolean isAdmin = false;
+                boolean canViewAuditTable = false;
                 if (userSessionData.getUser() != null) {
                     Set<Permission> permissions = userService
                             .getUserPermissionsByUserId(userSessionData.getUser().getId());
                     isAdmin = permissions.contains(Permission.VIEW_EXTERNAL_USER)
                             || permissions.contains(Permission.VIEW_INTERNAL_USER);
+                    canViewAuditTable = permissions.contains(Permission.VIEW_AUDIT_TABLE);
                 }
                 model.addAttribute("isAdminUser", isAdmin);
+                model.addAttribute("canViewAuditTable", canViewAuditTable);
 
                 // Check if user has no roles assigned and determine user type for custom
                 // message

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/entity/Permission.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/entity/Permission.java
@@ -16,7 +16,8 @@ public enum Permission {
     VIEW_USER_OFFICE,
     EDIT_USER_DETAILS,
     DELEGATE_EXTERNAL_USER_ACCESS,
-    DELETE_EXTERNAL_USER;
+    DELETE_EXTERNAL_USER,
+    VIEW_AUDIT_TABLE;
 
     public static final String[] ADMIN_PERMISSIONS = {
             VIEW_INTERNAL_USER.name(),
@@ -30,6 +31,7 @@ public enum Permission {
             VIEW_USER_OFFICE.name(),
             EDIT_USER_DETAILS.name(),
             DELETE_EXTERNAL_USER.name(),
-            VIEW_ALL_USER_MULTI_FIRM_PROFILES.name()
+            VIEW_ALL_USER_MULTI_FIRM_PROFILES.name(),
+            VIEW_AUDIT_TABLE.name()
     };
 }

--- a/src/main/resources/db/changelog/changesets/db.changesets-4.9.yaml
+++ b/src/main/resources/db/changelog/changesets/db.changesets-4.9.yaml
@@ -1,0 +1,16 @@
+databaseChangeLog:
+  - changeSet:
+      id: 1762344000645-1
+      author: niall.mcmahon
+      changes:
+        # Create new Information & Assurance role.
+        - sql:
+            dbms: postgresql
+            sql: "INSERT INTO app_role (id, app_id, name, description, user_type_restriction, authz_role, ordinal) VALUES (gen_random_uuid(), (SELECT id FROM app WHERE name = 'Manage Your Users'), 'Information & Assurance', 'A view-only role for accessing audit information', ARRAY ['INTERNAL'], true, 6)"
+        # Add the VIEW_AUDIT_TABLE permission to Global Admin and Information & Assurance roles.
+        - sql:
+            dbms: postgresql
+            sql: "INSERT INTO role_permission (app_role_id, permission) VALUES ((SELECT id FROM app_role WHERE name = 'Global Admin'), 'VIEW_AUDIT_TABLE')"
+        - sql:
+            dbms: postgresql
+            sql: "INSERT INTO role_permission (app_role_id, permission) VALUES ((SELECT id FROM app_role WHERE name = 'Information & Assurance'), 'VIEW_AUDIT_TABLE')"

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -52,15 +52,15 @@
                             </div>
                         </div>
                     </div>
+                </div>
 
-                    <div class="govuk-grid-row govuk-!-margin-top-4" th:if="${enableUserAuditTable}">
-                        <div class="govuk-grid-column-full">
-                            <div class="moj-ticket-panel__content moj-ticket-panel__content--blue">
-                                <h3 class="govuk-heading-m">
-                                    <a href="/admin/users/audit" class="govuk-link govuk-link--no-visited-state">User Access Audit Table</a>
-                                </h3>
-                                <p class="govuk-body">View all registered users including account status and role assignments</p>
-                            </div>
+                <div th:if="${canViewAuditTable && enableUserAuditTable}" class="govuk-grid-row govuk-!-margin-top-4">
+                    <div class="govuk-grid-column-full">
+                        <div class="moj-ticket-panel__content moj-ticket-panel__content--blue">
+                            <h3 class="govuk-heading-m">
+                                <a href="/admin/users/audit" class="govuk-link govuk-link--no-visited-state">User Access Audit Table</a>
+                            </h3>
+                            <p class="govuk-body">View all registered users including account status and role assignments</p>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
### Description :pencil:

Added new permissions for accessing the audit table page

---

### Changes Made :pencil:

- Added new "Information & Assurance" role.
- Added new VIEW_AUDIT_TABLE permission.
- Added migrations for configuring new role and permission.
- Changed audit controller to require new permission.
- Updated home page to conditionally render audit table link based on new permission.
- Added RBAC integration tests for audit table and home page link.

---

### Checklist :pencil:

- [X] I have added the relevant Liquibase changelog files for any entity changes
- [X] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [X] I have taken into account the application runs as 3 replicas in live environments
- [X] I have created any relevant documentation for this change
- [X] I have a corresponding JIRA ticket for this change 
- [X] I have added relevant unit & integration tests where applicable
