### PR TITLE
Reinstating the Zap weekly scan. Jira. STB-4084

### DIFF
--- a/.github/workflows/zap_dast_weekly_dev.yml
+++ b/.github/workflows/zap_dast_weekly_dev.yml
@@ -1,0 +1,104 @@
+name: ZAP DAST Weeky Full Scan
+
+on:
+  schedule:
+    - cron: '0 8 * * SUN'
+
+jobs:
+  zap_scan:
+    name: Run Full ZAP DAST Scan Against Live App
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Run ZAP Weekly Full Scan
+        uses: zaproxy/action-full-scan@v0.13.0
+        with:
+          target: 'https://dev.your-legal-aid-services.service.justice.gov.uk/'
+          cmd_options: '-a -j -m 120'
+          fail_action: false
+          issue_title: ZAP Full Scan Report - dev
+      - id: extract-summary
+        uses: sean0x42/markdown-extract@v2.1.0
+        with:
+          file: report_md.md
+          pattern: "Summary.of.Alerts"  # Bug in Action with passing quoted string, so use regex any char instead of spaces
+          case-sensitive: "true"
+      - name: Parse summary
+        run: |
+          #!/bin/bash -xe
+          high_value=$(echo "$ZAP_SUMMARY" | grep "| High |" | awk -F'|' '{print $3}' | xargs)
+          medium_value=$(echo "$ZAP_SUMMARY" | grep "| Medium |" | awk -F'|' '{print $3}' | xargs)
+          low_value=$(echo "$ZAP_SUMMARY" | grep "| Low |" | awk -F'|' '{print $3}' | xargs)
+          info_value=$(echo "$ZAP_SUMMARY" | grep "| Informational |" | awk -F'|' '{print $3}' | xargs)
+          echo "ZAP_HIGH=${high_value}" >> "$GITHUB_ENV"
+          echo "ZAP_MEDIUM=${medium_value}" >> "$GITHUB_ENV"
+          echo "ZAP_LOW=${low_value}" >> "$GITHUB_ENV"
+          echo "ZAP_INFO=${info_value}" >> "$GITHUB_ENV"
+        env:
+          ZAP_SUMMARY: ${{ steps.extract-summary.outputs.markdown }}
+      - name: Post to Slack
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          webhook: ${{ secrets.ZAP_SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "ZAP Weekly Scan Report: DEV Environment"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Scan Summary:*"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":rotating_light: *HIGH:* ${{ env.ZAP_HIGH }}"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":sign-warning: *MEDIUM:* ${{ env.ZAP_MEDIUM }}"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":orange_heart: *LOW:* ${{ env.ZAP_LOW }}"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":yellow_heart: *INFORMATIONAL:* ${{ env.ZAP_INFO }}"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Please review the detailed scan results and take necessary actions. \n\n View Details on GitHub: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                  }
+                }
+              ]
+            }
+      # - name: Upload Weekly Scan ZAP Report
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: weekly-zap-report
+      #     path: |
+      #       report_html.html
+      #       report_json.json

--- a/.github/workflows/zap_dast_weekly_dev.yml
+++ b/.github/workflows/zap_dast_weekly_dev.yml
@@ -6,38 +6,42 @@ on:
 
 jobs:
   zap_scan:
-    name: Run Full ZAP DAST Scan Against Live App
+    name: Run Full ZAP DEV DAST Scan Against Live App
     runs-on: ubuntu-latest
 
     steps:
       - name: Run ZAP Weekly Full Scan
-        uses: zaproxy/action-full-scan@v0.13.0
+        uses: zaproxy/action-baseline@de8ad967d3548d44ef623df22cf95c3b0baf8b25 # v0.15.0
         with:
           target: 'https://dev.your-legal-aid-services.service.justice.gov.uk/'
           cmd_options: '-a -j -m 120'
           fail_action: false
           issue_title: ZAP Full Scan Report - dev
-      - id: extract-summary
-        uses: sean0x42/markdown-extract@v2.1.0
-        with:
-          file: report_md.md
-          pattern: "Summary.of.Alerts"  # Bug in Action with passing quoted string, so use regex any char instead of spaces
-          case-sensitive: "true"
+
       - name: Parse summary
         run: |
           #!/bin/bash -xe
-          high_value=$(echo "$ZAP_SUMMARY" | grep "| High |" | awk -F'|' '{print $3}' | xargs)
-          medium_value=$(echo "$ZAP_SUMMARY" | grep "| Medium |" | awk -F'|' '{print $3}' | xargs)
-          low_value=$(echo "$ZAP_SUMMARY" | grep "| Low |" | awk -F'|' '{print $3}' | xargs)
-          info_value=$(echo "$ZAP_SUMMARY" | grep "| Informational |" | awk -F'|' '{print $3}' | xargs)
+          
+          # Read directly from the markdown file.
+          # -m 1 ensures we only grab the first match (which is the summary table at the top of the report)
+          high_value=$(grep -a -m 1 "| High |" report_md.md | awk -F'|' '{print $3}' | xargs)
+          medium_value=$(grep -a -m 1 "| Medium |" report_md.md | awk -F'|' '{print $3}' | xargs)
+          low_value=$(grep -a -m 1 "| Low |" report_md.md | awk -F'|' '{print $3}' | xargs)
+          info_value=$(grep -a -m 1 "| Informational |" report_md.md | awk -F'|' '{print $3}' | xargs)
+          
+          # Fallback to 0 if grep returns empty (e.g., if the ZAP report is totally empty/failed)
+          high_value=${high_value:-0}
+          medium_value=${medium_value:-0}
+          low_value=${low_value:-0}
+          info_value=${info_value:-0}
+
           echo "ZAP_HIGH=${high_value}" >> "$GITHUB_ENV"
           echo "ZAP_MEDIUM=${medium_value}" >> "$GITHUB_ENV"
           echo "ZAP_LOW=${low_value}" >> "$GITHUB_ENV"
           echo "ZAP_INFO=${info_value}" >> "$GITHUB_ENV"
-        env:
-          ZAP_SUMMARY: ${{ steps.extract-summary.outputs.markdown }}
+
       - name: Post to Slack
-        uses: slackapi/slack-github-action@v2.1.1
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           webhook: ${{ secrets.ZAP_SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
@@ -95,10 +99,3 @@ jobs:
                 }
               ]
             }
-      # - name: Upload Weekly Scan ZAP Report
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: weekly-zap-report
-      #     path: |
-      #       report_html.html
-      #       report_json.json


### PR DESCRIPTION
### Description :pencil:

Reinstating the ZAP weekly scan, as per Jira STB-4084

---

### Changes Made :pencil:

- Added zap_dast_weekly_dev.yaml, into .github/workflows. Scheduled to run 08:00 on Sundays.

---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [x] I have taken into account the application runs as 3 replicas in live environments
- [x] I have created any relevant documentation for this change
- [x] I have a corresponding JIRA ticket for this change 
- [ ] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:


---