### PR TITLE
STB-4009 - Fix link generation for firm type restriction error messages

### DIFF
--- a/src/main/resources/templates/silas-administration/create-role.html
+++ b/src/main/resources/templates/silas-administration/create-role.html
@@ -56,7 +56,7 @@
                                     </li>
                                     <li th:each="err : ${#fields.errors('firmTypeRestriction')}"
                                         th:if="${#fields.hasErrors('firmTypeRestriction')}">
-                                        <a th:href="${#lists.isEmpty(firmTypes)} ? '#firmTypeRestriction' : '#firmType-' + firmTypes[0].name()"
+                                        <a th:href="${#lists.isEmpty(firmTypes)} ? '#firmTypeRestriction' : |#firmType-${firmTypes[0].name()}|"
                                            th:text="${err}"></a>
                                     </li>
                                 </ul>


### PR DESCRIPTION
### Description :pencil:

Fix to enforce validation for assigning roles to internal users

https://github.com/user-attachments/assets/734a1c81-b4fe-4819-a5f7-6cb944992143

---

### Changes Made :pencil:

This pull request makes a minor update to the error summary link in the `create-role.html` template to use Thymeleaf's string interpolation syntax for constructing the anchor href. This change improves the readability and maintainability of the code.

- Updated the `th:href` attribute in the error summary list to use Thymeleaf's string interpolation (`|...|`) when generating the anchor for firm type errors in `create-role.html`.

---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [ ] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [x] I have a corresponding JIRA ticket for this change 
- [x] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:

Please fill in.

---