### PR TITLE
STB-4164 - Add CSV export error handling and update button logic in user audit table

### DIFF
--- a/src/main/resources/templates/user-audit/users.html
+++ b/src/main/resources/templates/user-audit/users.html
@@ -45,6 +45,8 @@
                      role="alert"
                      aria-labelledby="csv-error-summary-title"
                      data-module="govuk-error-summary"
+                     data-disable-auto-focus="true"
+                     tabindex="-1"
                      hidden>
                     <h2 class="govuk-error-summary__title" id="csv-error-summary-title">
                         There is a problem
@@ -934,7 +936,7 @@
                         e.preventDefault();
                         if (errorBanner) {
                             errorBanner.hidden = false;
-                            errorBanner.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                            errorBanner.focus();
                         }
                         return;
                     }

--- a/src/main/resources/templates/user-audit/users.html
+++ b/src/main/resources/templates/user-audit/users.html
@@ -963,7 +963,8 @@
                         <a class="govuk-button js-export-csv"
                            id="exportCsvButton"
                            th:attr="data-firm-selected=${firmSearch.getSelectedFirmId() != null or selectedUserType == 'INTERNAL'}, data-users-empty=${#lists.isEmpty(users)}"
-                           th:href="@{/admin/users/audit/download(search=${search},selectedFirmId=${firmSearch.selectedFirmId},silasRole=${selectedSilasRole},selectedAppId=${selectedAppId},selectedUserType=${selectedUserType},selectedFirmName=${firmSearch.firmSearch},neverActivated=${neverActivated})}">
+                           th:href="${firmSearch.getSelectedFirmId() != null or selectedUserType == 'INTERNAL'} ?
+                               @{/admin/users/audit/download(search=${search},selectedFirmId=${firmSearch.selectedFirmId},silasRole=${selectedSilasRole},selectedAppId=${selectedAppId},selectedUserType=${selectedUserType},selectedFirmName=${firmSearch.firmSearch},neverActivated=${neverActivated})} : '#'">
                             Export CSV
                         </a>
                     </th:block>

--- a/src/main/resources/templates/user-audit/users.html
+++ b/src/main/resources/templates/user-audit/users.html
@@ -39,13 +39,21 @@
             <div class="govuk-grid-column-full">
                 <h1 class="govuk-heading-l">User Access Audit Table</h1>
 
-                <!-- Deleted Users Button -->
-                <div class="govuk-!-margin-bottom-6">
-                    <a th:href="@{/admin/users/audit/deleted}"
-                       class="govuk-button govuk-button--secondary"
-                       data-module="govuk-button">
-                        View Deleted Users
-                    </a>
+                <!-- CSV export error summary -->
+                <div id="csv-export-error-summary"
+                     class="govuk-error-summary"
+                     role="alert"
+                     aria-labelledby="csv-error-summary-title"
+                     data-module="govuk-error-summary"
+                     hidden>
+                    <h2 class="govuk-error-summary__title" id="csv-error-summary-title">
+                        There is a problem
+                    </h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#firmSearch">Filter results to a single firm to enable CSV export.</a></li>
+                        </ul>
+                    </div>
                 </div>
 
                 <!-- Search Card -->
@@ -532,10 +540,6 @@
                 overflow-wrap: anywhere;
             }
 
-            #export-csv-error[hidden] {
-                display: none !important;
-            }
-
             @media (max-width: 1200px) {
 
                 .govuk-table__header,
@@ -904,14 +908,16 @@
                 });
             });
 
-            // Checks for empty csv
+            // Handles CSV export button: shows error banner when no firm selected, toast when results empty
             document.addEventListener('DOMContentLoaded', function () {
                 const exportLink = document.querySelector('.js-export-csv');
                 const toast = document.getElementById('csv-empty-toast');
+                const errorBanner = document.getElementById('csv-export-error-summary');
 
-                if (!exportLink || !toast) return;
+                if (!exportLink) return;
 
                 function showToast() {
+                    if (!toast) return;
                     toast.hidden = false;
                     toast.scrollIntoView({ behavior: 'smooth', block: 'start' });
 
@@ -922,29 +928,44 @@
                 }
 
                 exportLink.addEventListener('click', function (e) {
-                    const usersEmpty = exportLink.getAttribute('data-users-empty') === 'true';
+                    const firmSelected = exportLink.getAttribute('data-firm-selected') === 'true';
 
+                    if (!firmSelected) {
+                        e.preventDefault();
+                        if (errorBanner) {
+                            errorBanner.hidden = false;
+                            errorBanner.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                        }
+                        return;
+                    }
+
+                    const usersEmpty = exportLink.getAttribute('data-users-empty') === 'true';
                     if (usersEmpty) {
                         showToast();
                     }
                 });
             });
 
