### PR TITLE
STB-3251 - Refactor URL mappings in Thymeleaf templates to use safer path variable syntax

### DIFF
--- a/src/main/resources/templates/convert-to-multi-firm/index.html
+++ b/src/main/resources/templates/convert-to-multi-firm/index.html
@@ -11,13 +11,13 @@
 
 <body>
     <nav aria-label="Breadcrumb" class="govuk-breadcrumbs" id="breadcrumbs">
-        <a class="govuk-back-link" th:href="@{'/admin/users/manage/' + ${user.id}}">
-            Back</a>
+        <a class="govuk-back-link" th:href="@{/admin/users/manage/{id}(id=${user.id})}">
+            Back </a>
     </nav>
     <main class="govuk-main-wrapper" id="main-content">
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
-                <form th:action="@{'/admin/users/edit/' + ${user.id} + '/convert-to-multi-firm'}" th:method="post" th:object="${convertToMultiFirmForm}">
+                <form th:action="@{/admin/users/edit/{id}/convert-to-multi-firm(id=${user.id})}" th:method="post" th:object="${convertToMultiFirmForm}">
                     <div th:if="${#fields.hasErrors()}">
                         <div class="govuk-error-summary" role="alert" aria-labelledby="error-summary-title"
                             aria-describedby="error-summary-description" data-module="govuk-error-summary">

--- a/src/main/resources/templates/delete-user-reason.html
+++ b/src/main/resources/templates/delete-user-reason.html
@@ -23,7 +23,7 @@
         </div>
     </div>
 
-    <a class="govuk-back-link" th:href="@{'/admin/users/manage/' + ${user.id}}">Back</a>
+    <a class="govuk-back-link" th:href="@{/admin/users/manage/{id}(id=${user.id})}">Back</a>
 
     <h1 class="govuk-heading-l">
         Are you sure you want to remove access for <span th:text="${user.fullName}"></span>?
@@ -31,7 +31,7 @@
 
     <p class="govuk-body">This will remove the user's access in SiLAS right away and start the process to remove their access in Microsoft Entra. Their account may still be active for a short time until Microsoft fully deletes it.</p>
 
-    <form th:action="@{'/admin/users/manage/' + ${user.id} + '/delete'}" method="post" novalidate>
+    <form th:action="@{/admin/users/manage/{id}/delete(id=${user.id})}" method="post" novalidate>
         <div class="govuk-form-group" th:classappend="${fieldErrorMessage} ? ' govuk-form-group--error'">
             <label class="govuk-label" for="reason" th:if="${fieldErrorMessage == null || fieldErrorMessage == ''}">>Please enter a reason (minimum 10 characters).</label>
             <span class="govuk-error-message" th:if="${fieldErrorMessage}">
@@ -45,7 +45,7 @@
             <button type="submit" class="govuk-button" data-module="govuk-button">
                 Confirm and delete user
             </button>
-            <a class="govuk-link" th:href="@{'/admin/users/manage/' + ${user.id}}">Cancel</a>
+            <a class="govuk-link" th:href="@{/admin/users/manage/{id}(id=${user.id})}">Cancel</a>
         </div>
         <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
     </form>

--- a/src/main/resources/templates/edit-user-apps.html
+++ b/src/main/resources/templates/edit-user-apps.html
@@ -11,7 +11,7 @@
 
 <body>
     <nav aria-label="Breadcrumb" class="govuk-breadcrumbs" id="breadcrumbs">
-        <a class="govuk-back-link" th:href="@{'/admin/users/edit/' + ${user.id} + '/cancel'}">
+        <a class="govuk-back-link" th:href="@{/admin/users/edit/{id}/cancel(id=${user.id})}">
             Back </a>
     </nav>
     <main class="govuk-main-wrapper" id="main-content">
@@ -52,7 +52,7 @@
             </div>
             <div class="govuk-button-group">
                 <button type="submit" class="govuk-button">Continue</button>
