### PR TITLE
STB-4141 Add playwright tests for internal/external role filters on silas administration screen

### DIFF
--- a/src/main/resources/db/changelog/playwrightChangesets/seed-playwright-data.yml
+++ b/src/main/resources/db/changelog/playwrightChangesets/seed-playwright-data.yml
@@ -722,7 +722,7 @@ databaseChangeLog:
       id: 1770936555-16
       author: chris.marron
       context: playwright
-      comment: "Insert internal app role for Roles and Permissions user type filter testing"
+      comment: "Insert internal app roles for Roles and Permissions user type filter testing"
       changes:
         - sql:
             dbms: postgresql
@@ -736,12 +736,22 @@ databaseChangeLog:
                 user_type_restriction,
                 ordinal
               )
-              VALUES (
+              VALUES 
+              (
                 FALSE,
                 '99999999-9999-9999-9999-999999999999',
                 'ffffffff-ffff-ffff-ffff-cccccccccccc',
-                'Test Internal App Role Access',
-                'Test Internal App Role Access',
+                'Test Internal App Role One',
+                'Test Internal App Role One',
                 '{INTERNAL}',
                 2
+              ),
+              (
+                FALSE,
+                '99999999-9999-9999-9999-999999999999',
+                'ffffffff-ffff-ffff-ffff-dddddddddddd',
+                'Test Internal App Role Two',
+                'Test Internal App Role Two',
+                '{INTERNAL}',
+                3
               );

--- a/src/main/resources/db/changelog/playwrightChangesets/seed-playwright-data.yml
+++ b/src/main/resources/db/changelog/playwrightChangesets/seed-playwright-data.yml
@@ -717,3 +717,31 @@ databaseChangeLog:
                 false,
                 true
               );
+
+  - changeSet:
+      id: 1770936555-16
+      author: chris.marron
+      context: playwright
+      comment: "Insert internal app role for Roles and Permissions user type filter testing"
+      changes:
+        - sql:
+            dbms: postgresql
+            sql: |
+              INSERT INTO public.app_role (
+                authz_role,
+                app_id,
+                id,
+                description,
+                name,
+                user_type_restriction,
+                ordinal
+              )
+              VALUES (
+                FALSE,
+                '99999999-9999-9999-9999-999999999999',
+                'ffffffff-ffff-ffff-ffff-cccccccccccc',
+                'Test Internal App Role Access',
+                'Test Internal App Role Access',
+                '{INTERNAL}',
+                2
+              );

--- a/src/playwrightTest/java/uk/gov/justice/laa/portal/landingpage/playwright/pages/AdminPage.java
+++ b/src/playwrightTest/java/uk/gov/justice/laa/portal/landingpage/playwright/pages/AdminPage.java
@@ -65,6 +65,7 @@ public class AdminPage {
     private final Locator accessForbiddenMessage;
     private final Locator goToHomepageButton;
     private final Locator signOutAndTryAgainButton;
+    private final Locator userTypeFilterSelect;
 
     public AdminPage(Page page, int port) {
         this.page = page;
@@ -122,6 +123,7 @@ public class AdminPage {
         this.rolesRows = rolesTable.locator("tbody.govuk-table__body tr.govuk-table__row");
         this.reorderRolesLink = rolesAndPermissionsPanel.locator("a.govuk-link:has-text('Reorder application "
                 + "roles')");
+        this.userTypeFilterSelect = rolesAndPermissionsPanel.locator("#userTypeFilter");
 
         //Forbidden Access Page
         this.accessForbiddenHeading = page.locator("h1.govuk-heading-l:has-text('Access forbidden')");
@@ -323,5 +325,40 @@ public class AdminPage {
                         + ". Expected '" + expected + "' but was '" + actual + "'. Full actual: " + actualHeaders);
             }
         }
+    }
+
+    public AdminPage assertUserTypeFilterVisible() {
+        goToRolesAndPermissionsTab();
+        assertThat(userTypeFilterSelect).isVisible();
+        return this;
+    }
+
+    public AdminPage filterRolesByUserType(String userType) {
+        goToRolesAndPermissionsTab();
+
+        assertThat(userTypeFilterSelect).isVisible();
+        userTypeFilterSelect.selectOption(userType);
+
+        page.waitForLoadState(LoadState.DOMCONTENTLOADED);
+        assertThat(rolesAndPermissionsPanel).isVisible();
+
+        return this;
+    }
+
+    public AdminPage assertOnlySelectedUserTypeIsDisplayed(String expectedUserType) {
+        goToRolesAndPermissionsTab();
+
+        int rowCount = rolesRows.count();
+
+        if (rowCount == 0) {
+            throw new AssertionError("Expected at least 1 role to be displayed after filtering by " + expectedUserType);
+        }
+
+        for (int i = 0; i < rowCount; i++) {
+            Locator userTypeCell = rolesRows.nth(i).locator("td.govuk-table__cell").nth(4);
+            assertThat(userTypeCell).hasText(expectedUserType);
+        }
+
+        return this;
     }
 }

