### PR TITLE
STB-4148: Rework internal user deletion logic to avoid hibernate exception.

### DIFF
--- a/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/polling/InternalUserPollingIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/polling/InternalUserPollingIntegrationTest.java
@@ -1,0 +1,107 @@
+package uk.gov.justice.laa.portal.landingpage.polling;
+
+import com.microsoft.graph.models.DirectoryObject;
+import com.microsoft.graph.models.DirectoryObjectCollectionResponse;
+import com.microsoft.graph.serviceclient.GraphServiceClient;
+import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import uk.gov.justice.laa.portal.landingpage.controller.BaseIntegrationTest;
+import uk.gov.justice.laa.portal.landingpage.entity.EntraUser;
+import uk.gov.justice.laa.portal.landingpage.entity.UserProfile;
+import uk.gov.justice.laa.portal.landingpage.entity.UserType;
+import uk.gov.justice.laa.portal.landingpage.repository.EntraUserRepository;
+import uk.gov.justice.laa.portal.landingpage.repository.UserProfileRepository;
+import uk.gov.justice.laa.portal.landingpage.service.UserService;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings({"SpringJavaInjectionPointsAutowiringInspection", "SpringBootApplicationProperties"})
+// Enable polling for this test only.
+@TestPropertySource(properties = {
+    "internal.user.polling.enabled=true"
+})
+public class InternalUserPollingIntegrationTest extends BaseIntegrationTest {
+
+    @Autowired
+    private EntraUserRepository entraUserRepository;
+
+    @Autowired
+    private UserProfileRepository userProfileRepository;
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private InternalUserPolling internalUserPolling;
+
+    @MockitoBean(answers = Answers.RETURNS_DEEP_STUBS)
+    private GraphServiceClient graphServiceClient;
+
+    @Test
+    public void testInternalUserPollingDeletesNotReturnedInternalUser() {
+        // Have the poll response return all users before adding new user.
+        List<UUID> allUserEntraIds = userService.getInternalUserEntraIds();
+        // Setup mock entra response.
+        List<DirectoryObject> directoryObjects = allUserEntraIds.stream()
+                .map(uuid -> {
+                    DirectoryObject directoryObject = mock(DirectoryObject.class);
+                    when(directoryObject.getId()).thenReturn(uuid.toString());
+                    return directoryObject;
+                })
+                .toList();
+        DirectoryObjectCollectionResponse response = mock(DirectoryObjectCollectionResponse.class);
+        when(response.getValue()).thenReturn(directoryObjects);
+        when(graphServiceClient.groups().byGroupId(any()).members().get()).thenReturn(response);
+
+        // Add a new internal user.
+        EntraUser userToBeDeleted = buildEntraUser(UUID.randomUUID().toString(), "internalpollingtest@test.com", "InternalPolling", "Test");
+        UserProfile profileToBeDeleted = buildLaaUserProfile(userToBeDeleted, UserType.INTERNAL, true, "Global Admin");
+        userToBeDeleted = entraUserRepository.saveAndFlush(userToBeDeleted);
+        profileToBeDeleted = userProfileRepository.saveAndFlush(profileToBeDeleted);
+
+        // Poll
+        internalUserPolling.poll();
+
+        // Ensure newly added user was successfully deleted after polling.
+        Optional<EntraUser> deletedUser = entraUserRepository.findById(userToBeDeleted.getId());
+        Optional<UserProfile> deletedProfile = userProfileRepository.findById(profileToBeDeleted.getId());
+
+        assertThat(deletedUser).isEmpty();
+        assertThat(deletedProfile).isEmpty();
+    }
+
+    @Test
+    public void testInternalUserPollingDoesNotDeleteUsersWhenAllUsersExist() {
+        // Have the poll response return all users.
+        List<UUID> allUserEntraIds = userService.getInternalUserEntraIds();
+        // Setup mock entra response.
+        List<DirectoryObject> directoryObjects = allUserEntraIds.stream()
+                .map(uuid -> {
+                    DirectoryObject directoryObject = mock(DirectoryObject.class);
+                    when(directoryObject.getId()).thenReturn(uuid.toString());
+                    return directoryObject;
+                })
+                .toList();
+        DirectoryObjectCollectionResponse response = mock(DirectoryObjectCollectionResponse.class);
+        when(response.getValue()).thenReturn(directoryObjects);
+        when(graphServiceClient.groups().byGroupId(any()).members().get()).thenReturn(response);
+
+        // Poll
+        internalUserPolling.poll();
+
+        // Ensure no users deleted.
+        assertThat(allUserEntraIds.size()).isEqualTo(userService.getInternalUserEntraIds().size());
+    }
+
+}

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/service/UserService.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/service/UserService.java
@@ -1537,7 +1537,7 @@ public class UserService {
 
                 EntraUser entraUser = optionalEntraUser.get();
 
-                List<UserProfile> profiles = userProfileRepository.findAllByEntraUser(entraUser);
+                Set<UserProfile> profiles = entraUser.getUserProfiles();
                 boolean isInternalUser = profiles.stream()
                         .anyMatch(profile -> profile.getUserType() == UserType.INTERNAL);
 
@@ -1561,16 +1561,10 @@ public class UserService {
                         userProfileRepository.save(profile);
                     }
                     userProfileRepository.flush();
-
-                    userProfileRepository.deleteAll(profiles);
-                    userProfileRepository.flush();
                     logger.debug("Deleted {} profiles for internal user: {}", profiles.size(), entraId);
                 }
 