-                <a th:href="@{'/admin/users/edit/' + ${user.id} + '/cancel'}" class="govuk-link">Cancel</a>
+                <a th:href="@{/admin/users/edit/{id}/cancel(id=${user.id})}" class="govuk-link">Cancel</a>
             </div>
         </form>
     </main>

--- a/src/main/resources/templates/edit-user-details-check-answer.html
+++ b/src/main/resources/templates/edit-user-details-check-answer.html
@@ -11,7 +11,7 @@
 
 <body>
     <nav aria-label="Breadcrumb" class="govuk-breadcrumbs" id="breadcrumbs">
-        <a class="govuk-back-link" th:href="@{'/admin/users/edit/' + ${user.id} + '/cancel'}">
+        <a class="govuk-back-link" th:href="@{/admin/users/edit/{id}/cancel(id=${user.id})}">
             Back </a>
     </nav>
     <main class="govuk-main-wrapper" id="main-content">
@@ -45,7 +45,7 @@
                                     <span th:text="*{firstName}"></span>
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
-                                    <a th:href="@{'/admin/users/edit/' + ${user.id} + '/details'}" class="govuk-link">Change</a>
+                                    <a th:href="@{/admin/users/edit/{id}/details(id=${user.id})}" class="govuk-link">Change</a>
                                 </dd>
                             </div>
                             <div class="govuk-summary-list__row">
@@ -54,7 +54,7 @@
                                     <span th:text="*{lastName}"></span>
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
-                                    <a th:href="@{'/admin/users/edit/' + ${user.id} + '/details'}" class="govuk-link">Change</a>
+                                    <a th:href="@{/admin/users/edit/{id}/details(id=${user.id})}" class="govuk-link">Change</a>
                                 </dd>
                             </div>
                         </dl>
@@ -65,7 +65,7 @@
                 </p>
                 <div class="govuk-button-group">
                     <button type="submit" class="govuk-button">Confirm</button>
-                    <a th:href="@{'/admin/users/edit/' + ${user.id} + '/cancel'}" class="govuk-link">Cancel</a>
+                    <a th:href="@{/admin/users/edit/{id}/cancel(id=${user.id})}" class="govuk-link">Cancel</a>
                 </div>
             </form>
         </fieldset>

--- a/src/main/resources/templates/edit-user-details.html
+++ b/src/main/resources/templates/edit-user-details.html
@@ -11,7 +11,7 @@
 
 <body>
     <nav aria-label="Breadcrumb" class="govuk-breadcrumbs" id="breadcrumbs">
-        <a class="govuk-back-link" th:href="@{'/admin/users/manage/' + ${user.id}}">
+        <a class="govuk-back-link" th:href="@{/admin/users/manage/{id}(id=${user.id})}">
             Back </a>
     </nav>
     <main class="govuk-main-wrapper" id="main-content">
@@ -77,7 +77,7 @@
                 </div>
                 <div class="govuk-button-group">
                     <button type="submit" class="govuk-button">Update</button>
-                    <a th:href="@{'/admin/users/edit/' + ${user.id} + '/cancel'}" class="govuk-link">Cancel</a>
+                    <a th:href="@{/admin/users/edit/{id}/cancel(id=${user.id})}" class="govuk-link">Cancel</a>
                 </div>
             </form>
         </fieldset>

--- a/src/main/resources/templates/edit-user-offices-check-answer.html
+++ b/src/main/resources/templates/edit-user-offices-check-answer.html
@@ -11,7 +11,7 @@
 
 <body>
     <nav aria-label="Breadcrumb" class="govuk-breadcrumbs" id="breadcrumbs">
-        <a class="govuk-back-link" th:href="@{'/admin/users/edit/' + ${user.id} + '/offices'}">
+        <a class="govuk-back-link" th:href="@{/admin/users/edit/{id}/offices(id=${user.id})}">
             Back </a>
     </nav>
     <main class="govuk-main-wrapper" id="main-content">
@@ -33,7 +33,7 @@
                                 (<span th:text="${office.code}"></span>)
                             </dd>
                             <dd class="govuk-summary-list__actions">
