### PR TITLE
STB-3990: Fix for create a role not validating appFilter was populated

### DIFF
--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/AdminController.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/AdminController.java
@@ -23,7 +23,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
@@ -813,19 +812,24 @@ public class AdminController {
 
     @GetMapping("/silas-administration/roles/create")
     @PreAuthorize("@accessControlService.authenticatedUserHasPermission(T(uk.gov.justice.laa.portal.landingpage.entity.Permission).CREATE_LAA_APP_ROLE)")
-    public String showRoleCreationForm(Model model, HttpSession session, @RequestParam (required = false) String appFilter) {
+    public String showRoleCreationForm(Model model, RedirectAttributes redirectAttributes, HttpSession session,
+                                       @RequestParam (required = false) String appFilter) {
         RoleCreationDto roleCreationDto = (RoleCreationDto) session.getAttribute("roleCreationDto");
         if (roleCreationDto == null) {
             roleCreationDto = new RoleCreationDto();
         }
 
-        if (appFilter != null) {
-            List<AppDto> allApps = appService.getAllLaaApps();
-            for (AppDto app : allApps) {
-                if (app.getName().equals(appFilter)) {
-                    roleCreationDto.setParentAppId(UUID.fromString(app.getId()));
-                    break;
-                }
+        if (appFilter.isEmpty()) {
+            redirectAttributes.addFlashAttribute("appRolesErrorMessage", "Please select an application to create its "
+                    + "roles");
+            return "redirect:/admin/silas-administration?tab=roles";
+        }
+
+        List<AppDto> allApps = appService.getAllLaaApps();
+        for (AppDto app : allApps) {
+            if (app.getName().equals(appFilter)) {
+                roleCreationDto.setParentAppId(UUID.fromString(app.getId()));
+                break;
             }
         }
 

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/AdminControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/AdminControllerTest.java
@@ -1198,8 +1198,10 @@ class AdminControllerTest {
         String appName = "Test App";
         when(appService.getAllLaaApps()).thenReturn(apps);
 
+        RedirectAttributes redirectAttributes = new RedirectAttributesModelMap();
+
         // Act
-        String result = adminController.showRoleCreationForm(model, session, appName);
+        String result = adminController.showRoleCreationForm(model, redirectAttributes, session, appName);
 
         // Assert
         assertEquals("silas-administration/create-role", result);
@@ -1208,6 +1210,21 @@ class AdminControllerTest {
         assertThat(model.getAttribute("userTypes")).isEqualTo(UserType.values());
         assertThat(model.getAttribute("firmTypes")).isEqualTo(FirmType.values());
         assertThat(model.getAttribute("appFilter")).isEqualTo(appName);
+    }
+
+    @Test
+    void testShowRoleCreationForm_redirectsToRolesTabWhenAppFilterEmpty() {
+        // Arrange
+        MockHttpSession session = new MockHttpSession();
+        String appName = "";
+
+        RedirectAttributes redirectAttributes = new RedirectAttributesModelMap();
+
+        // Act
+        String result = adminController.showRoleCreationForm(model, redirectAttributes, session, appName);
+
+        // Assert
+        assertEquals("redirect:/admin/silas-administration?tab=roles", result);
     }
 
     @Test
@@ -1223,9 +1240,10 @@ class AdminControllerTest {
         List<AppDto> apps = createMockApps();
         String appName = "Test App";
         when(appService.getAllLaaApps()).thenReturn(apps);
+        RedirectAttributes redirectAttributes = new RedirectAttributesModelMap();
 
         // Act
-        String result = adminController.showRoleCreationForm(model, session, appName);
+        String result = adminController.showRoleCreationForm(model, redirectAttributes, session, appName);
 
         // Assert
         assertEquals("silas-administration/create-role", result);


### PR DESCRIPTION
### Description :pencil:

Previously users were still being redirected to create a role form even if an application wasn't pre-selected.  This shouldn't be the case

---

### Changes Made :pencil:

- Validation added to admin controller, ensuring appFilter is populated before allowing redirection to Create A Role form.
- If appFilter is empty, user is shown an error and not redirected to create a role form
- 

---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [ ] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [x] I have a corresponding JIRA ticket for this change 
- [x] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:

Please fill in.

---