### PR TITLE
STB-4184: Bug fix for internal users appearing in deleted table

### DIFF
--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/service/UserService.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/service/UserService.java
@@ -2412,15 +2412,16 @@ public class UserService {
         Sort sortObj = Sort.by(sortDirection, sortField);
         PageRequest pageRequest = PageRequest.of(page - 1, pageSize, sortObj);
 
-        // Query deleted users
+        // Query deleted users for the requested page
         Page<UserAccountStatusAudit> auditPage =
             userAccountStatusAuditRepository.findDeletedUsers(
                 searchTerm,
                 pageRequest);
 
-        // Map to DTOs
+        // Map to DTOs, filtering out INTERNAL users from current page
         List<DeletedUserAuditDto> deletedUsers =
             auditPage.getContent().stream()
+                .filter(audit -> !isDeletedUserInternal(audit))
                 .map(audit -> DeletedUserAuditDto.builder()
                     .userName(audit.getUserName())
                     .userEmail(audit.getUserEmail())
@@ -2429,13 +2430,34 @@ public class UserService {
                     .build())
                 .collect(Collectors.toList());
 
+        long totalInternalUsers = 0;
+        if (auditPage.getTotalElements() > 0) {
+            // Create a pageable that fetches all results to count INTERNAL users
+            PageRequest allPagesRequest = PageRequest.of(0, (int) auditPage.getTotalElements(), sortObj);
+            Page<UserAccountStatusAudit> allAuditPages = userAccountStatusAuditRepository.findDeletedUsers(searchTerm, allPagesRequest);
+            totalInternalUsers = allAuditPages.getContent().stream()
+                    .filter(this::isDeletedUserInternal)
+                    .count();
+        }
+
+        long totalDeletedUsersExcludingInternal = auditPage.getTotalElements() - totalInternalUsers;
+        long totalPages = (totalDeletedUsersExcludingInternal + pageSize - 1) / pageSize;
+
         return PaginatedDeletedUsers.builder()
             .deletedUsers(deletedUsers)
-            .totalDeletedUsers(auditPage.getTotalElements())
-            .totalPages(auditPage.getTotalPages())
+            .totalDeletedUsers(totalDeletedUsersExcludingInternal)
+            .totalPages((int) totalPages)
             .currentPage(page)
             .pageSize(pageSize)
             .build();
+    }
+
+    private boolean isDeletedUserInternal(UserAccountStatusAudit audit) {
+        if (audit.getEntraUser() != null) {
+            return audit.getEntraUser().getUserProfiles().stream()
+                    .anyMatch(profile -> profile.getUserType() == UserType.INTERNAL);
+        }
+        return false;
     }
 
     public void updateUserProfileSilasStatus() {

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/service/UserServiceDeletedUsersTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/service/UserServiceDeletedUsersTest.java
@@ -12,15 +12,22 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import uk.gov.justice.laa.portal.landingpage.dto.DeletedUserAuditDto;
 import uk.gov.justice.laa.portal.landingpage.dto.PaginatedDeletedUsers;
+import uk.gov.justice.laa.portal.landingpage.entity.EntraUser;
 import uk.gov.justice.laa.portal.landingpage.entity.UserAccountStatus;
 import uk.gov.justice.laa.portal.landingpage.entity.UserAccountStatusAudit;
+import uk.gov.justice.laa.portal.landingpage.entity.UserProfile;
+import uk.gov.justice.laa.portal.landingpage.entity.UserType;
 import uk.gov.justice.laa.portal.landingpage.repository.UserAccountStatusAuditRepository;
 
 import java.time.LocalDateTime;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -44,22 +51,56 @@ class UserServiceDeletedUsersTest {
 
     private UserAccountStatusAudit deletedAudit1;
     private UserAccountStatusAudit deletedAudit2;
+    private UserAccountStatusAudit deletedAuditInternal;
 
     @BeforeEach
     void setUp() {
-        // Create test deleted user audit records
+        // Create test deleted user audit records for external users
         deletedAudit1 = UserAccountStatusAudit.builder()
                 .userEmail("deleted.user1@example.com")
+                .userName("Deleted User One")
                 .statusChange(UserAccountStatus.DELETED)
                 .statusChangedBy("John Doe")
                 .statusChangedDate(LocalDateTime.of(2024, 1, 15, 10, 30))
+                .entraUser(null) // No EntraUser reference after deletion
                 .build();
 
         deletedAudit2 = UserAccountStatusAudit.builder()
                 .userEmail("deleted.user2@example.com")
+                .userName("Deleted User Two")
                 .statusChange(UserAccountStatus.DELETED)
                 .statusChangedBy("Jane Smith")
                 .statusChangedDate(LocalDateTime.of(2024, 1, 16, 14, 45))
+                .entraUser(null) // No EntraUser reference after deletion
+                .build();
+
+        // Create test deleted user audit record for an INTERNAL user
+        // This represents the edge case where an INTERNAL user somehow appears in deleted records
+        EntraUser internalEntraUser = EntraUser.builder()
+                .id(UUID.randomUUID())
+                .entraOid(UUID.randomUUID().toString())
+                .email("internal.deleted@example.com")
+                .firstName("Internal")
+                .lastName("User")
+                .build();
+
+        UserProfile internalProfile = UserProfile.builder()
+                .id(UUID.randomUUID())
+                .userType(UserType.INTERNAL)
+                .activeProfile(true)
+                .build();
+
+        Set<UserProfile> internalProfiles = new HashSet<>();
+        internalProfiles.add(internalProfile);
+        internalEntraUser.setUserProfiles(internalProfiles);
+
+        deletedAuditInternal = UserAccountStatusAudit.builder()
+                .userEmail("internal.deleted@example.com")
+                .userName("Internal Deleted User")
+                .statusChange(UserAccountStatus.DELETED)
+                .statusChangedBy("Admin")
+                .statusChangedDate(LocalDateTime.of(2024, 1, 17, 9, 15))
+                .entraUser(internalEntraUser) // EntraUser still exists with INTERNAL profile
                 .build();
     }
 
@@ -109,7 +150,7 @@ class UserServiceDeletedUsersTest {
         assertNotNull(result);
         assertEquals(1, result.getDeletedUsers().size());
         assertEquals(1, result.getTotalDeletedUsers());
-        assertEquals("deleted.user1@example.com", result.getDeletedUsers().get(0).getUserEmail());
+        assertEquals("deleted.user1@example.com", result.getDeletedUsers().getFirst().getUserEmail());
     }
 
     @Test
@@ -151,10 +192,10 @@ class UserServiceDeletedUsersTest {
         assertEquals(2, result.getDeletedUsers().size());
 
         // Verify the repository was called with correct sort field
-        verify(userAccountStatusAuditRepository).findDeletedUsers(
+        verify(userAccountStatusAuditRepository, org.mockito.Mockito.atLeastOnce()).findDeletedUsers(
                 isNull(),
                 argThat(pageable ->
-                    pageable.getSort().getOrderFor("userEmail") != null
+                    pageable != null && pageable.getSort().getOrderFor("userEmail") != null
                 )
         );
     }
@@ -177,24 +218,39 @@ class UserServiceDeletedUsersTest {
         assertNotNull(result);
 
         // Verify the repository was called with correct sort field
-        verify(userAccountStatusAuditRepository).findDeletedUsers(
+        verify(userAccountStatusAuditRepository, org.mockito.Mockito.atLeastOnce()).findDeletedUsers(
                 isNull(),
                 argThat(pageable ->
-                    pageable.getSort().getOrderFor("statusChangedBy") != null
+                    pageable != null && pageable.getSort().getOrderFor("statusChangedBy") != null
                 )
         );
     }
 
     @Test
     void getDeletedUsers_shouldHandleSecondPage() {
-        // Arrange
-        List<UserAccountStatusAudit> auditList = Arrays.asList(deletedAudit1);
-        Page<UserAccountStatusAudit> auditPage = new PageImpl<>(auditList, PageRequest.of(1, 10), 12);
+
+        List<UserAccountStatusAudit> page2List = Arrays.asList(deletedAudit1);
+        Page<UserAccountStatusAudit> page2 = new PageImpl<>(page2List, PageRequest.of(1, 10), 12);
+
+        List<UserAccountStatusAudit> allAuditsList =
+                Arrays.asList(deletedAudit1, deletedAudit2);
+        Page<UserAccountStatusAudit> allPages = new PageImpl<>(allAuditsList, PageRequest.of(0, 12), 12);
 
         when(userAccountStatusAuditRepository.findDeletedUsers(
                 isNull(),
-                any(Pageable.class)))
-                .thenReturn(auditPage);
+                argThat(pageable ->
+                        pageable != null
+                                && pageable.getPageNumber() == 1
+                                && pageable.getPageSize() == 10)))
+                .thenReturn(page2);
+
+        when(userAccountStatusAuditRepository.findDeletedUsers(
+                isNull(),
+                argThat(pageable ->
+                        pageable != null
+                                && pageable.getPageNumber() == 0)))
+                .thenReturn(allPages);
+
 
         // Act
         PaginatedDeletedUsers result = userService.getDeletedUsers(null, 2, 10, "statusChangedDate", "desc");
@@ -202,13 +258,72 @@ class UserServiceDeletedUsersTest {
         // Assert
         assertNotNull(result);
         assertEquals(2, result.getCurrentPage());
-        assertEquals(2, result.getTotalPages());
+        assertEquals(2, result.getTotalPages()); // 12 total / 10 per page = 2 pages
+    }
 
-        // Verify pagination
-        verify(userAccountStatusAuditRepository).findDeletedUsers(
+    @Test
+    void getDeletedUsers_shouldFilterOutInternalUsers() {
+        List<UserAccountStatusAudit> auditList = Arrays.asList(deletedAudit1, deletedAuditInternal, deletedAudit2);
+        Page<UserAccountStatusAudit> auditPage = new PageImpl<>(auditList, PageRequest.of(0, 10), 3);
+
+        when(userAccountStatusAuditRepository.findDeletedUsers(
                 isNull(),
-                argThat(pageable -> pageable.getPageNumber() == 1) // 0-based index
-        );
+                any(Pageable.class)))
+                .thenReturn(auditPage);
+
+        PaginatedDeletedUsers result = userService.getDeletedUsers(null, 1, 10, "statusChangedDate", "desc");
+
+        assertNotNull(result);
+        assertEquals(2, result.getDeletedUsers().size());
+        assertEquals(2, result.getTotalDeletedUsers());
+        assertEquals(1, result.getTotalPages());
+
+        boolean hasInternalUser = result.getDeletedUsers().stream()
+                .anyMatch(user -> user.getUserEmail().equals("internal.deleted@example.com"));
+        assertFalse(hasInternalUser, "Internal users should be filtered out");
+
+        boolean hasExternalUser1 = result.getDeletedUsers().stream()
+                .anyMatch(user -> user.getUserEmail().equals("deleted.user1@example.com"));
+        boolean hasExternalUser2 = result.getDeletedUsers().stream()
+                .anyMatch(user -> user.getUserEmail().equals("deleted.user2@example.com"));
+        assertTrue(hasExternalUser1, "External user 1 should be present");
+        assertTrue(hasExternalUser2, "External user 2 should be present");
+    }
+
+    @Test
+    void getDeletedUsers_shouldOnlyReturnInternalUsersWhenAllDeleted() {
+        List<UserAccountStatusAudit> auditList = Arrays.asList(deletedAuditInternal);
+        Page<UserAccountStatusAudit> auditPage = new PageImpl<>(auditList, PageRequest.of(0, 10), 1);
+
+        when(userAccountStatusAuditRepository.findDeletedUsers(
+                isNull(),
+                any(Pageable.class)))
+                .thenReturn(auditPage);
+
+        PaginatedDeletedUsers result = userService.getDeletedUsers(null, 1, 10, "statusChangedDate", "desc");
+
+        assertNotNull(result);
+        assertTrue(result.getDeletedUsers().isEmpty(), "All internal users should be filtered out");
+        assertEquals(0, result.getTotalDeletedUsers());
+        assertEquals(0, result.getTotalPages());
+    }
+
+    @Test
+    void getDeletedUsers_shouldFilterExternalUsersWithoutEntraReference() {
+
+        List<UserAccountStatusAudit> auditList = Arrays.asList(deletedAudit1, deletedAudit2);
+        Page<UserAccountStatusAudit> auditPage = new PageImpl<>(auditList, PageRequest.of(0, 10), 2);
+
+        when(userAccountStatusAuditRepository.findDeletedUsers(
+                isNull(),
+                any(Pageable.class)))
+                .thenReturn(auditPage);
+
+        PaginatedDeletedUsers result = userService.getDeletedUsers(null, 1, 10, "statusChangedDate", "desc");
+
+        assertNotNull(result);
+        assertEquals(2, result.getDeletedUsers().size());
+        assertEquals(2, result.getTotalDeletedUsers());
     }
 }
 


### PR DESCRIPTION
### Description :pencil:

https://dsdmoj.atlassian.net/browse/STB-4184

---

### Changes Made :pencil:

- Add INTERNAL user check when in getDeletedUsers service
- 
- 

---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [ ] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [x] I have a corresponding JIRA ticket for this change 
- [x] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:

Please fill in.

---