-                                <a th:href="@{'/admin/users/edit/' + ${user.id} + '/offices'}" class="govuk-link">Change</a>
+                                <a th:href="@{/admin/users/edit/{id}/offices(id=${user.id})}" class="govuk-link">Change</a>
                             </dd>
                         </div>
                     </dl>
@@ -43,7 +43,7 @@
                                 <span>Access to All Offices</span>
                             </dd>
                             <dd class="govuk-summary-list__actions">
-                                <a th:href="@{'/admin/users/edit/' + ${user.id} + '/offices'}" class="govuk-link">Change</a>
+                                <a th:href="@{/admin/users/edit/{id}/offices(id=${user.id})}" class="govuk-link">Change</a>
                             </dd>
                         </div>
                     </div>
@@ -54,7 +54,7 @@
             </p>
             <div class="govuk-button-group">
                 <button type="submit" class="govuk-button">Confirm</button>
-                <a th:href="@{'/admin/users/edit/' + ${user.id} + '/cancel'}" class="govuk-link">Cancel</a>
+                <a th:href="@{/admin/users/edit/{id}/cancel(id=${user.id})}" class="govuk-link">Cancel</a>
             </div>
         </form>
     </main>

--- a/src/main/resources/templates/edit-user-offices.html
+++ b/src/main/resources/templates/edit-user-offices.html
@@ -11,7 +11,7 @@
 
 <body>
     <nav aria-label="Breadcrumb" class="govuk-breadcrumbs" id="breadcrumbs">
-        <a class="govuk-back-link" th:href="@{'/admin/users/edit/' + ${user.id} + '/cancel'}">
+        <a class="govuk-back-link" th:href="@{/admin/users/edit/{id}/cancel(id=${user.id})}">
             Back </a>
     </nav>
     <main class="govuk-main-wrapper" id="main-content">
@@ -72,8 +72,8 @@
                 </fieldset>
             </div>
             <div class="govuk-button-group">
-                <button type="submit" class="govuk-button">Update</button>
-                <a th:href="@{'/admin/users/edit/' + ${user.id} + '/cancel'}" class="govuk-link">Cancel</a>
+                <button type="submit" class="govuk-button">Continue</button>
+                <a th:href="@{/admin/users/edit/{id}/cancel(id=${user.id})}" class="govuk-link">Cancel</a>
             </div>
         </form>
     </main>

--- a/src/main/resources/templates/edit-user-roles-check-answer.html
+++ b/src/main/resources/templates/edit-user-roles-check-answer.html
@@ -56,7 +56,7 @@
                             <span>No role assigned</span>
                         </dd>
                         <dd class="govuk-summary-list__actions">
-                            <a th:href="@{'/admin/users/edit/' + ${user.id} + '/apps'}" class="govuk-link">Change</a>
+                            <a th:href="@{/admin/users/edit/{id}/apps(id=${user.id})}" class="govuk-link">Change</a>
                         </dd>
                     </div>
                 </div>
@@ -67,7 +67,7 @@
         </p>
         <div class="govuk-button-group">
             <button type="submit" class="govuk-button">Confirm</button>
-            <a th:href="@{'/admin/users/edit/' + ${user.id} + '/cancel'}" class="govuk-link">Cancel</a>
+            <a th:href="@{/admin/users/edit/{id}/cancel(id=${user.id})}" class="govuk-link">Cancel</a>
         </div>
     </form>
 </main>

--- a/src/main/resources/templates/edit-user-roles.html
+++ b/src/main/resources/templates/edit-user-roles.html
@@ -184,7 +184,7 @@
                 </div>
                 <div class="govuk-button-group">
                     <button type="submit" class="govuk-button">Continue</button>
-                    <a th:href="@{'/admin/users/edit/' + ${user.id} + '/cancel'}" class="govuk-link">Cancel</a>
+                    <a th:href="@{/admin/users/edit/{id}/cancel(id=${user.id})}" class="govuk-link">Cancel</a>
                 </div>
             </form>
         </div>