-
-            document.addEventListener('DOMContentLoaded', function () {
-                const button = document.getElementById('exportCsvButton');
-                const error = document.getElementById('export-csv-error');
-
-                if (button) {
-                    button.addEventListener('click', function (event) {
-                        event.preventDefault();
-                        error.hidden = false;
-                        button.classList.add('govuk-button--warning');
-                    });
-                }
-            });
-
         </script>
+
+        <!-- Export CSV and action buttons -->
+        <div class="govuk-grid-row govuk-!-margin-top-4">
+            <div class="govuk-grid-column-full">
+                <div class="moj-button-group">
+                    <th:block th:if="${exportCsv}">
+                        <a class="govuk-button js-export-csv"
+                           id="exportCsvButton"
+                           th:attr="data-firm-selected=${firmSearch.getSelectedFirmId() != null or selectedUserType == 'INTERNAL'}, data-users-empty=${#lists.isEmpty(users)}"
+                           th:href="@{/admin/users/audit/download(search=${search},selectedFirmId=${firmSearch.selectedFirmId},silasRole=${selectedSilasRole},selectedAppId=${selectedAppId},selectedUserType=${selectedUserType},selectedFirmName=${firmSearch.firmSearch},neverActivated=${neverActivated})}">
+                            Export CSV
+                        </a>
+                    </th:block>
+                    <a th:href="@{/admin/users/audit/deleted}" class="govuk-link govuk-!-margin-left-4">
+                        View all deleted users
+                    </a>
+                </div>
+            </div>
+        </div>
 
         <!-- Audit Table -->
         <div class="govuk-grid-row govuk-!-margin-top-6" id="audit-table">
@@ -1085,27 +1106,6 @@
                     </table>
                 </div>
             </div>
-        </div>
-
-        <!-- Export CSV -->
-        <div class="moj-button-group moj-button-group--inline moj-button-group--with-divider"
-             th:if="${exportCsv and firmSearch.getSelectedFirmId() == null and selectedUserType != 'INTERNAL'}">
-            <a href="#" class="govuk-button" id="exportCsvButton" aria-describedby="export-csv-error">
-                Export as CSV
-            </a>
-            <span id="export-csv-error" class="govuk-error-message govuk-!-margin-left-2" hidden>
-        <span class="govuk-visually-hidden">Error:</span>
-        You need to filter results to a single firm to enable CSV export.
-    </span>
-        </div>
-
-        <div class="moj-nutton-group moj-button-group--inline moj-button-group--with-divider"
-             th:if="${exportCsv and (firmSearch.getSelectedFirmId() != null or selectedUserType == 'INTERNAL')}">
-            <a class="govuk-button js-export-csv"
-               th:attr="data-users-empty=${#lists.isEmpty(users)}"
-               th:href="@{/admin/users/audit/download(search=${search},selectedFirmId=${firmSearch.selectedFirmId}, silasRole=${selectedSilasRole},selectedAppId=${selectedAppId},selectedUserType=${selectedUserType}, selectedFirmName=${firmSearch.firmSearch}, neverActivated=${neverActivated})}">
-                Export as CSV
-            </a>
         </div>
 
         <!-- Pagination -->

--- a/src/main/resources/templates/user-audit/users.html
+++ b/src/main/resources/templates/user-audit/users.html
@@ -44,6 +44,7 @@
                      class="govuk-error-summary"
                      role="alert"
                      aria-labelledby="csv-error-summary-title"
+                     aria-describedby="csv-error-summary-description"
                      data-module="govuk-error-summary"
                      data-disable-auto-focus="true"
                      tabindex="-1"
@@ -51,7 +52,7 @@
                     <h2 class="govuk-error-summary__title" id="csv-error-summary-title">
                         There is a problem
                     </h2>
-                    <div class="govuk-error-summary__body">
+                    <div class="govuk-error-summary__body" id="csv-error-summary-description">
                         <ul class="govuk-list govuk-error-summary__list">
                             <li><a href="#firmSearch">Filter results to a single firm to enable CSV export.</a></li>
                         </ul>

--- a/src/main/resources/templates/user-audit/users.html
+++ b/src/main/resources/templates/user-audit/users.html
@@ -941,6 +941,10 @@
                         return;
                     }
 
