### PR TITLE
STB-4056: Fix missing user uptake report error

### DIFF
--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/repository/EntraUserRepository.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/repository/EntraUserRepository.java
@@ -417,6 +417,7 @@ public interface EntraUserRepository extends JpaRepository<EntraUser, UUID> {
 
 
     @Query("""
+        SELECT COUNT(DISTINCT eu.id)
         FROM EntraUser eu
         LEFT JOIN UserProfile up
             ON up.entraUser.id = eu.id


### PR DESCRIPTION
### Description :pencil:

User uptake report was erroring on generation, due to no count in SQL query

---

### Changes Made :pencil:

- added COUNT to SQL query for method countActiveExternalMultiFirmUsers()
- 
- 

---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [x] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [x] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [x] I have a corresponding JIRA ticket for this change 
- [x] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:

Please fill in.

---