--- a/src/playwrightTest/java/uk/gov/justice/laa/portal/landingpage/playwright/tests/AdminPageTest.java
+++ b/src/playwrightTest/java/uk/gov/justice/laa/portal/landingpage/playwright/tests/AdminPageTest.java
@@ -172,8 +172,8 @@ public class AdminPageTest extends BaseFrontEndTest {
                 .assertReorderRolesLinkVisible();
 
         Assertions.assertTrue(
-                adminPage.getRolesRowCount() == 5,
-                "Expected Roles table to contain 5 rows"
+                adminPage.getRolesRowCount() == 6,
+                "Expected Roles table to contain 6 rows"
         );
 
         page.locator("select#appFilter").selectOption("Test LAA App Two");
@@ -207,8 +207,8 @@ public class AdminPageTest extends BaseFrontEndTest {
                 .assertReorderRolesLinkVisible();
 
         Assertions.assertTrue(
-                adminPage.getRolesRowCount() == 4,
-                "Expected Roles table to contain 4 rows"
+                adminPage.getRolesRowCount() == 5,
+                "Expected Roles table to contain 5 rows"
         );
 
     }

--- a/src/playwrightTest/java/uk/gov/justice/laa/portal/landingpage/playwright/tests/AdminPageTest.java
+++ b/src/playwrightTest/java/uk/gov/justice/laa/portal/landingpage/playwright/tests/AdminPageTest.java
@@ -399,4 +399,20 @@ public class AdminPageTest extends BaseFrontEndTest {
         PlaywrightAssertions.assertThat(dismiss).isVisible();
         PlaywrightAssertions.assertThat(dismiss).hasAttribute("href", "/admin/silas-administration?tab=apps");
     }
+
+    private static Stream<String> userTypes() {
+        return Stream.of("INTERNAL", "EXTERNAL");
+    }
+
+    @ParameterizedTest(name = "Roles user type filter only returns {0} roles")
+    @MethodSource("userTypes")
+    @DisplayName("Roles and Permissions user type filter only returns selected user type")
+    void rolesFilter_onlyReturnsSelectedUserType(String userType) {
+        AdminPage adminPage = loginAndGetAdminPage(TestUser.SILAS_ADMINISTRATION);
+
+        adminPage.assertRolesTableColumns()
+                .assertUserTypeFilterVisible()
+                .filterRolesByUserType(userType)
+                .assertOnlySelectedUserTypeIsDisplayed(userType);
+    }
 }

--- a/src/playwrightTest/java/uk/gov/justice/laa/portal/landingpage/playwright/tests/AdminPageTest.java
+++ b/src/playwrightTest/java/uk/gov/justice/laa/portal/landingpage/playwright/tests/AdminPageTest.java
@@ -172,8 +172,8 @@ public class AdminPageTest extends BaseFrontEndTest {
                 .assertReorderRolesLinkVisible();
 
         Assertions.assertTrue(
-                adminPage.getRolesRowCount() == 6,
-                "Expected Roles table to contain 6 rows"
+                adminPage.getRolesRowCount() == 7,
+                "Expected Roles table to contain 7 rows"
         );
 
         page.locator("select#appFilter").selectOption("Test LAA App Two");
@@ -207,8 +207,8 @@ public class AdminPageTest extends BaseFrontEndTest {
                 .assertReorderRolesLinkVisible();
 
         Assertions.assertTrue(
-                adminPage.getRolesRowCount() == 5,
-                "Expected Roles table to contain 5 rows"
+                adminPage.getRolesRowCount() == 6,
+                "Expected Roles table to contain 6 rows"
         );
 
     }


### PR DESCRIPTION
There is new functionality added for the silas administration page which allows the user to filter via external and internal roles. 

This PR verifies the functionality of these filters

### Description :pencil:

Please fill in.

---

### Changes Made :pencil:

- 
- 
- 

---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [ ] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [x] I have a corresponding JIRA ticket for this change 
- [ ] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:

Please fill in.

---