--- a/src/main/resources/templates/grant-access-check-answers.html
+++ b/src/main/resources/templates/grant-access-check-answers.html
@@ -97,7 +97,7 @@
                         <button type="submit" class="govuk-button" data-module="govuk-button">
                             Confirm
                         </button>
-                        <a th:href="@{'/admin/users/grant-access/' + ${user.id} + '/cancel'}"
+                        <a th:href="@{/admin/users/grant-access/{id}/cancel(id=${user.id})}"
                             class="govuk-link">Cancel</a>
                     </div>
                 </form>

--- a/src/main/resources/templates/grant-access-user-apps.html
+++ b/src/main/resources/templates/grant-access-user-apps.html
@@ -11,8 +11,8 @@
 
 <body>
     <nav aria-label="Breadcrumb" class="govuk-breadcrumbs" id="breadcrumbs">
-        <a class="govuk-back-link govuk-!-margin-bottom-3" th:href="@{'/admin/users/manage/' + ${user.id}}">
-            Back</a>
+        <a class="govuk-back-link govuk-!-margin-bottom-3" th:href="@{/admin/users/manage/{id}(id=${user.id})}">
+            Back </a>
     </nav>
     <main class="govuk-main-wrapper" id="main-content">
         <form method="post" th:action="@{/admin/users/grant-access/{id}/apps(id=${user.id})}"
@@ -69,7 +69,7 @@
             </div>
             <div class="govuk-button-group">
                 <button type="submit" class="govuk-button">Continue</button>
-                <a th:href="@{'/admin/users/grant-access/' + ${user.id} + '/cancel'}" class="govuk-link">Cancel</a>
+                <a th:href="@{/admin/users/grant-access/{id}/cancel(id=${user.id})}" class="govuk-link">Cancel</a>
             </div>
         </form>
     </main>

--- a/src/main/resources/templates/grant-access-user-offices.html
+++ b/src/main/resources/templates/grant-access-user-offices.html
@@ -75,7 +75,7 @@
             </div>
             <div class="govuk-button-group">
                 <button type="submit" class="govuk-button">Continue</button>
-                <a th:href="@{'/admin/users/grant-access/' + ${user.id} + '/cancel'}" class="govuk-link">Cancel</a>
+                <a th:href="@{/admin/users/grant-access/{id}/cancel(id=${user.id})}" class="govuk-link">Cancel</a>
             </div>
         </form>
     </main>

--- a/src/main/resources/templates/grant-access-user-roles.html
+++ b/src/main/resources/templates/grant-access-user-roles.html
@@ -174,7 +174,7 @@
             </div>
             <div class="govuk-button-group">
                 <button type="submit" class="govuk-button">Continue</button>
-                <a th:href="@{'/admin/users/grant-access/' + ${user.id} + '/cancel'}" class="govuk-link">Cancel</a>
+                <a th:href="@{/admin/users/grant-access/{id}/cancel(id=${user.id})}" class="govuk-link">Cancel</a>
             </div>
         </form>
     </main>

--- a/src/main/resources/templates/manage-user.html
+++ b/src/main/resources/templates/manage-user.html
@@ -70,7 +70,7 @@
                             class="govuk-tag govuk-tag--green govuk-!-font-weight-bold govuk-!-margin-top-1">COMPLETE</strong>
                     </div>
                     <form class="form" th:if="${!isAccessGranted and canEditUser}"
-                        th:action="@{'/admin/users/manage/' + ${user.id} + '/grant-access'}" method="post">
+                        th:action="@{/admin/users/manage/{id}/grant-access(id=${user.id})}" method="post">
                         <div class="moj-page-header-actions__actions">
                             <div class="moj-button-group moj-button-group--inline">
                                 <button type="submit" class="govuk-button govuk-button--primary"
@@ -126,7 +126,7 @@
                                 <ul class="govuk-summary-card__actions">
                                     <li th:if="${canDeleteUser}" class="govuk-summary-card__action">
                                         <a class="govuk-link govuk-!-font-weight-regular" style="font-weight: normal;"