+                    if (errorBanner) {
+                        errorBanner.hidden = true;
+                    }
+
                     const usersEmpty = exportLink.getAttribute('data-users-empty') === 'true';
                     if (usersEmpty) {
                         showToast();

--- a/src/playwrightTest/java/uk/gov/justice/laa/portal/landingpage/playwright/pages/AuditPage.java
+++ b/src/playwrightTest/java/uk/gov/justice/laa/portal/landingpage/playwright/pages/AuditPage.java
@@ -264,13 +264,17 @@ public class AuditPage {
     }
 
     public double getExportCsvButtonY() {
+        Assertions.assertTrue(exportCsvButton.isVisible(), "Export CSV button must be visible before comparing position");
         var box = exportCsvButton.boundingBox();
-        return box != null ? box.y : 0;
+        Assertions.assertNotNull(box, "Export CSV button bounding box must not be null");
+        return box.y;
     }
 
     public double getAuditTableY() {
+        Assertions.assertTrue(auditTable.isVisible(), "Audit table must be visible before comparing position");
         var box = auditTable.boundingBox();
-        return box != null ? box.y : 0;
+        Assertions.assertNotNull(box, "Audit table bounding box must not be null");
+        return box.y;
     }
 
     public void clickExportCsvExpectingDownload() {

--- a/src/playwrightTest/java/uk/gov/justice/laa/portal/landingpage/playwright/pages/AuditPage.java
+++ b/src/playwrightTest/java/uk/gov/justice/laa/portal/landingpage/playwright/pages/AuditPage.java
@@ -1,14 +1,14 @@
 package uk.gov.justice.laa.portal.landingpage.playwright.pages;
 
-import com.microsoft.playwright.Locator;
-import com.microsoft.playwright.Page;
+import java.util.List;
 
-import com.microsoft.playwright.options.LoadState;
 import org.junit.jupiter.api.Assertions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.List;
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.options.LoadState;
 
 
 public class AuditPage {
@@ -48,6 +48,12 @@ public class AuditPage {
 
     private final Locator resultsSummary;
     private final Locator tableHeaders;
+
+    // CSV Export
+    private final Locator exportCsvButton;
+    private final Locator csvErrorBanner;
+    private final Locator viewDeletedUsersLink;
+    private final Locator auditTable;
 
     public AuditPage(Page page, int port) {
         this.page = page;
@@ -97,6 +103,11 @@ public class AuditPage {
         // Results Summary
         this.resultsSummary = page.locator(".moj-pagination__results");
 
+        // CSV Export
+        this.exportCsvButton = page.locator("#exportCsvButton");
+        this.csvErrorBanner = page.locator("#csv-export-error-summary");
+        this.viewDeletedUsersLink = page.locator("a:has-text('View all deleted users')");
+        this.auditTable = page.locator("#audit-table");
     }
 
     public void assertUserIsPresent(String email) {
@@ -200,6 +211,73 @@ public class AuditPage {
         );
     }
 
+    public void assertExportCsvButtonVisible() {
+        log.info("Asserting Export CSV button is visible");
+        Assertions.assertTrue(exportCsvButton.isVisible(), "Expected Export CSV button to be visible");
+    }
+
+    public void assertExportCsvButtonNotDisabled() {
+        log.info("Asserting Export CSV button is not disabled");
+        Assertions.assertFalse(
+                exportCsvButton.isDisabled(),
+                "Export CSV button should not be disabled"
+        );
+        Assertions.assertFalse(
+                exportCsvButton.getAttribute("class").contains("govuk-button--disabled"),
+                "Export CSV button should not have the disabled class"
+        );
+    }
+
+    public void clickExportCsv() {
+        log.info("Clicking Export CSV button");
+        exportCsvButton.click();
+        page.waitForLoadState(LoadState.DOMCONTENTLOADED);
+    }
+
+    public void assertCsvErrorBannerVisible() {
+        log.info("Asserting CSV error banner is visible");
+        Assertions.assertTrue(
+                csvErrorBanner.isVisible(),
+                "Expected CSV export error summary banner to be visible"
+        );
+    }
+
+    public void assertCsvErrorBannerHidden() {
+        log.info("Asserting CSV error banner is hidden");
+        Assertions.assertFalse(
+                csvErrorBanner.isVisible(),
+                "Expected CSV export error summary banner to be hidden"
+        );
+    }
+
+    public void assertCsvErrorBannerContainsText(String expectedText) {
+        log.info("Asserting CSV error banner contains text: {}", expectedText);
+        Assertions.assertTrue(
+                csvErrorBanner.innerText().contains(expectedText),
+                "Expected CSV error banner to contain: " + expectedText
+        );
+    }
+
+    public void assertViewDeletedUsersLinkVisible() {
+        log.info("Asserting 'View all deleted users' link is visible");
+        Assertions.assertTrue(viewDeletedUsersLink.isVisible(), "Expected 'View all deleted users' link to be visible");
+    }
+
+    public double getExportCsvButtonY() {
+        var box = exportCsvButton.boundingBox();
+        return box != null ? box.y : 0;
+    }
+
+    public double getAuditTableY() {
+        var box = auditTable.boundingBox();
+        return box != null ? box.y : 0;
+    }
+
+    public void clickExportCsvExpectingDownload() {
+        log.info("Clicking Export CSV button (expecting download, not error banner)");
+        // Use Playwright download interception to avoid actually saving the file
+        page.waitForDownload(exportCsvButton::click);
+    }
+
 
 }
-

--- a/src/playwrightTest/java/uk/gov/justice/laa/portal/landingpage/playwright/tests/AuditPageTest.java
+++ b/src/playwrightTest/java/uk/gov/justice/laa/portal/landingpage/playwright/tests/AuditPageTest.java
@@ -172,12 +172,14 @@ public class AuditPageTest extends BaseFrontEndTest {
     }
 
     @Test
-    @DisplayName("Clicking Export CSV with a firm filter does not show the error banner")
-    void exportCsv_withFirmSelected_doesNotShowErrorBanner() {
+    @DisplayName("Selecting a firm in the autocomplete without submitting still shows the CSV error banner")
+    void exportCsv_withFirmSelectedButNotApplied_showsErrorBanner() {
+        // data-firm-selected is rendered server-side; filling the autocomplete client-side
+        // does not reload the page, so the button still considers no firm selected.
         AuditPage auditPage = loginAndGetAuditPage(TestUser.GLOBAL_ADMIN);
         auditPage.searchAndSelectFirm("90001");
-        auditPage.clickExportCsvExpectingDownload();
-        auditPage.assertCsvErrorBannerHidden();
+        auditPage.clickExportCsv();
+        auditPage.assertCsvErrorBannerVisible();
     }
 
     @Test

--- a/src/playwrightTest/java/uk/gov/justice/laa/portal/landingpage/playwright/tests/AuditPageTest.java
+++ b/src/playwrightTest/java/uk/gov/justice/laa/portal/landingpage/playwright/tests/AuditPageTest.java
@@ -1,16 +1,17 @@
 package uk.gov.justice.laa.portal.landingpage.playwright.tests;
 
+import java.util.List;
+import java.util.stream.Stream;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+
 import uk.gov.justice.laa.portal.landingpage.playwright.common.BaseFrontEndTest;
 import uk.gov.justice.laa.portal.landingpage.playwright.common.TestUser;
 import uk.gov.justice.laa.portal.landingpage.playwright.pages.AuditPage;
-
-import java.util.List;
-import java.util.stream.Stream;
 
 public class AuditPageTest extends BaseFrontEndTest {
 
@@ -122,5 +123,67 @@ public class AuditPageTest extends BaseFrontEndTest {
                 TestUser.NO_ROLES
         );
     }
-}
 
+    // -----------------------------------------------------------------------
+    // CSV Export tests
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("Export CSV button is visible and enabled above the audit table")
+    void exportCsvButton_isVisibleAndEnabled() {
+        AuditPage auditPage = loginAndGetAuditPage(TestUser.GLOBAL_ADMIN);
+        auditPage.assertExportCsvButtonVisible();
+        auditPage.assertExportCsvButtonNotDisabled();
+    }
+
+    @Test
+    @DisplayName("Export CSV button is above the audit table")
+    void exportCsvButton_isAboveAuditTable() {
+        AuditPage auditPage = loginAndGetAuditPage(TestUser.GLOBAL_ADMIN);
+        double buttonY = auditPage.getExportCsvButtonY();
+        double tableY = auditPage.getAuditTableY();
+        Assertions.assertTrue(
+                buttonY < tableY,
+                "Export CSV button should appear above the audit table"
+        );
+    }
+
+    @Test
+    @DisplayName("CSV error banner is not shown on initial page load")
+    void csvErrorBanner_isHiddenOnLoad() {
+        AuditPage auditPage = loginAndGetAuditPage(TestUser.GLOBAL_ADMIN);
+        auditPage.assertCsvErrorBannerHidden();
+    }
+
+    @Test
+    @DisplayName("Clicking Export CSV without a firm filter shows the error banner")
+    void exportCsv_withoutFirm_showsErrorBanner() {
+        AuditPage auditPage = loginAndGetAuditPage(TestUser.GLOBAL_ADMIN);
+        auditPage.clickExportCsv();
+        auditPage.assertCsvErrorBannerVisible();
+    }
+
+    @Test
+    @DisplayName("Error banner shows exact required message when no firm is selected")
+    void exportCsv_withoutFirm_errorBannerHasCorrectText() {
+        AuditPage auditPage = loginAndGetAuditPage(TestUser.GLOBAL_ADMIN);
+        auditPage.clickExportCsv();
+        auditPage.assertCsvErrorBannerContainsText("Filter results to a single firm to enable CSV export.");
+    }
+
+    @Test
+    @DisplayName("Clicking Export CSV with a firm filter does not show the error banner")
+    void exportCsv_withFirmSelected_doesNotShowErrorBanner() {
+        AuditPage auditPage = loginAndGetAuditPage(TestUser.GLOBAL_ADMIN);
+        auditPage.searchAndSelectFirm("90001");
+        auditPage.clickExportCsvExpectingDownload();
+        auditPage.assertCsvErrorBannerHidden();
+    }
+
+    @Test
+    @DisplayName("'View all deleted users' link is visible above the audit table")
+    void viewDeletedUsersLink_isVisible() {
+        AuditPage auditPage = loginAndGetAuditPage(TestUser.GLOBAL_ADMIN);
+        auditPage.assertViewDeletedUsersLinkVisible();
+    }
+}


### PR DESCRIPTION
### Description :pencil:

Replaces the disabled Export CSV button with an always-enabled button above the audit table. Clicking without a firm filter shows a GOV.UK error summary banner instead of a disabled state or tooltip.

---

### Changes Made :pencil:

This pull request refactors the CSV export functionality in the `user-audit/users.html` template to improve user experience and error handling. The main changes include consolidating the CSV export button logic, replacing inline error messages with a GOV.UK error summary banner, and improving the JavaScript to handle button states and error displays more robustly.

**CSV Export Button and Error Handling Improvements:**

* Replaced the previous conditional rendering of the CSV export button and inline error message with a unified button that always appears when CSV export is enabled, and moved error messaging to a GOV.UK error summary banner (`csv-export-error-summary`). [[1]](diffhunk://#diff-4fe2469bf790b31891790116b593d7950c44d4a8551a9348a132664315146907L42-R56) [[2]](diffhunk://#diff-4fe2469bf790b31891790116b593d7950c44d4a8551a9348a132664315146907L1090-L1110)
* Updated JavaScript to show the error summary banner if a user tries to export CSV without selecting a firm, and to show a toast if the results are empty. The script now checks data attributes (`data-firm-selected`, `data-users-empty`) on the export button to determine which feedback to show. [[1]](diffhunk://#diff-4fe2469bf790b31891790116b593d7950c44d4a8551a9348a132664315146907L907-R920) [[2]](diffhunk://#diff-4fe2469bf790b31891790116b593d7950c44d4a8551a9348a132664315146907L925-R969)
* Removed redundant CSS and JavaScript related to the old inline error message (`#export-csv-error`). [[1]](diffhunk://#diff-4fe2469bf790b31891790116b593d7950c44d4a8551a9348a132664315146907L535-L538) [[2]](diffhunk://#diff-4fe2469bf790b31891790116b593d7950c44d4a8551a9348a132664315146907L925-R969) [[3]](diffhunk://#diff-4fe2469bf790b31891790116b593d7950c44d4a8551a9348a132664315146907L1090-L1110)

**UI and Layout Adjustments:**

* Moved the CSV export and "View all deleted users" actions into a single button group for a cleaner and more consistent layout.
* Changed the "View Deleted Users" button to a link and repositioned it alongside the export button for better accessibility and visual grouping. [[1]](diffhunk://#diff-4fe2469bf790b31891790116b593d7950c44d4a8551a9348a132664315146907L42-R56) [[2]](diffhunk://#diff-4fe2469bf790b31891790116b593d7950c44d4a8551a9348a132664315146907L925-R969)

These changes provide a more accessible and user-friendly way to handle CSV exports, ensuring users receive clear feedback when actions are unavailable or unsuccessful.

---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [ ] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [x] I have a corresponding JIRA ticket for this change 
- [ ] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:

Please fill in.

---