### PR TITLE
STB-3171 - Align ‘Manage Access’ and ‘Change Services’ flows with the Your Legal Aid Services homepage structure

### DIFF
--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/MultiFirmUserController.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/MultiFirmUserController.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -44,6 +45,7 @@ import uk.gov.justice.laa.portal.landingpage.dto.EntraUserDto;
 import uk.gov.justice.laa.portal.landingpage.dto.FirmDto;
 import uk.gov.justice.laa.portal.landingpage.dto.OfficeDto;
 import uk.gov.justice.laa.portal.landingpage.dto.UserProfileDto;
+import uk.gov.justice.laa.portal.landingpage.entity.AppType;
 import uk.gov.justice.laa.portal.landingpage.entity.EntraUser;
 import uk.gov.justice.laa.portal.landingpage.entity.Firm;
 import uk.gov.justice.laa.portal.landingpage.entity.FirmType;
@@ -60,14 +62,13 @@ import uk.gov.justice.laa.portal.landingpage.model.OfficeModel;
 import uk.gov.justice.laa.portal.landingpage.model.UserRole;
 import uk.gov.justice.laa.portal.landingpage.service.AppRoleService;
 import uk.gov.justice.laa.portal.landingpage.service.EventService;
+import static uk.gov.justice.laa.portal.landingpage.service.FirmComparatorByRelevance.relevance;
 import uk.gov.justice.laa.portal.landingpage.service.FirmService;
 import uk.gov.justice.laa.portal.landingpage.service.LoginService;
 import uk.gov.justice.laa.portal.landingpage.service.OfficeService;
 import uk.gov.justice.laa.portal.landingpage.service.RoleAssignmentService;
 import uk.gov.justice.laa.portal.landingpage.service.UserService;
 import uk.gov.justice.laa.portal.landingpage.utils.CcmsRoleGroupsUtil;
-
-import static uk.gov.justice.laa.portal.landingpage.service.FirmComparatorByRelevance.relevance;
 import static uk.gov.justice.laa.portal.landingpage.utils.RestUtils.getListFromHttpSession;
 import static uk.gov.justice.laa.portal.landingpage.utils.RestUtils.getObjectFromHttpSession;
 import uk.gov.justice.laa.portal.landingpage.viewmodel.AppRoleViewModel;
