### PR TITLE
STB-3994 - NONE allows all roles (including FUM and unauthenticated) to re-enable a user — identical behaviour to null.

### DIFF
--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/entity/DisableType.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/entity/DisableType.java
@@ -26,8 +26,8 @@ public enum DisableType {
     SYNC("Sync"),
 
     /**
-     * Disabled without a known actor (legacy / manual process before tracking was introduced).
-     * Only External User Manager / Admin or higher can re-enable.
+     * Disabled by a manual user sync process, or an unattributed disable before full tracking was introduced.
+     * All roles are permitted to re-enable (identical behaviour to a {@code null} disable type).
      */
     NONE("None"),
 

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/entity/DisableType.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/entity/DisableType.java
@@ -7,8 +7,8 @@ package uk.gov.justice.laa.portal.landingpage.entity;
  *
  * <p>The hierarchy (lowest to highest delegation):
  * <ol>
+ *   <li>{@link #NONE}      – disabled by a manual sync process (or unattributed); all roles permitted to re-enable</li>
  *   <li>{@link #SYNC}      – disabled by an automated sync process; only EUM/EUA or higher can re-enable</li>
- *   <li>{@link #NONE}      – disabled without a known actor (legacy); only EUM/EUA or higher can re-enable</li>
  *   <li>{@link #FIRM}      – disabled by a Firm User Manager; any FUM (same firm), EUM/EUA or higher can re-enable</li>
  *   <li>{@link #LAA}       – disabled by an External User Manager or External User Admin; only EUM/EUA or higher</li>
  *   <li>{@link #PRIVILEGED} – disabled by Security Response or Global Admin; only GA or SR can re-enable</li>

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/service/UserEnablementPolicy.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/service/UserEnablementPolicy.java
@@ -16,7 +16,8 @@ import uk.gov.justice.laa.portal.landingpage.entity.DisableType;
  * <table border="1">
  *   <tr><th>disable_type</th><th>FUM</th><th>EUM / EUA</th><th>SR / GA</th></tr>
  *   <tr><td>NULL (unknown/legacy)</td><td>✅</td><td>✅</td><td>✅</td></tr>
- *   <tr><td>NONE (sync)</td><td>❌</td><td>✅</td><td>✅</td></tr>
+ *   <tr><td>NONE (manual sync)</td><td>✅</td><td>✅</td><td>✅</td></tr>
+ *   <tr><td>SYNC (automated sync)</td><td>❌</td><td>✅</td><td>✅</td></tr>
  *   <tr><td>FIRM</td><td>✅ (same-firm check required separately)</td><td>✅</td><td>✅</td></tr>
  *   <tr><td>LAA</td><td>❌</td><td>✅</td><td>✅</td></tr>
  *   <tr><td>PRIVILEGED</td><td>❌</td><td>❌</td><td>✅</td></tr>

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/service/UserEnablementPolicy.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/service/UserEnablementPolicy.java
@@ -64,8 +64,8 @@ public class UserEnablementPolicy {
                     isEuaLevel || isGlobalAdminOrSecurityResponse;
 
             case NONE ->
-                    // Sync-disabled: EUM/EUA or higher only
-                    isEuaLevel || isGlobalAdminOrSecurityResponse;
+                    // Manual sync / legacy-with-known-type: all roles permitted (identical to null)
+                    true;
 
             case FIRM ->
                     // FUM-disabled: any FUM (same-firm check handled separately), EUM/EUA, or higher

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/service/UserEnablementPolicyTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/service/UserEnablementPolicyTest.java
@@ -1,15 +1,15 @@
 package uk.gov.justice.laa.portal.landingpage.service;
 
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+
 import uk.gov.justice.laa.portal.landingpage.entity.AuthzRole;
 import uk.gov.justice.laa.portal.landingpage.entity.DisableType;
-
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(MockitoExtension.class)
 class UserEnablementPolicyTest {
@@ -35,7 +35,7 @@ class UserEnablementPolicyTest {
             assertThat(policy.canEnable(null, List.of())).isTrue();
         }
 
-        // --- NONE disable type (Manual User Sync / Automatic User Sync) ---
+        // --- NONE disable type (Manual User Sync — all roles permitted) ---
 
         @Test
         void none_gaCanEnable() {
@@ -58,13 +58,45 @@ class UserEnablementPolicyTest {
         }
 
         @Test
-        void none_fumCannotEnable() {
-            assertThat(policy.canEnable(DisableType.NONE, List.of(FUM))).isFalse();
+        void none_fumCanEnable() {
+            assertThat(policy.canEnable(DisableType.NONE, List.of(FUM))).isTrue();
         }
 
         @Test
-        void none_noRoleCannotEnable() {
-            assertThat(policy.canEnable(DisableType.NONE, List.of())).isFalse();
+        void none_noRoleCanEnable() {
+            assertThat(policy.canEnable(DisableType.NONE, List.of())).isTrue();
+        }
+
+        // --- SYNC disable type (Automatic User Sync — EUM/EUA+ only) ---
+
+        @Test
+        void sync_gaCanEnable() {
+            assertThat(policy.canEnable(DisableType.SYNC, List.of(GA))).isTrue();
+        }
+
+        @Test
+        void sync_srCanEnable() {
+            assertThat(policy.canEnable(DisableType.SYNC, List.of(SR))).isTrue();
+        }
+
+        @Test
+        void sync_eumCanEnable() {
+            assertThat(policy.canEnable(DisableType.SYNC, List.of(EUM))).isTrue();
+        }
+
+        @Test
+        void sync_euaCanEnable() {
+            assertThat(policy.canEnable(DisableType.SYNC, List.of(EUA))).isTrue();
+        }
+
+        @Test
+        void sync_fumCannotEnable() {
+            assertThat(policy.canEnable(DisableType.SYNC, List.of(FUM))).isFalse();
+        }
+
+        @Test
+        void sync_noRoleCannotEnable() {
+            assertThat(policy.canEnable(DisableType.SYNC, List.of())).isFalse();
         }
 
         // --- FIRM disable type (Firm User Manager disabled the user) ---


### PR DESCRIPTION


### Description :pencil:

NONE allows all roles (including FUM and unauthenticated) to re-enable a user — identical behaviour to null.

---

### Changes Made :pencil:

This pull request updates the user enablement policy logic to allow all roles to re-enable users disabled by a manual sync or legacy process (represented by the `NONE` disable type), aligning its behavior with the case where the disable type is `null`. It also updates the associated tests to reflect this change and adds more comprehensive test coverage for both `NONE` and `SYNC` disable types.

**Policy logic changes:**

* Updated the `UserEnablementPolicy.canEnable` method so that when the `disableType` is `NONE`, any role (including no role) can re-enable the user, instead of restricting this action to only higher-level roles.
* Clarified the `DisableType.NONE` enum documentation to indicate that all roles are now permitted to re-enable users disabled by manual sync or legacy processes.

**Test improvements:**

* Updated and expanded tests in `UserEnablementPolicyTest` to verify that all roles (including no role) can enable users with the `NONE` disable type, and that only higher-level roles can enable users with the `SYNC` disable type.
* Improved test descriptions and organization for clarity, including updating comments to match the new policy behavior.
* Minor test file import reordering for clarity and consistency.
---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [ ] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [x] I have a corresponding JIRA ticket for this change 
- [x] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:

Please fill in.

---