-                // Remove user profiles from user to avoid stale references.
-                if (entraUser.getUserProfiles() != null && !entraUser.getUserProfiles().isEmpty()) {
-                    entraUser.getUserProfiles().clear();
-                }
+                userProfileRepository.deleteAll(entraUser.getUserProfiles());
                 entraUserRepository.delete(entraUser);
                 entraUserRepository.flush();
 

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/service/UserServiceTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/service/UserServiceTest.java
@@ -10245,7 +10245,6 @@ class UserServiceTest {
             // Given
             UUID entraId1 = UUID.randomUUID();
             UUID entraId2 = UUID.randomUUID();
-            List<UUID> entraIds = List.of(entraId1, entraId2);
 
             EntraUser entraUser1 = EntraUser.builder()
                     .id(UUID.randomUUID())
@@ -10275,19 +10274,18 @@ class UserServiceTest {
                     .entraUser(entraUser2)
                     .build();
 
+            entraUser1.setUserProfiles(new HashSet<>(Set.of(profile1)));
+            entraUser2.setUserProfiles(new HashSet<>(Set.of(profile2)));
+
             when(mockEntraUserRepository.findByEntraOid(entraId1.toString())).thenReturn(Optional.of(entraUser1));
             when(mockEntraUserRepository.findByEntraOid(entraId2.toString())).thenReturn(Optional.of(entraUser2));
-            when(mockUserProfileRepository.findAllByEntraUser(entraUser1)).thenReturn(List.of(profile1));
-            when(mockUserProfileRepository.findAllByEntraUser(entraUser2)).thenReturn(List.of(profile2));
             when(mockUserAccountStatusAuditRepository.findByEntraUser(any())).thenReturn(List.of());
-
+            List<UUID> entraIds = List.of(entraId1, entraId2);
             // When
             int result = userService.deleteInternalUsersByEntraIds(entraIds);
 
             // Then
             assertEquals(2, result);
-            verify(mockUserProfileRepository).deleteAll(List.of(profile1));
-            verify(mockUserProfileRepository).deleteAll(List.of(profile2));
             verify(mockEntraUserRepository).delete(entraUser1);
             verify(mockEntraUserRepository).delete(entraUser2);
         }
@@ -10309,8 +10307,9 @@ class UserServiceTest {
                     .entraUser(entraUser)
                     .build();
 
+            entraUser.setUserProfiles(new HashSet<>(Set.of(externalProfile)));
+
             when(mockEntraUserRepository.findByEntraOid(entraId.toString())).thenReturn(Optional.of(entraUser));
-            when(mockUserProfileRepository.findAllByEntraUser(entraUser)).thenReturn(List.of(externalProfile));
 
             // When
             int result = userService.deleteInternalUsersByEntraIds(entraIds);
@@ -10346,7 +10345,6 @@ class UserServiceTest {
             // Given
             UUID entraId1 = UUID.randomUUID();
             UUID entraId2 = UUID.randomUUID();
-            List<UUID> entraIds = List.of(entraId1, entraId2);
 
             EntraUser entraUser2 = EntraUser.builder()
                     .id(UUID.randomUUID())
@@ -10359,11 +10357,13 @@ class UserServiceTest {
                     .entraUser(entraUser2)
                     .build();
 
+            entraUser2.setUserProfiles(new HashSet<>(Set.of(profile2)));
+
             // First user not found, second user exists
             when(mockEntraUserRepository.findByEntraOid(entraId1.toString())).thenReturn(Optional.empty());
             when(mockEntraUserRepository.findByEntraOid(entraId2.toString())).thenReturn(Optional.of(entraUser2));
-            when(mockUserProfileRepository.findAllByEntraUser(entraUser2)).thenReturn(List.of(profile2));
             when(mockUserAccountStatusAuditRepository.findByEntraUser(entraUser2)).thenReturn(List.of());
+            List<UUID> entraIds = List.of(entraId1, entraId2);
 
             // When
             int result = userService.deleteInternalUsersByEntraIds(entraIds);


### PR DESCRIPTION
### Description :pencil:

Reworked internal user deletion logic to avoid hibernate exception.

---

### Changes Made :pencil:

- Changed logic to fetch user profiles directly from entra user object.
- Delete all user profiles directly from entra user project before deleting user.
- Added integration tests to test polling.

---

### Checklist :pencil:

- [X] I have added the relevant Liquibase changelog files for any entity changes
- [X] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [X] I have taken into account the application runs as 3 replicas in live environments
- [X] I have created any relevant documentation for this change
- [X] I have a corresponding JIRA ticket for this change 
- [X] I have added relevant unit & integration tests where applicable