-                                           th:href="@{'/admin/users/manage/' + ${user.id} + '/delete'}">Delete user</a>
+                                           th:href="@{/admin/users/manage/{id}/delete(id=${user.id})}">Delete user</a>
                                     </li>
                                     <li th:if="${canDeleteFirmProfile and user.entraUser.multiFirmUser}" class="govuk-summary-card__action">
                                         <a class="govuk-link govuk-!-font-weight-regular" style="font-weight: normal;"
@@ -184,7 +184,7 @@
                                                th:href="@{/admin/users (search=${user.entraUser.email})}">View all firms for <span th:text="${user.entraUser.fullName}"></span></a>
                                             <a th:if="${!user.entraUser.multiFirmUser and canEditUser}"
                                                class="govuk-link"
-                                               th:href="@{'/admin/users/edit/' + ${user.id} + '/convert-to-multi-firm'}">
+                                               th:href="@{/admin/users/edit/{id}/convert-to-multi-firm(id=${user.id})}">
                                                 Convert to multi-firm
                                             </a>
                                         </dd>
@@ -202,7 +202,7 @@
                                 <ul th:if="${isAccessGranted and canEditUser}" class="govuk-summary-card__actions">
                                     <li class="govuk-summary-card__action">
                                         <a class="govuk-link"
-                                            th:href="@{'/admin/users/edit/' + ${user.id} + '/apps'}">Change</a>
+                                            th:href="@{/admin/users/edit/{id}/apps(id=${user.id})}">Change</a>
                                     </li>
                                 </ul>
                             </div>
@@ -228,7 +228,7 @@
                                 <ul th:if="${isAccessGranted and canManageOffices}" class="govuk-summary-card__actions">
                                     <li class="govuk-summary-card__action">
                                         <a class="govuk-link"
-                                            th:href="@{'/admin/users/edit/' + ${user.id} + '/offices'}">Change</a>
+                                            th:href="@{/admin/users/edit/{id}/offices(id=${user.id})}">Change</a>
                                     </li>
                                 </ul>
                             </div>


### PR DESCRIPTION
### Description :pencil:

All URLs now use the safer path variable syntax `@{/path/{id}(id=${user.id})} `instead of string concatenation `@{'/path/' + ${user.id} + '/action'}`

Issues shown in sentry here: https://ministryofjustice.sentry.io/issues/7059915195/?alert_rule_id=16194025&alert_type=issue&notification_uuid=a196934d-e471-48ed-a217-cd0db00ad1ca&project=4509286516588544&referrer=slack&statsPeriod=90d

---

### Changes Made :pencil:

This pull request refactors the way user-specific URLs are constructed in various Thymeleaf templates. Instead of using string concatenation to build URLs with user IDs, it switches to Thymeleaf's path variable syntax for improved readability, maintainability, and consistency across the codebase.

The most important changes include:

**Refactoring URL Construction for User Management:**

* Replaced all instances of string concatenation (e.g., `'/admin/users/manage/' + ${user.id}`) with Thymeleaf's path variable syntax (e.g., `@{/admin/users/manage/{id}(id=${user.id})}`) for navigation links, form actions, and button links in user management templates such as `manage-user.html`, `delete-user-reason.html`, and `edit-user-details.html`. [[1]](diffhunk://#diff-3057ce20a9f8d23c09e11d63ca7ecd48a04b871bab6ee7f9b97c5db30b1de35eL26-R34) [[2]](diffhunk://#diff-74f5555adea7f86842466a2789f5e0c3c2e9588d82de78b5110c9252d9839277L14-R14) [[3]](diffhunk://#diff-e687d7fb36c1e4429780d9d4c1569e1332afd69837e881337c296ff589df4c15L73-R73) [[4]](diffhunk://#diff-e687d7fb36c1e4429780d9d4c1569e1332afd69837e881337c296ff589df4c15L129-R129)

