### PR TITLE
STB-4123 - Make entra_user_id non-nullable on user_profile

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     -   id: gitleaks
   # GitGuardian Shield secret scanner
 -   repo: https://github.com/gitguardian/ggshield
-    rev: v1.50.2
+    rev: v1.50.3
     hooks:
     -   id: ggshield
         language_version: python3

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/entity/UserProfile.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/entity/UserProfile.java
@@ -56,7 +56,7 @@ public class UserProfile extends AuditableEntity {
     private UUID legacyUserId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "entra_user_id", foreignKey = @ForeignKey(name = "FK_user_profile_user_id"))
+    @JoinColumn(name = "entra_user_id", nullable = false, foreignKey = @ForeignKey(name = "FK_user_profile_user_id"))
     @ToString.Exclude
     @JsonIgnore
     private EntraUser entraUser;

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/service/ExternalUserPollingService.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/service/ExternalUserPollingService.java
@@ -222,7 +222,6 @@ public class ExternalUserPollingService {
                     if (entraUser.getUserProfiles() != null) {
                         entraUser.getUserProfiles().remove(userProfile);
                     }
-                    userProfile.setEntraUser(null);
 
                     userProfileRepository.save(userProfile);
                     userProfileRepository.flush();

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/service/UserService.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/service/UserService.java
@@ -502,7 +502,6 @@ public class UserService {
                             up.getOffices().isEmpty() ? 0 : up.getOffices().size());
                     up.getOffices().clear();
                 }
-                up.setEntraUser(null);
                 userProfileRepository.save(up);
             }
             userProfileRepository.flush();
@@ -568,7 +567,7 @@ public class UserService {
         // Remove bidirectional association: profile from entra user and entra user from
         // profile
         entraUser.getUserProfiles().remove(userProfile);
-        userProfile.setEntraUser(null);
+
         userProfileRepository.save(userProfile);
         userProfileRepository.flush();
 
@@ -1505,7 +1504,6 @@ public class UserService {
                         if (profile.getAppRoles() != null) {
                             profile.getAppRoles().clear();
                         }
-                        profile.setEntraUser(null);
                         userProfileRepository.save(profile);
                     }
                     userProfileRepository.flush();

--- a/src/main/resources/db/changelog/changesets/db.changesets-5.47.yaml
+++ b/src/main/resources/db/changelog/changesets/db.changesets-5.47.yaml
@@ -1,0 +1,10 @@
+databaseChangeLog:
+  - changeSet:
+      id: make-entra_user_id-column-on-user_profile-not-null
+      author: your-name
+
+      changes:
+        - addNotNullConstraint:
+            tableName: user_profile
+            columnName: entra_user_id
+            columnDataType: uuid


### PR DESCRIPTION
### Description :pencil:

STB-4123 - Make entra_user_id non-nullable on user_profile

https://dsdmoj.atlassian.net/browse/STB-4123

---

### Changes Made :pencil:

- 
- 
- 

---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [ ] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [ ] I have a corresponding JIRA ticket for this change 
- [ ] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:

Please fill in.

---