### PR TITLE
STB-4081: GitHub Actions permission fix for deploy_dev workflow

### DIFF
--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -8,6 +8,8 @@ on:
 permissions:
   contents: read
   id-token: write
+  actions: read
+  security-events: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -22,6 +22,8 @@ on:
 
 permissions:
   contents: read
+  actions: read
+  security-events: write
 
 jobs:
   vulnerability-scan:


### PR DESCRIPTION
### Description :pencil:

Need to add additional permissions to deploy_dev, for Snyk to write to Security tab

---

### Changes Made :pencil:

- Update to deploy_dev and snyk.yaml workflow permissions

---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [x] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [x] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [x] I have a corresponding JIRA ticket for this change 
- [ ] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:



---