* Updated all user edit and grant-access flows to use the new path variable syntax in their respective templates, ensuring consistency for actions like "cancel", "change", and "delete" across `edit-user-apps.html`, `edit-user-offices.html`, `edit-user-roles.html`, `grant-access-user-apps.html`, `grant-access-user-offices.html`, and `grant-access-user-roles.html`. [[1]](diffhunk://#diff-48c519552d23e02bc74c546f46e34c738810dc95b35851929928f96dbf1a1b29L14-R14) [[2]](diffhunk://#diff-48c519552d23e02bc74c546f46e34c738810dc95b35851929928f96dbf1a1b29L55-R55) [[3]](diffhunk://#diff-b84ef58fc3d5b9858ebd6d9b887bcc2ec2c19fef7a6fa138b4474ba0596d0f9aL14-R14) [[4]](diffhunk://#diff-b84ef58fc3d5b9858ebd6d9b887bcc2ec2c19fef7a6fa138b4474ba0596d0f9aL75-R76) [[5]](diffhunk://#diff-2e7247015f748e65a2d95d69ff754b3f40b6be9404ce858aa56feab88d78c03aL59-R59) [[6]](diffhunk://#diff-2e7247015f748e65a2d95d69ff754b3f40b6be9404ce858aa56feab88d78c03aL70-R70) [[7]](diffhunk://#diff-3ffbb9b888cb915b27b6a66567778680fa1f2b9829913d8b19a5c2de08ac3f32L187-R187) [[8]](diffhunk://#diff-e754d3f165de717dfc3bbb8d91223484668b5722d1a0050d76033eac52755009L100-R100) [[9]](diffhunk://#diff-8760a4fea45f6365de3c0e9c9cfdbdf16512cf1f8a9e6bd6bfbbefa9f070b050L14-R14) [[10]](diffhunk://#diff-8760a4fea45f6365de3c0e9c9cfdbdf16512cf1f8a9e6bd6bfbbefa9f070b050L72-R72) [[11]](diffhunk://#diff-df6e154a4edcb883c4a38700219709ccb3c12f2c91b1c829f3b3768fcaad2175L78-R78) [[12]](diffhunk://#diff-49e6e20271b574307572d8c7c84188ead2e7222e89125c8a44505d1085e0cc11L177-R177)

**Consistency in Edit and Review Flows:**

* Standardized the use of path variable syntax for "Change" and "Cancel" links in all check-answer templates, such as `edit-user-details-check-answer.html` and `edit-user-offices-check-answer.html`, making navigation and form actions more robust and less error-prone. [[1]](diffhunk://#diff-05eda1583a6335813651199546cc4a2c0675711c0500792c29f155adccc4b064L48-R48) [[2]](diffhunk://#diff-05eda1583a6335813651199546cc4a2c0675711c0500792c29f155adccc4b064L57-R57) [[3]](diffhunk://#diff-05eda1583a6335813651199546cc4a2c0675711c0500792c29f155adccc4b064L68-R68) [[4]](diffhunk://#diff-fc7cb3b940ef2a6b9aa04beac9df0c573ff3b51878ddd6648c0936502ec3d38dL14-R14) [[5]](diffhunk://#diff-fc7cb3b940ef2a6b9aa04beac9df0c573ff3b51878ddd6648c0936502ec3d38dL36-R36) [[6]](diffhunk://#diff-fc7cb3b940ef2a6b9aa04beac9df0c573ff3b51878ddd6648c0936502ec3d38dL46-R46) [[7]](diffhunk://#diff-fc7cb3b940ef2a6b9aa04beac9df0c573ff3b51878ddd6648c0936502ec3d38dL57-R57)

**General Template Improvements:**

* Improved maintainability by ensuring all user-related actions (edit, delete, grant access, etc.) use a single, clear URL construction pattern throughout the codebase.

These changes collectively make the templates easier to read, reduce the chance of URL construction errors, and align with best practices for Thymeleaf and Spring applications.

---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [ ] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [x] I have a corresponding JIRA ticket for this change 
- [x] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:

Please fill in.

---