### PR TITLE
STB-4081: Updating GitHub Action workflow top level permissions, to address Ash…

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -13,6 +13,9 @@ on:
       - synchronize
       - closed
 
+permissions:
+  contents: read
+
 jobs:
   pa11y:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}  # Only if deploy succeeds

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+  id-token: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false

--- a/.github/workflows/deploy_prd.yml
+++ b/.github/workflows/deploy_prd.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [prd]
 
+permissions:
+  contents: read
+  id-token: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false

--- a/.github/workflows/deploy_test.yml
+++ b/.github/workflows/deploy_test.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [test]
 
+permissions:
+  id-token: write
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
@@ -14,9 +18,6 @@ jobs:
     if: github.ref == 'refs/heads/test'
     runs-on: ubuntu-latest
     environment: test
-    permissions:
-      id-token: write # This is required for requesting the JWT
-      contents: read # This is required for actions/checkout
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/jira_check.yml
+++ b/.github/workflows/jira_check.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, edited, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   check-pr-title:
     runs-on: ubuntu-latest

--- a/.github/workflows/linter-check.yml
+++ b/.github/workflows/linter-check.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [ opened, edited, reopened, synchronize ]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Run Checkstyle

--- a/.github/workflows/promote_to_prod.yml
+++ b/.github/workflows/promote_to_prod.yml
@@ -3,6 +3,10 @@ name: Merge to Production
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   create-prod-pr:
     runs-on: ubuntu-latest

--- a/.github/workflows/promote_to_test.yml
+++ b/.github/workflows/promote_to_test.yml
@@ -3,6 +3,9 @@ name: Promote Main into Test
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   merge:
     runs-on: ubuntu-latest

--- a/.github/workflows/secret_scan_gitguardian.yml
+++ b/.github/workflows/secret_scan_gitguardian.yml
@@ -10,12 +10,13 @@ on:
   push:
     branches:
       - main
-        
+
+permissions:
+  contents: read
+
 jobs:
   scan:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/secret_scan_gitleaks.yml
+++ b/.github/workflows/secret_scan_gitleaks.yml
@@ -11,6 +11,9 @@ on:
   schedule:
     - cron: "53 1 * * *" # run once a day at 01:53 UTC
 
+permissions:
+  contents: read
+
 jobs:
   scan:
     name: gitleaks

--- a/.github/workflows/secret_scan_trufflehog.yml
+++ b/.github/workflows/secret_scan_trufflehog.yml
@@ -11,6 +11,9 @@ on:
   schedule:
     - cron: "53 0 * * *" # run once a day at 00:53 UTC
 
+permissions:
+  contents: read
+
 jobs:
   scan:
     runs-on: ubuntu-latest

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -19,6 +19,10 @@ on:
         description: 'Snyk Organization ID'
       SNYK_SLACK_WEBHOOK_URL:
         required: false
+
+permissions:
+  contents: read
+
 jobs:
   vulnerability-scan:
     runs-on: ubuntu-latest

--- a/.github/workflows/zap_dast_daily_prd.yml
+++ b/.github/workflows/zap_dast_daily_prd.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '0 3 * * 1-5' # At 03:00 on Monday through Friday
 
+permissions:
+  contents: none
+
 jobs:
   zap_scan:
     name: ZAP PRD DAST Daily Baseline Scan Against Live App

--- a/.github/workflows/zap_dast_daily_test.yml
+++ b/.github/workflows/zap_dast_daily_test.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '0 8 * * 1-5' # At 08:00 on Monday through Friday
 
+permissions:
+  contents: none
+
 jobs:
   zap_scan:
     name: ZAP TEST DAST Daily Baseline Scan Against Live App

--- a/.github/workflows/zap_dast_weekly_dev.yml
+++ b/.github/workflows/zap_dast_weekly_dev.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '0 8 * * SUN'
 
+permissions:
+  contents: none
+
 jobs:
   zap_scan:
     name: Run Full ZAP DEV DAST Scan Against Live App


### PR DESCRIPTION
GitHub Action top level permissions update  

### Description :pencil:

The Ash checkov scan has highlighted excessive permissions for some GitHub Action workflows. This PR addresses this by reducing the top level permissions to what's required for their required functionality. 

---

### Changes Made :pencil:

- Setting top level GitHub Action permissions on the relevant workflows

---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [x] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [x] I have a corresponding JIRA ticket for this change 
- [ ] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:



---