### PR TITLE
STB-4148: Adding user profile clearing when deleting entra user to avoid stale references.

### DIFF
--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/service/ExternalUserPollingService.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/service/ExternalUserPollingService.java
@@ -231,6 +231,10 @@ public class ExternalUserPollingService {
 
             userProfileRepository.flush();
 
+            // Remove user profiles from user to avoid stale references.
+            if (entraUser.getUserProfiles() != null && !entraUser.getUserProfiles().isEmpty()) {
+                entraUser.getUserProfiles().clear();
+            }
             entraUserRepository.delete(entraUser);
             entraUserRepository.flush();
             

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/service/UserService.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/service/UserService.java
@@ -508,6 +508,10 @@ public class UserService {
             userProfileRepository.deleteAll(profiles);
             userProfileRepository.flush();
         }
+        // Remove user profiles from user to avoid stale references.
+        if (entraUser.getUserProfiles() != null && !entraUser.getUserProfiles().isEmpty()) {
+            entraUser.getUserProfiles().clear();
+        }
         entraUserRepository.delete(entraUser);
         entraUserRepository.flush();
         return builder.build();
@@ -1513,6 +1517,10 @@ public class UserService {
                     logger.debug("Deleted {} profiles for internal user: {}", profiles.size(), entraId);
                 }
 
+                // Remove user profiles from user to avoid stale references.
+                if (entraUser.getUserProfiles() != null && !entraUser.getUserProfiles().isEmpty()) {
+                    entraUser.getUserProfiles().clear();
+                }
                 entraUserRepository.delete(entraUser);
                 entraUserRepository.flush();
 

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/service/UserServiceTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/service/UserServiceTest.java
@@ -269,7 +269,7 @@ class UserServiceTest {
                 .entraUser(entraUser)
                 .appRoles(new HashSet<>(Set.of(ccmsRole)))
                 .build();
-        entraUser.setUserProfiles(Set.of(profile));
+        entraUser.setUserProfiles(new HashSet<>(Set.of(profile)));
 
         when(mockUserProfileRepository.findById(profileId)).thenReturn(Optional.of(profile));
         when(mockUserProfileRepository.findAllByEntraUser(entraUser)).thenReturn(List.of(profile));
@@ -326,7 +326,7 @@ class UserServiceTest {
                 .entraUser(entraUser)
                 .appRoles(new HashSet<>(Set.of(nonCcmsRole)))
                 .build();
-        entraUser.setUserProfiles(Set.of(profile));
+        entraUser.setUserProfiles(new HashSet<>(Set.of(profile)));
 
         when(mockUserProfileRepository.findById(profileId)).thenReturn(Optional.of(profile));
         when(mockUserProfileRepository.findAllByEntraUser(entraUser)).thenReturn(List.of(profile));
@@ -365,7 +365,7 @@ class UserServiceTest {
                 .entraUser(entraUser)
                 .appRoles(new HashSet<>(Set.of(role1)))
                 .build();
-        entraUser.setUserProfiles(Set.of(profile));
+        entraUser.setUserProfiles(new HashSet<>(Set.of(profile)));
 
         EntraUserDto entraUserDto = new MapperConfig().modelMapper().map(entraUser, EntraUserDto.class);
 
@@ -408,7 +408,7 @@ class UserServiceTest {
                 .entraUser(entraUser)
                 .appRoles(new HashSet<>(Set.of(role1)))
                 .build();
-        entraUser.setUserProfiles(Set.of(profile));
+        entraUser.setUserProfiles(new HashSet<>(Set.of(profile)));
 
         EntraUserDto entraUserDto = new MapperConfig().modelMapper().map(entraUser, EntraUserDto.class);
 
@@ -453,7 +453,7 @@ class UserServiceTest {
                 .entraUser(entraUser)
                 .appRoles(new HashSet<>(Set.of(role1)))
                 .build();
-        entraUser.setUserProfiles(Set.of(profile));
+        entraUser.setUserProfiles(new HashSet<>(Set.of(profile)));
 
         EntraUserDto entraUserDto = new MapperConfig().modelMapper().map(entraUser, EntraUserDto.class);
 


### PR DESCRIPTION
### Description :pencil:

Deleting users was throwing a hibernate exception due to stale references to deleted user profiles. Have added a check to clear profiles before deletion.

---

### Changes Made :pencil:

- Added a check before deleting a user to clear their profiles.
- Updated unit tests to use mutable collections so avoid immutable collection exceptions.

---

### Checklist :pencil:

- [X] I have added the relevant Liquibase changelog files for any entity changes
- [X] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [X] I have taken into account the application runs as 3 replicas in live environments
- [X] I have created any relevant documentation for this change
- [X] I have a corresponding JIRA ticket for this change 
- [X] I have added relevant unit & integration tests where applicable