@@ -98,6 +99,19 @@ public class MultiFirmUserController {
     private final ModelMapper mapper;
 
     private final FirmService firmService;
+
+    private LinkedHashMap<AppType, List<AppDto>> buildGroupedApps(List<AppDto> apps) {
+        LinkedHashMap<AppType, List<AppDto>> grouped = new LinkedHashMap<>();
+        for (AppType type : AppType.values()) {
+            List<AppDto> typeApps = apps.stream()
+                    .filter(app -> type.equals(app.getAppType()))
+                    .toList();
+            if (!typeApps.isEmpty()) {
+                grouped.put(type, typeApps);
+            }
+        }
+        return grouped;
+    }
 
 
     @GetMapping("/user/add/profile/select/internalUserFirm")
@@ -480,6 +494,7 @@ public class MultiFirmUserController {
         EntraUserDto entraUserDto = getObjectFromHttpSession(session, "entraUser", EntraUserDto.class).orElseThrow();
         model.addAttribute("entraUser", entraUserDto);
         model.addAttribute("apps", assignableApps);
+        model.addAttribute("groupedApps", buildGroupedApps(assignableApps));
 
         session.setAttribute("addProfileUserAppsModel", model);
         model.addAttribute(ModelAttributes.PAGE_TITLE, "Add profile - Select services - " + entraUserDto.getFullName());
@@ -500,6 +515,7 @@ public class MultiFirmUserController {
 
             model.addAttribute("entraUser", modelFromSession.getAttribute("entraUser"));
             model.addAttribute("apps", modelFromSession.getAttribute("apps"));
+            model.addAttribute("groupedApps", modelFromSession.getAttribute("groupedApps"));
             return "multi-firm-user/select-user-apps";
         }
 
@@ -574,7 +590,7 @@ public class MultiFirmUserController {
 
         // Apply CCMS filtering before storing in model
         List<AppRoleViewModel> finalRoles = appRoleViewModels;
-        
+
         if (isCcmsApp) {
             // Filter to only CCMS roles for organization
             List<AppRoleViewModel> ccmsRoles = appRoleViewModels.stream()
@@ -585,7 +601,7 @@ public class MultiFirmUserController {
             if (!ccmsRoles.isEmpty()) {
                 // Organize CCMS roles by section dynamically
                 organizedRoles.putAll(CcmsRoleGroupsUtil.organizeCcmsRolesBySection(ccmsRoles));
-                
+
                 // Use filtered CCMS roles for both display and session storage
                 finalRoles = ccmsRoles;
             }

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/MultiFirmUserController.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/MultiFirmUserController.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -46,7 +45,6 @@ import uk.gov.justice.laa.portal.landingpage.dto.EntraUserDto;
 import uk.gov.justice.laa.portal.landingpage.dto.FirmDto;
 import uk.gov.justice.laa.portal.landingpage.dto.OfficeDto;
 import uk.gov.justice.laa.portal.landingpage.dto.UserProfileDto;
-import uk.gov.justice.laa.portal.landingpage.entity.AppType;
 import uk.gov.justice.laa.portal.landingpage.entity.EntraUser;
 import uk.gov.justice.laa.portal.landingpage.entity.Firm;
 import uk.gov.justice.laa.portal.landingpage.entity.FirmType;
@@ -62,6 +60,7 @@ import uk.gov.justice.laa.portal.landingpage.forms.RolesForm;
 import uk.gov.justice.laa.portal.landingpage.model.OfficeModel;
 import uk.gov.justice.laa.portal.landingpage.model.UserRole;
 import uk.gov.justice.laa.portal.landingpage.service.AppRoleService;
+import uk.gov.justice.laa.portal.landingpage.service.AppService;
 import uk.gov.justice.laa.portal.landingpage.service.EventService;
 import static uk.gov.justice.laa.portal.landingpage.service.FirmComparatorByRelevance.relevance;
 import uk.gov.justice.laa.portal.landingpage.service.FirmService;
@@ -73,7 +72,6 @@ import uk.gov.justice.laa.portal.landingpage.utils.CcmsRoleGroupsUtil;
 import static uk.gov.justice.laa.portal.landingpage.utils.RestUtils.getListFromHttpSession;
 import static uk.gov.justice.laa.portal.landingpage.utils.RestUtils.getObjectFromHttpSession;
 import static uk.gov.justice.laa.portal.landingpage.utils.RestUtils.getSetFromHttpSession;
-
 import uk.gov.justice.laa.portal.landingpage.viewmodel.AppRoleViewModel;
 
 /**
@@ -93,6 +91,8 @@ public class MultiFirmUserController {
 
     private final AppRoleService appRoleService;
 
+    private final AppService appService;
+
     private final RoleAssignmentService roleAssignmentService;
 
     private final OfficeService officeService;
@@ -102,20 +102,6 @@ public class MultiFirmUserController {
     private final ModelMapper mapper;
 
     private final FirmService firmService;
-
-    private LinkedHashMap<AppType, List<AppDto>> buildGroupedApps(List<AppDto> apps) {
-        LinkedHashMap<AppType, List<AppDto>> grouped = new LinkedHashMap<>();
-        for (AppType type : AppType.values()) {
-            List<AppDto> typeApps = apps.stream()
-                    .filter(app -> type.equals(app.getAppType()))
-                    .toList();
-            if (!typeApps.isEmpty()) {
-                grouped.put(type, typeApps);
-            }
-        }
-        return grouped;
-    }
-
 
     @GetMapping("/user/add/profile/select/internalUserFirm")
     @PreAuthorize("@accessControlService.authenticatedUserHasAnyGivenPermissions(T(uk.gov.justice.laa.portal.landingpage.entity.Permission).DELEGATE_EXTERNAL_USER_ACCESS_INTERNAL)")
@@ -497,7 +483,7 @@ public class MultiFirmUserController {
         EntraUserDto entraUserDto = getObjectFromHttpSession(session, "entraUser", EntraUserDto.class).orElseThrow();
         model.addAttribute("entraUser", entraUserDto);
         model.addAttribute("apps", assignableApps);
-        model.addAttribute("groupedApps", buildGroupedApps(assignableApps));
+        model.addAttribute("groupedApps", appService.buildGroupedApps(assignableApps));
 
         session.setAttribute("addProfileUserAppsModel", model);
         model.addAttribute(ModelAttributes.PAGE_TITLE, "Add profile - Select services - " + entraUserDto.getFullName());

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
@@ -60,6 +60,7 @@ import uk.gov.justice.laa.portal.landingpage.dto.OfficeDto;
 import uk.gov.justice.laa.portal.landingpage.dto.UpdateUserAuditEvent;
 import uk.gov.justice.laa.portal.landingpage.dto.UserProfileDto;
 import uk.gov.justice.laa.portal.landingpage.dto.UserSearchCriteria;
+import uk.gov.justice.laa.portal.landingpage.entity.AppType;
 import uk.gov.justice.laa.portal.landingpage.entity.EntraUser;
 import uk.gov.justice.laa.portal.landingpage.entity.FirmType;
 import uk.gov.justice.laa.portal.landingpage.entity.Office;
@@ -334,7 +335,7 @@ public class UserController {
         final boolean canEditUserRoleAssignments = accessControlService.canEditUserAppRoleAssignments(user.getId().toString());
 
         String silasStatus = userService.calculateSilasStatusForUserProfile(user);
-        
+
         model.addAttribute("user", user);
         model.addAttribute("silasStatus", silasStatus);
         model.addAttribute("userAppRoles", userAppRoles);
@@ -1116,6 +1117,7 @@ public class UserController {
 
         model.addAttribute("user", user);
         model.addAttribute("apps", editableApps);
+        model.addAttribute("groupedApps", buildGroupedApps(editableApps));
         model.addAttribute(ModelAttributes.PAGE_TITLE, "Edit user services - " + user.getFullName());
         if (errorMessage != null) {
             model.addAttribute("errorMessage", errorMessage);
@@ -1141,6 +1143,19 @@ public class UserController {
 
     }
 
+    private LinkedHashMap<AppType, List<AppDto>> buildGroupedApps(List<AppDto> apps) {
+        LinkedHashMap<AppType, List<AppDto>> grouped = new LinkedHashMap<>();
+        for (AppType type : AppType.values()) {
+            List<AppDto> typeApps = apps.stream()
+                    .filter(app -> type.equals(app.getAppType()))
+                    .toList();
+            if (!typeApps.isEmpty()) {
+                grouped.put(type, typeApps);
+            }
+        }
+        return grouped;
+    }
+
     @PostMapping("/users/edit/{id}/apps")
     @PreAuthorize("@accessControlService.canEditUserAppRoleAssignments(#id)")
     public RedirectView setSelectedAppsEdit(@PathVariable String id,
@@ -1161,18 +1176,18 @@ public class UserController {
         // Get previous app selection to determine if roles need to be cleaned up
         List<String> previousSelectedApps = getListFromHttpSession(session, "selectedApps", String.class)
                 .orElse(new ArrayList<>());
-        
+
         session.setAttribute("selectedApps", selectedApps);
-        
+
         // Clean up role selections when app selection changes
         @SuppressWarnings("unchecked")
         Map<Integer, List<String>> editUserAllSelectedRoles = (Map<Integer, List<String>>) session
                 .getAttribute("editUserAllSelectedRoles");
-        
+
         if (editUserAllSelectedRoles != null && !selectedApps.equals(previousSelectedApps)) {
             // App selection changed - need to clean up and reindex role data
             Map<Integer, List<String>> cleanedRoles = new HashMap<>();
-            
+
             // Only preserve role data for apps that are still selected and reindex them
             for (int i = 0; i < selectedApps.size(); i++) {
                 String appId = selectedApps.get(i);
@@ -1183,7 +1198,7 @@ public class UserController {
             }
             session.setAttribute("editUserAllSelectedRoles", cleanedRoles);
         }
-        
+
         if (selectedApps.isEmpty()) {
             // Ensure passed in ID is a valid UUID to avoid open redirects.
             session.setAttribute("editUserAllSelectedRoles", new HashMap<>());
@@ -1492,7 +1507,7 @@ public class UserController {
                     for (String selectedRole : selectedRoles) {
                         AppRoleDto role = roles.get(selectedRole);
                         UserRole userRole = new UserRole();
-                        userRole.setRoleName(role.getName());
+                        userRole.setRoleName(role.getDescription());
                         userRole.setAppName(role.getApp().getName());
                         userRole.setUrl(url);
                         selectedAppRole.add(userRole);
@@ -1974,6 +1989,7 @@ public class UserController {
 
         model.addAttribute("user", user);
         model.addAttribute("apps", editableApps);
+        model.addAttribute("groupedApps", buildGroupedApps(editableApps));
 
         // Store the model in session to handle validation errors later
         session.setAttribute("grantAccessUserAppsModel", model);
@@ -2002,6 +2018,7 @@ public class UserController {
             }
             model.addAttribute("user", modelFromSession.getAttribute("user"));
             model.addAttribute("apps", apps);
+            model.addAttribute("groupedApps", buildGroupedApps(apps != null ? apps : List.of()));
             return "grant-access-user-apps";
         }
 

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
@@ -61,7 +61,6 @@ import uk.gov.justice.laa.portal.landingpage.dto.OfficeDto;
 import uk.gov.justice.laa.portal.landingpage.dto.UpdateUserAuditEvent;
 import uk.gov.justice.laa.portal.landingpage.dto.UserProfileDto;
 import uk.gov.justice.laa.portal.landingpage.dto.UserSearchCriteria;
-import uk.gov.justice.laa.portal.landingpage.entity.AppType;
 import uk.gov.justice.laa.portal.landingpage.entity.EntraUser;
 import uk.gov.justice.laa.portal.landingpage.entity.FirmType;
 import uk.gov.justice.laa.portal.landingpage.entity.Office;
@@ -89,6 +88,7 @@ import uk.gov.justice.laa.portal.landingpage.model.PaginatedUsers;
 import uk.gov.justice.laa.portal.landingpage.model.UserRole;
 import uk.gov.justice.laa.portal.landingpage.service.AccessControlService;
 import uk.gov.justice.laa.portal.landingpage.service.AppRoleService;
+import uk.gov.justice.laa.portal.landingpage.service.AppService;
 import uk.gov.justice.laa.portal.landingpage.service.EmailValidationService;
 import uk.gov.justice.laa.portal.landingpage.service.EventService;
 import static uk.gov.justice.laa.portal.landingpage.service.FirmComparatorByRelevance.relevance;
@@ -131,6 +131,7 @@ public class UserController {
     private final RoleAssignmentService roleAssignmentService;
     private final EmailValidationService emailValidationService;
     private final AppRoleService appRoleService;
+    private final AppService appService;
     private final UserAccountStatusService userAccountStatusService;
     private final NotificationService notificationService;
 
@@ -1119,7 +1120,7 @@ public class UserController {
         session.removeAttribute("roleSelectableAppIndexes");
         model.addAttribute("user", user);
         model.addAttribute("apps", editableApps);
-        model.addAttribute("groupedApps", buildGroupedApps(editableApps));
+        model.addAttribute("groupedApps", appService.buildGroupedApps(editableApps));
         model.addAttribute(ModelAttributes.PAGE_TITLE, "Edit user services - " + user.getFullName());
         if (errorMessage != null) {
             model.addAttribute("errorMessage", errorMessage);
@@ -1143,19 +1144,6 @@ public class UserController {
                     .forEach(appDto -> appDto.setChangeNotAllowed(true));
         }
 
-    }
-
-    private LinkedHashMap<AppType, List<AppDto>> buildGroupedApps(List<AppDto> apps) {
-        LinkedHashMap<AppType, List<AppDto>> grouped = new LinkedHashMap<>();
-        for (AppType type : AppType.values()) {
-            List<AppDto> typeApps = apps.stream()
-                    .filter(app -> type.equals(app.getAppType()))
-                    .toList();
-            if (!typeApps.isEmpty()) {
-                grouped.put(type, typeApps);
-            }
-        }
-        return grouped;
     }
 
     @PostMapping("/users/edit/{id}/apps")
@@ -2025,7 +2013,7 @@ public class UserController {
         session.removeAttribute("roleSelectableAppIndexes");
         model.addAttribute("user", user);
         model.addAttribute("apps", editableApps);
-        model.addAttribute("groupedApps", buildGroupedApps(editableApps));
+        model.addAttribute("groupedApps", appService.buildGroupedApps(editableApps));
 
         // Store the model in session to handle validation errors later
         session.setAttribute("grantAccessUserAppsModel", model);
@@ -2054,7 +2042,7 @@ public class UserController {
             }
             model.addAttribute("user", modelFromSession.getAttribute("user"));
             model.addAttribute("apps", apps);
-            model.addAttribute("groupedApps", buildGroupedApps(apps != null ? apps : List.of()));
+            model.addAttribute("groupedApps", appService.buildGroupedApps(apps != null ? apps : List.of()));
             return "grant-access-user-apps";
         }
 

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/entity/AppType.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/entity/AppType.java
@@ -4,8 +4,8 @@ import lombok.Getter;
 
 @Getter
 public enum AppType {
-    AUTHZ(0, "Admin Services"),
-    LAA(1, "Leagal aid services");
+    AUTHZ(0, "Admin services"),
+    LAA(1, "Legal aid Services");
 
     private final int ordinal;
     private final String name;

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/service/AppService.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/service/AppService.java
@@ -1,25 +1,5 @@
 package uk.gov.justice.laa.portal.landingpage.service;
 
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
-import org.modelmapper.ModelMapper;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import uk.gov.justice.laa.portal.landingpage.dto.AppDto;
-import uk.gov.justice.laa.portal.landingpage.dto.AppSynchronizationAuditEvent;
-import uk.gov.justice.laa.portal.landingpage.dto.CurrentUserDto;
-import uk.gov.justice.laa.portal.landingpage.dto.UserProfileDto;
-import uk.gov.justice.laa.portal.landingpage.entity.App;
-import uk.gov.justice.laa.portal.landingpage.entity.AppType;
-import uk.gov.justice.laa.portal.landingpage.forms.AppsOrderForm;
-import uk.gov.justice.laa.portal.landingpage.repository.AppRepository;
-import uk.gov.justice.laa.portal.landingpage.techservices.GetAllApplicationsResponse;
-import uk.gov.justice.laa.portal.landingpage.techservices.TechServicesApiResponse;
-
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -31,6 +11,27 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import uk.gov.justice.laa.portal.landingpage.dto.AppDto;
+import uk.gov.justice.laa.portal.landingpage.dto.AppSynchronizationAuditEvent;
+import uk.gov.justice.laa.portal.landingpage.dto.CurrentUserDto;
+import uk.gov.justice.laa.portal.landingpage.dto.UserProfileDto;
+import uk.gov.justice.laa.portal.landingpage.entity.App;
+import uk.gov.justice.laa.portal.landingpage.entity.AppType;
+import uk.gov.justice.laa.portal.landingpage.forms.AppsOrderForm;
+import uk.gov.justice.laa.portal.landingpage.repository.AppRepository;
+import uk.gov.justice.laa.portal.landingpage.techservices.GetAllApplicationsResponse;
+import uk.gov.justice.laa.portal.landingpage.techservices.TechServicesApiResponse;
 
 @Slf4j
 @Service

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/service/AppService.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/service/AppService.java
@@ -23,6 +23,7 @@ import uk.gov.justice.laa.portal.landingpage.techservices.TechServicesApiRespons
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -353,6 +354,19 @@ public class AppService {
     private boolean areSecurityGroupsEqual(List<GetAllApplicationsResponse.TechServicesApplication.AppSecurityGroup> remoteSecGroups, App local) {
         String remoteSecGroupId = remoteSecGroups == null || remoteSecGroups.isEmpty() ? null : remoteSecGroups.getFirst().getId();
         return Objects.equals(remoteSecGroupId, local.getSecurityGroupOid());
+    }
+
+    public LinkedHashMap<AppType, List<AppDto>> buildGroupedApps(List<AppDto> apps) {
+        LinkedHashMap<AppType, List<AppDto>> grouped = new LinkedHashMap<>();
+        for (AppType type : AppType.values()) {
+            List<AppDto> typeApps = apps.stream()
+                    .filter(app -> type.equals(app.getAppType()))
+                    .toList();
+            if (!typeApps.isEmpty()) {
+                grouped.put(type, typeApps);
+            }
+        }
+        return grouped;
     }
 
 }

--- a/src/main/resources/static/css/styles.css
+++ b/src/main/resources/static/css/styles.css
@@ -65,3 +65,14 @@
     font-weight: bold;
     padding: 0.4em;
 }
+
+/* Vertically centre the checkbox visual when a hint (description) is present */
+.govuk-checkboxes__item:has(.govuk-checkboxes__hint) .govuk-checkboxes__label::before {
+    top: 50%;
+    transform: translateY(-50%);
+}
+
+.govuk-checkboxes__item:has(.govuk-checkboxes__hint) .govuk-checkboxes__label::after {
+    top: calc(50% - 9px);
+    transform: rotate(-45deg);
+}

--- a/src/main/resources/templates/edit-user-apps.html
+++ b/src/main/resources/templates/edit-user-apps.html
@@ -40,57 +40,33 @@
                         Select all that apply
                     </div>
 
-                    <!-- Admin Services Section -->
-                    <h2 class="govuk-heading-m govuk-!-margin-top-6">Admin services</h2>
-                    <div class="govuk-checkboxes" data-module="govuk-checkboxes">
-                        <th:block th:each="app : ${apps}">
-                            <div class="govuk-checkboxes__item" th:if="${app.appType != null and app.appType.name() == 'AUTHZ' and !app.hiddenFromSelection}">
-                                <input class="govuk-checkboxes__input"
-                                       th:id="'app-' + ${app.id}"
-                                       name="apps"
-                                       th:checked="${app.selected}"
-                                       th:value="${app.id}"
-                                       type="checkbox"
-                                       th:disabled="${app.changeNotAllowed}">
-                                <label class="govuk-label govuk-checkboxes__label"
-                                       th:for="'app-' + ${app.id}">
-                                    <span th:text="${app.name}"></span>
-                                </label>
-                                <div th:if="${app.description != null && !app.description.isEmpty()}"
-                                     class="govuk-hint govuk-checkboxes__hint"
-                                     th:text="${app.description}"></div>
-                            </div>
-                            <div th:if="${app.appType != null and app.appType.name() == 'AUTHZ' and app.selected && (app.changeNotAllowed || app.hiddenFromSelection)}">
-                                <input th:id="'app-hidden-' + ${app.id}" name="apps" th:value="${app.id}" type="hidden" />
-                            </div>
-                        </th:block>
-                    </div>
-
-                    <!-- Legal Aid Services Section -->
-                    <h2 class="govuk-heading-m govuk-!-margin-top-6">Legal aid Services</h2>
-                    <div class="govuk-checkboxes" data-module="govuk-checkboxes">
-                        <th:block th:each="app : ${apps}">
-                            <div class="govuk-checkboxes__item" th:if="${app.appType != null and app.appType.name() == 'LAA' and !app.hiddenFromSelection}">
-                                <input class="govuk-checkboxes__input"
-                                       th:id="'app-' + ${app.id}"
-                                       name="apps"
-                                       th:checked="${app.selected}"
-                                       th:value="${app.id}"
-                                       type="checkbox"
-                                       th:disabled="${app.changeNotAllowed}">
-                                <label class="govuk-label govuk-checkboxes__label"
-                                       th:for="'app-' + ${app.id}">
-                                    <span th:text="${app.name}"></span>
-                                </label>
-                                <div th:if="${app.description != null && !app.description.isEmpty()}"
-                                     class="govuk-hint govuk-checkboxes__hint"
-                                     th:text="${app.description}"></div>
-                            </div>
-                            <div th:if="${app.appType != null and app.appType.name() == 'LAA' and app.selected && (app.changeNotAllowed || app.hiddenFromSelection)}">
-                                <input th:id="'app-hidden-' + ${app.id}" name="apps" th:value="${app.id}" type="hidden" />
-                            </div>
-                        </th:block>
-                    </div>
+                    <!-- App sections grouped by type, driven by database -->
+                    <th:block th:each="groupEntry : ${groupedApps.entrySet()}">
+                        <h2 class="govuk-heading-m govuk-!-margin-top-6" th:text="${groupEntry.key.name}"></h2>
+                        <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+                            <th:block th:each="app : ${groupEntry.value}">
+                                <div class="govuk-checkboxes__item" th:if="${!app.hiddenFromSelection}">
+                                    <input class="govuk-checkboxes__input"
+                                           th:id="'app-' + ${app.id}"
+                                           name="apps"
+                                           th:checked="${app.selected}"
+                                           th:value="${app.id}"
+                                           type="checkbox"
+                                           th:disabled="${app.changeNotAllowed}">
+                                    <label class="govuk-label govuk-checkboxes__label"
+                                           th:for="'app-' + ${app.id}">
+                                        <span th:text="${app.name}"></span>
+                                    </label>
+                                    <div th:if="${app.description != null && !app.description.isEmpty()}"
+                                         class="govuk-hint govuk-checkboxes__hint"
+                                         th:text="${app.description}"></div>
+                                </div>
+                                <div th:if="${app.selected && (app.changeNotAllowed || app.hiddenFromSelection)}">
+                                    <input th:id="'app-hidden-' + ${app.id}" name="apps" th:value="${app.id}" type="hidden" />
+                                </div>
+                            </th:block>
+                        </div>
+                    </th:block>
                 </fieldset>
             </div>
             <div class="govuk-button-group">

--- a/src/main/resources/templates/grant-access-check-answers.html
+++ b/src/main/resources/templates/grant-access-check-answers.html
@@ -38,7 +38,7 @@
                                         class="govuk-summary-list__row">
                                         <dt class="govuk-summary-list__key"
                                             th:text="${iterStat.first ? appEntry.key : ''}">App Name</dt>
-                                        <dd class="govuk-summary-list__value" th:text="${appRole.name}">Role Name</dd>
+                                        <dd class="govuk-summary-list__value" th:text="${appRole.description}">Role Name</dd>
                                         <dd class="govuk-summary-list__actions">
                                             <a class="govuk-link"
                                                 th:href="@{/admin/users/grant-access/{id}/apps(id=${user.id})}">Change</a>

--- a/src/main/resources/templates/grant-access-user-apps.html
+++ b/src/main/resources/templates/grant-access-user-apps.html
@@ -57,35 +57,22 @@
                     </div>
                     <p class="govuk-error-message" th:if="${#fields.hasErrors('apps')}" th:errors="*{apps}"></p>
 
-                    <!-- Admin Services Section -->
-                    <h2 class="govuk-heading-m govuk-!-margin-top-6">Admin services</h2>
-                    <div class="govuk-checkboxes" data-module="govuk-checkboxes">
-                        <th:block th:each="app : ${apps}">
-                            <div class="govuk-checkboxes__item" th:if="${app.appType != null and app.appType.name() == 'AUTHZ'}">
-                                <input class="govuk-checkboxes__input" th:id="${app.id}" name="apps"
-                                    th:checked="${app.selected}" th:value="${app.id}" type="checkbox">
-                                <label class="govuk-label govuk-checkboxes__label" th:for="${app.id}">
-                                    <span th:text="${app.name}"></span>
-                                </label>
-                                <div class="govuk-hint govuk-checkboxes__hint" th:text="${app.description}"></div>
-                            </div>
-                        </th:block>
-                    </div>
-
-                    <!-- Legal Aid Services Section -->
-                    <h2 class="govuk-heading-m govuk-!-margin-top-6">Legal aid Services</h2>
-                    <div class="govuk-checkboxes" data-module="govuk-checkboxes">
-                        <th:block th:each="app : ${apps}">
-                            <div class="govuk-checkboxes__item" th:if="${app.appType != null and app.appType.name() == 'LAA'}">
-                                <input class="govuk-checkboxes__input" th:id="${app.id}" name="apps"
-                                    th:checked="${app.selected}" th:value="${app.id}" type="checkbox">
-                                <label class="govuk-label govuk-checkboxes__label" th:for="${app.id}">
-                                    <span th:text="${app.name}"></span>
-                                </label>
-                                <div class="govuk-hint govuk-checkboxes__hint" th:text="${app.description}"></div>
-                            </div>
-                        </th:block>
-                    </div>
+                    <!-- App sections grouped by type, driven by database -->
+                    <th:block th:each="groupEntry : ${groupedApps.entrySet()}">
+                        <h2 class="govuk-heading-m govuk-!-margin-top-6" th:text="${groupEntry.key.name}"></h2>
+                        <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+                            <th:block th:each="app : ${groupEntry.value}">
+                                <div class="govuk-checkboxes__item">
+                                    <input class="govuk-checkboxes__input" th:id="${app.id}" name="apps"
+                                        th:checked="${app.selected}" th:value="${app.id}" type="checkbox">
+                                    <label class="govuk-label govuk-checkboxes__label" th:for="${app.id}">
+                                        <span th:text="${app.name}"></span>
+                                    </label>
+                                    <div class="govuk-hint govuk-checkboxes__hint" th:text="${app.description}"></div>
+                                </div>
+                            </th:block>
+                        </div>
+                    </th:block>
                 </fieldset>
             </div>
             <div class="govuk-button-group">

--- a/src/main/resources/templates/multi-firm-user/select-user-apps.html
+++ b/src/main/resources/templates/multi-firm-user/select-user-apps.html
@@ -46,35 +46,22 @@
                     </div>
                     <p class="govuk-error-message" th:if="${#fields.hasErrors('apps')}" th:errors="*{apps}"></p>
 
-                    <!-- Admin Services Section -->
-                    <h2 class="govuk-heading-m govuk-!-margin-top-6">Admin services</h2>
-                    <div class="govuk-checkboxes" data-module="govuk-checkboxes">
-                        <th:block th:each="app : ${apps}">
-                            <div class="govuk-checkboxes__item" th:if="${app.appType != null and app.appType.name() == 'AUTHZ'}">
-                                <input class="govuk-checkboxes__input" th:id="${app.id}" name="apps" th:checked="${app.selected}"
-                                    th:value="${app.id}" type="checkbox">
-                                <label class="govuk-label govuk-checkboxes__label" th:for="${app.id}">
-                                    <span th:text="${app.name}"></span>
-                                </label>
-                                <div class="govuk-hint govuk-checkboxes__hint" th:text="${app.description}"></div>
-                            </div>
-                        </th:block>
-                    </div>
-
-                    <!-- Legal Aid Services Section -->
-                    <h2 class="govuk-heading-m govuk-!-margin-top-6">Legal aid Services</h2>
-                    <div class="govuk-checkboxes" data-module="govuk-checkboxes">
-                        <th:block th:each="app : ${apps}">
-                            <div class="govuk-checkboxes__item" th:if="${app.appType != null and app.appType.name() == 'LAA'}">
-                                <input class="govuk-checkboxes__input" th:id="${app.id}" name="apps" th:checked="${app.selected}"
-                                    th:value="${app.id}" type="checkbox">
-                                <label class="govuk-label govuk-checkboxes__label" th:for="${app.id}">
-                                    <span th:text="${app.name}"></span>
-                                </label>
-                                <div class="govuk-hint govuk-checkboxes__hint" th:text="${app.description}"></div>
-                            </div>
-                        </th:block>
-                    </div>
+                    <!-- App sections grouped by type, driven by database -->
+                    <th:block th:each="groupEntry : ${groupedApps.entrySet()}">
+                        <h2 class="govuk-heading-m govuk-!-margin-top-6" th:text="${groupEntry.key.name}"></h2>
+                        <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+                            <th:block th:each="app : ${groupEntry.value}">
+                                <div class="govuk-checkboxes__item">
+                                    <input class="govuk-checkboxes__input" th:id="${app.id}" name="apps" th:checked="${app.selected}"
+                                        th:value="${app.id}" type="checkbox">
+                                    <label class="govuk-label govuk-checkboxes__label" th:for="${app.id}">
+                                        <span th:text="${app.name}"></span>
+                                    </label>
+                                    <div class="govuk-hint govuk-checkboxes__hint" th:text="${app.description}"></div>
+                                </div>
+                            </th:block>
+                        </div>
+                    </th:block>
                 </fieldset>
             </div>
             <div class="govuk-button-group">

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/MultiFirmUserControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/MultiFirmUserControllerTest.java
@@ -69,6 +69,7 @@ import uk.gov.justice.laa.portal.landingpage.forms.RolesForm;
 import uk.gov.justice.laa.portal.landingpage.model.OfficeModel;
 import uk.gov.justice.laa.portal.landingpage.model.UserRole;
 import uk.gov.justice.laa.portal.landingpage.service.AppRoleService;
+import uk.gov.justice.laa.portal.landingpage.service.AppService;
 import uk.gov.justice.laa.portal.landingpage.service.EventService;
 import uk.gov.justice.laa.portal.landingpage.service.FirmService;
 import uk.gov.justice.laa.portal.landingpage.service.LoginService;
@@ -100,6 +101,8 @@ public class MultiFirmUserControllerTest {
     @Mock
     private FirmService firmService;
     @Mock
+    private AppService appService;
+    @Mock
     private BindingResult bindingResult;
     @Mock
     private ApplicationsForm applicationsForm;
@@ -115,7 +118,7 @@ public class MultiFirmUserControllerTest {
         model = new ExtendedModelMap();
         session = new MockHttpSession();
         controller = new MultiFirmUserController(userService, loginService, appRoleService,
-                roleAssignmentService, officeService, eventService, mapper, firmService);
+                appService, roleAssignmentService, officeService, eventService, mapper, firmService);
         firmSearchForm = FirmSearchForm.builder()
                 .build();
         multiFirmUserForm = MultiFirmUserForm.builder()

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/UserControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/UserControllerTest.java
@@ -1598,9 +1598,9 @@ class UserControllerTest {
         String app1Id = "app1";
         String app2Id = "app2";
         String app3Id = "app3";
-        
+
         MockHttpSession session = new MockHttpSession();
-        
+
         // Mock AppDto objects with ordinals for sorting (only for selected apps)
         AppDto app1 = AppDto.builder().id(app1Id).ordinal(1).build();
         AppDto app3 = AppDto.builder().id(app3Id).ordinal(3).build();
@@ -1611,22 +1611,22 @@ class UserControllerTest {
         session.setAttribute("selectedApps", List.of(app1Id, app2Id, app3Id));
         Map<Integer, List<String>> existingRoles = new HashMap<>();
         existingRoles.put(0, List.of("role1", "role2")); // app1 roles
-        existingRoles.put(1, List.of("role3"));          // app2 roles  
+        existingRoles.put(1, List.of("role3"));          // app2 roles
         existingRoles.put(2, List.of("role4", "role5")); // app3 roles
         session.setAttribute("editUserAllSelectedRoles", existingRoles);
-        
+
         // When - user deselects app2, keeping only app1 and app3
         List<String> newApps = List.of(app1Id, app3Id);
         UUID userId = UUID.randomUUID();
         RedirectView redirectView = userController.setSelectedAppsEdit(userId.toString(), newApps, session);
-        
+
         // Then
         assertThat(redirectView.getUrl()).isEqualTo(String.format("/admin/users/edit/%s/roles", userId));
-        
+
         @SuppressWarnings("unchecked")
         List<String> updatedApps = (List<String>) session.getAttribute("selectedApps");
         assertThat(updatedApps).containsExactly(app1Id, app3Id);
-        
+
         @SuppressWarnings("unchecked")
         Map<Integer, List<String>> updatedRoles = (Map<Integer, List<String>>) session.getAttribute("editUserAllSelectedRoles");
         assertThat(updatedRoles).hasSize(2);
@@ -1641,9 +1641,9 @@ class UserControllerTest {
         UUID userId = UUID.randomUUID();
         String app1Id = "app1";
         String app2Id = "app2";
-        
+
         MockHttpSession session = new MockHttpSession();
-        
+
         // Mock AppDto objects with ordinals for sorting
         AppDto app1 = AppDto.builder().id(app1Id).ordinal(1).build();
         AppDto app2 = AppDto.builder().id(app2Id).ordinal(2).build();
@@ -1652,17 +1652,17 @@ class UserControllerTest {
 
         // Setup initial state: no previous selectedApps or role data
         List<String> newApps = List.of(app1Id, app2Id);
-        
+
         // When
         RedirectView redirectView = userController.setSelectedAppsEdit(userId.toString(), newApps, session);
-        
+
         // Then
         assertThat(redirectView.getUrl()).isEqualTo(String.format("/admin/users/edit/%s/roles", userId));
-        
+
         @SuppressWarnings("unchecked")
         List<String> updatedApps = (List<String>) session.getAttribute("selectedApps");
         assertThat(updatedApps).containsExactly(app1Id, app2Id);
-        
+
         // Should not have created editUserAllSelectedRoles since there was no existing data to clean
         assertThat(session.getAttribute("editUserAllSelectedRoles")).isNull();
     }
@@ -1694,11 +1694,11 @@ class UserControllerTest {
         AppDto app2 = AppDto.builder().id(appId2.toString()).name("app2").enabled(true).build();
         AppDto app3 = AppDto.builder().id(appId3.toString()).name("app3").enabled(true).build();
         AppRoleDto app1Role1Dto = AppRoleDto.builder().id(role1.toString())
-                .app(app1).name("role1").build();
+                .app(app1).name("role1").description("role1").build();
         AppRoleDto app1Role2Dto = AppRoleDto.builder().id(role2.toString())
-                .app(app1).name("role2").build();
+                .app(app1).name("role2").description("role2").build();
         AppRoleDto app1Role3Dto = AppRoleDto.builder().id(role2.toString())
-                .app(app1).name("role3").build();
+                .app(app1).name("role3").description("role3").build();
         Map<String, AppRoleDto> app1Roles = Map.of(role1.toString(), app1Role1Dto, role2.toString(), app1Role2Dto,
                 role3.toString(), app1Role3Dto);
         testSession.setAttribute("editUserAllSelectedRoles", existingRoles);
@@ -1800,11 +1800,11 @@ class UserControllerTest {
         AppDto app2 = AppDto.builder().id(appId2.toString()).name("app2").enabled(true).build();
         AppDto app3 = AppDto.builder().id(appId3.toString()).name("app3").enabled(true).build();
         AppRoleDto app1Role1Dto = AppRoleDto.builder().id(role1.toString())
-                .app(app1).name("role1").build();
+                .app(app1).name("role1").description("role1").build();
         AppRoleDto app1Role2Dto = AppRoleDto.builder().id(role2.toString())
-                .app(app1).name("role2").build();
+                .app(app1).name("role2").description("role2").build();
         AppRoleDto app1Role3Dto = AppRoleDto.builder().id(role2.toString())
-                .app(app1).name("role3").build();
+                .app(app1).name("role3").description("role3").build();
         Map<String, AppRoleDto> app1Roles = Map.of(role1.toString(), app1Role1Dto, role2.toString(), app1Role2Dto,
                 role3.toString(), app1Role3Dto);
         testSession.setAttribute("editUserAllSelectedRoles", existingRoles);
@@ -7765,7 +7765,7 @@ class UserControllerTest {
             AppDto ccmsApp = new AppDto();
             ccmsApp.setId(UUID.randomUUID().toString());
             ccmsApp.setName("Apply for civil legal aid using CCMS");
-            
+
             testSession.setAttribute("selectedApps", List.of(ccmsApp.getId()));
 
             List<AppRoleDto> roles = List.of(

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/UserControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/UserControllerTest.java
@@ -107,6 +107,7 @@ import uk.gov.justice.laa.portal.landingpage.model.PaginatedUsers;
 import uk.gov.justice.laa.portal.landingpage.model.UserRole;
 import uk.gov.justice.laa.portal.landingpage.service.AccessControlService;
 import uk.gov.justice.laa.portal.landingpage.service.AppRoleService;
+import uk.gov.justice.laa.portal.landingpage.service.AppService;
 import uk.gov.justice.laa.portal.landingpage.service.EmailValidationService;
 import uk.gov.justice.laa.portal.landingpage.service.EventService;
 import uk.gov.justice.laa.portal.landingpage.service.FirmService;
@@ -155,6 +156,8 @@ class UserControllerTest {
     @Mock
     private AppRoleService appRoleService;
     @Mock
+    private AppService appService;
+    @Mock
     private UserAccountStatusService disableUserService;
     @Mock
     private NotificationService notificationService;
@@ -165,7 +168,7 @@ class UserControllerTest {
     void setUp() {
         userController = new UserController(loginService, userService, officeService, eventService, firmService,
                 new MapperConfig().modelMapper(), accessControlService, roleAssignmentService, emailValidationService,
-                appRoleService, disableUserService, notificationService);
+                appRoleService, appService, disableUserService, notificationService);
         userController.disableUserFeatureEnabled = true;
         model = new ExtendedModelMap();
         firmSearchForm = FirmSearchForm.builder().build();


### PR DESCRIPTION
### Description :pencil:

Align ‘Manage Access’ and ‘Change Services’ flows with the Your Legal Aid Services homepage structure

<img width="1718" height="926" alt="Screenshot 2026-04-27 at 11 17 39" src="https://github.com/user-attachments/assets/5707599d-8fc6-4814-b08e-a99302114587" />


---

### Changes Made :pencil:

This pull request updates how user applications ("apps") are displayed and grouped throughout the user management flows, making the grouping of apps by type dynamic and data-driven. It also improves the clarity of role descriptions and corrects some labels. The most important changes are as follows:

**Dynamic grouping of apps by type:**
* Introduced a `buildGroupedApps` method in both `UserController` and `MultiFirmUserController` to group `AppDto` objects by their `AppType` for all relevant endpoints. This replaces hardcoded app sections in the UI with sections generated from the database, making the UI more flexible and maintainable. [[1]](diffhunk://#diff-cc502383c8840f906acd828f944dcf030a4aa456f929788137a668d708b22808R106-R118) [[2]](diffhunk://#diff-1c3931784714b5992966f392b56dad9140ea42ba7303dfce45c2cb8533ed3885R1148-R1160)
* Updated all relevant controller methods to add the new `groupedApps` model attribute, ensuring the views receive the grouped data. [[1]](diffhunk://#diff-cc502383c8840f906acd828f944dcf030a4aa456f929788137a668d708b22808R500) [[2]](diffhunk://#diff-cc502383c8840f906acd828f944dcf030a4aa456f929788137a668d708b22808R521) [[3]](diffhunk://#diff-1c3931784714b5992966f392b56dad9140ea42ba7303dfce45c2cb8533ed3885R1122) [[4]](diffhunk://#diff-1c3931784714b5992966f392b56dad9140ea42ba7303dfce45c2cb8533ed3885R2028) [[5]](diffhunk://#diff-1c3931784714b5992966f392b56dad9140ea42ba7303dfce45c2cb8533ed3885R2057)

**Template/UI improvements:**
* Refactored the templates (`edit-user-apps.html`, `grant-access-user-apps.html`, `multi-firm-user/select-user-apps.html`) to use the new `groupedApps` structure, dynamically generating app sections and removing hardcoded "Admin services" and "Legal aid Services" headings. [[1]](diffhunk://#diff-48c519552d23e02bc74c546f46e34c738810dc95b35851929928f96dbf1a1b29L43-R48) [[2]](diffhunk://#diff-48c519552d23e02bc74c546f46e34c738810dc95b35851929928f96dbf1a1b29L63-L93) [[3]](diffhunk://#diff-8760a4fea45f6365de3c0e9c9cfdbdf16512cf1f8a9e6bd6bfbbefa9f070b050L60-R65) [[4]](diffhunk://#diff-8760a4fea45f6365de3c0e9c9cfdbdf16512cf1f8a9e6bd6bfbbefa9f070b050L74-L88) [[5]](diffhunk://#diff-cf53a53b6d52ada3c88fb86e65828859a48ddcd141fa47f5a257c94f616c79d9L49-R54) [[6]](diffhunk://#diff-cf53a53b6d52ada3c88fb86e65828859a48ddcd141fa47f5a257c94f616c79d9L63-L77)

**Label and description fixes:**
* Corrected typos and inconsistencies in `AppType` enum display names ("Leagal aid services" → "Legal aid Services", "Admin Services" → "Admin services").
* Updated the role display in check answers and confirmation screens to use the role's description instead of its internal name for better clarity. [[1]](diffhunk://#diff-e754d3f165de717dfc3bbb8d91223484668b5722d1a0050d76033eac52755009L41-R41) [[2]](diffhunk://#diff-1c3931784714b5992966f392b56dad9140ea42ba7303dfce45c2cb8533ed3885L1514-R1529)

These changes make the app assignment and editing flows more robust, maintainable, and user-friendly by ensuring app sections are always consistent with the underlying data model.

---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [ ] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [x] I have a corresponding JIRA ticket for this change 
- [x] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:

Please fill in.

---