### PR TITLE
STB-4096 - Fix breadcrumb and back button links to use profileId for correct navigation

### DIFF
--- a/src/main/resources/templates/user-audit/full-details.html
+++ b/src/main/resources/templates/user-audit/full-details.html
@@ -11,7 +11,7 @@
 
 <body>
     <nav aria-label="Breadcrumb" class="govuk-breadcrumbs" id="breadcrumbs">
-        <a class="govuk-back-link" th:href="@{/admin/users/audit/{id}(id=${user.userId})}">
+        <a class="govuk-back-link" th:href="@{/admin/users/audit/{id}(id=${profileId})}">
             Back
         </a>
     </nav>
@@ -159,7 +159,7 @@
             <!-- Action Buttons -->
             <div class="govuk-button-group govuk-!-margin-top-4">
                 <!-- Back Button -->
-                <a class="govuk-button" th:href="@{/admin/users/audit}">
+                <a class="govuk-button" th:href="@{/admin/users/audit/{id}(id=${profileId})}">
                     Back to Identity Information
                 </a>
             </div>


### PR DESCRIPTION
### Description :pencil:

Fixed back navigation in `full-details.html` to use `profileId` instead of `user.userId `so "Back to Identity Information" and the breadcrumb back-link correctly return to the identity/details page with full profile data intact.

---

### Changes Made :pencil:

This pull request updates navigation links in the `user-audit/full-details.html` template to ensure that the correct user profile is referenced when navigating back to audit and identity information pages. The changes improve navigation accuracy by using the `profileId` variable rather than a potentially incorrect or missing identifier.

Navigation improvements:

* Updated the breadcrumb back link to use `profileId` instead of `user.userId`, ensuring users are returned to the correct audit page.
* Modified the "Back to Identity Information" button to include the `profileId` in the URL, directing users to the specific identity information for the relevant profile.

---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [ ] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [x] I have a corresponding JIRA ticket for this change 
- [ ] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:

Please fill in.

---