### PR TITLE
STB-4129 - Add nosemgrep comments and remove CSRF tokens from multiple HTML templates

### DIFF
--- a/src/main/resources/templates/cancel-add-user-confirmation.html
+++ b/src/main/resources/templates/cancel-add-user-confirmation.html
@@ -31,6 +31,7 @@
     <p class="govuk-body">
         If you cancel, any information you’ve entered will be lost.
     </p>
+    <!-- nosemgrep -->
     <form th:action="@{/admin/user/create/details}" method="post" style="display: inline;">
         <div class="moj-button-group">
             <button type="submit" class="govuk-button" data-module="govuk-button">
@@ -39,7 +40,6 @@
             <a class="govuk-link" th:href="@{/admin/user/create/cancel}">Cancel and leave</a>
         </div>
     </form>
-    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
 </main>
 </body>
 </html>

--- a/src/main/resources/templates/cancel-grant-access-user-confirmation.html
+++ b/src/main/resources/templates/cancel-grant-access-user-confirmation.html
@@ -31,6 +31,7 @@
     <p class="govuk-body">
         If you cancel, any information you’ve entered will be lost.
     </p>
+    <!-- nosemgrep -->
     <form th:action="@{/admin/users/manage/{id}/grant-access(id=${user.id})}" method="post" style="display: inline;">
         <div class="moj-button-group">
             <button type="submit" class="govuk-button" data-module="govuk-button">
@@ -39,7 +40,6 @@
             <a th:href="@{/admin/users/grant-access/{id}/cancel(id=${user.id})}" class="govuk-link">Cancel and leave</a>
         </div>
     </form>
-    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
 </main>
 </body>
 </html>

--- a/src/main/resources/templates/delete-user-reason.html
+++ b/src/main/resources/templates/delete-user-reason.html
@@ -31,6 +31,7 @@
 
     <p class="govuk-body">This will remove the user's access in SiLAS right away and start the process to remove their access in Microsoft Entra. Their account may still be active for a short time until Microsoft fully deletes it.</p>
 
+    <!-- nosemgrep -->
     <form th:action="@{/admin/users/manage/{id}/delete(id=${user.id})}" method="post" novalidate>
         <div class="govuk-form-group" th:classappend="${fieldErrorMessage} ? ' govuk-form-group--error'">
             <label class="govuk-label" for="reason" th:if="${fieldErrorMessage == null || fieldErrorMessage == ''}">>Please enter a reason (minimum 10 characters).</label>

--- a/src/main/resources/templates/delete-user-reason.html
+++ b/src/main/resources/templates/delete-user-reason.html
@@ -34,7 +34,7 @@
     <!-- nosemgrep -->
     <form th:action="@{/admin/users/manage/{id}/delete(id=${user.id})}" method="post" novalidate>
         <div class="govuk-form-group" th:classappend="${fieldErrorMessage} ? ' govuk-form-group--error'">
-            <label class="govuk-label" for="reason" th:if="${fieldErrorMessage == null || fieldErrorMessage == ''}">>Please enter a reason (minimum 10 characters).</label>
+            <label class="govuk-label" for="reason" th:if="${fieldErrorMessage == null || fieldErrorMessage == ''}">Please enter a reason (minimum 10 characters).</label>
             <span class="govuk-error-message" th:if="${fieldErrorMessage}">
                 <span class="govuk-visually-hidden">Error:</span>
                 <span id="reason-error" th:text="${fieldErrorMessage}"></span>

--- a/src/main/resources/templates/enable-user-confirmation.html
+++ b/src/main/resources/templates/enable-user-confirmation.html
@@ -18,6 +18,7 @@
     <p class="govuk-body">
         You are about to enable <span th:text="${user.fullName}"></span>'s access to LAA services via SiLAS.
     </p>
+    <!-- nosemgrep -->
     <form th:action="@{/admin/users/manage/{id}/enable(id=${user.id}, referer=${referer})}" method="post" style="display: inline;">
         <div class="moj-button-group">
             <button type="submit" class="govuk-button" data-module="govuk-button">
@@ -26,7 +27,6 @@
             <a class="govuk-link" th:href="${cancelPath}">Cancel</a>
         </div>
     </form>
-    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
 </main>
 </body>
 </html>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -54,6 +54,7 @@
                         target="_blank">Terms
                         and Conditions</a>.
                 </p>
+                <!-- nosemgrep -->
                 <form th:action="@{/login}" th:method="post">
                     <div class="govuk-form-group">
 

--- a/src/main/resources/templates/logout-confirmation.html
+++ b/src/main/resources/templates/logout-confirmation.html
@@ -28,6 +28,7 @@
     <h1 class="govuk-heading-l">
         Are you sure you want to sign out for <span th:text="${currentUser.name}"></span>?
     </h1>
+    <!-- nosemgrep -->
     <form th:action="@{/logout}" method="post" style="display: inline;">
         <div class="moj-button-group">
                 <button type="submit" class="govuk-button" data-module="govuk-button">
@@ -36,7 +37,6 @@
             <a class="govuk-link" th:href="@{/home}">Cancel</a>
         </div>
     </form>
-        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
 </main>
 </body>
 </html>

--- a/src/main/resources/templates/manage-user.html
+++ b/src/main/resources/templates/manage-user.html
@@ -104,6 +104,7 @@
                                 <span class="govuk-tag govuk-tag--grey govuk-!-font-weight-bold govuk-!-margin-top-1" style="min-width: 200px">UNKNOWN</span>
                             </th:block>
                     </div>
+                    <!-- nosemgrep -->
                     <form class="form" th:if="${!isAccessGranted and canGrantUserAccess}"
                         th:action="@{/admin/users/manage/{id}/grant-access(id=${user.id})}" method="post">
                         <div class="moj-page-header-actions__actions">

--- a/src/main/resources/templates/reassign-firm/check-answers.html
+++ b/src/main/resources/templates/reassign-firm/check-answers.html
@@ -110,6 +110,7 @@
                     </div>
                 </dl>
 
+                <!-- nosemgrep -->
                 <form method="post" th:action="@{'/admin/users/reassign-firm/' + ${user.id} + '/confirmation'}">
                     <!-- Hidden fields to carry forward all the data -->
                     <input type="hidden" name="selectedFirmId" th:value="${selectedFirmId}" />

--- a/src/main/resources/templates/silas-administration/create-role-check-answers.html
+++ b/src/main/resources/templates/silas-administration/create-role-check-answers.html
@@ -142,6 +142,7 @@
                     </div>
                 </dl>
 
+                <!-- nosemgrep -->
                 <form th:action="@{/admin/silas-administration/roles/create/check-your-answers}" method="post">
                     <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
                     <div class="govuk-button-group">

--- a/src/main/resources/templates/silas-administration/delete-app-role-check-answers.html
+++ b/src/main/resources/templates/silas-administration/delete-app-role-check-answers.html
@@ -114,6 +114,7 @@
                     </div>
                 </dl>
 
+                <!-- nosemgrep -->
                 <form method="post" th:action="@{'/admin/silas-administration/delete-role/' + ${roleId} + '/check-answers'}">
                     <div class="govuk-button-group">
                         <button type="submit" class="govuk-button govuk-button--warning" data-module="govuk-button">

--- a/src/main/resources/templates/silas-administration/delete-app-roles.html
+++ b/src/main/resources/templates/silas-administration/delete-app-roles.html
@@ -67,6 +67,7 @@
                     Role Name
                 </label>
                 <div th:each="role : ${roles}">
+                    <!-- nosemgrep -->
                     <form method="post" th:action="@{'/admin/silas-administration/delete-role/' + ${role.id}}">
                         <div class="govuk-grid-row">
                             <div class="govuk-grid-column-one-half">

--- a/src/main/resources/templates/silas-administration/edit-app-details-check-answers.html
+++ b/src/main/resources/templates/silas-administration/edit-app-details-check-answers.html
@@ -109,6 +109,7 @@
 
             </dl>
 
+            <!-- nosemgrep -->
             <form method="post" th:action="@{'/admin/silas-administration/app/' + ${app.id} + '/check-answers'}">
                 <div class="govuk-button-group">
                     <button type="submit" class="govuk-button" data-module="govuk-button">

--- a/src/main/resources/templates/silas-administration/edit-app-roles-order-check-answers.html
+++ b/src/main/resources/templates/silas-administration/edit-app-roles-order-check-answers.html
@@ -56,6 +56,7 @@
                     </div>
                 </dl>
 
+                <!-- nosemgrep -->
                 <form method="post" th:action="@{'/admin/silas-administration/roles/reorder/check-answers'}">
                     <div class="govuk-button-group">
                         <button type="submit" class="govuk-button" data-module="govuk-button">

--- a/src/main/resources/templates/silas-administration/edit-apps-order-check-answers.html
+++ b/src/main/resources/templates/silas-administration/edit-apps-order-check-answers.html
@@ -56,6 +56,7 @@
                     </div>
                 </dl>
 
+                <!-- nosemgrep -->
                 <form method="post" th:action="@{'/admin/silas-administration/apps/reorder/check-answers'}">
                     <div class="govuk-button-group">
                         <button type="submit" class="govuk-button" data-module="govuk-button">

--- a/src/main/resources/templates/silas-administration/edit-role-assignment-restrictions-check-answers.html
+++ b/src/main/resources/templates/silas-administration/edit-role-assignment-restrictions-check-answers.html
@@ -89,6 +89,7 @@
 
             </dl>
 
+            <!-- nosemgrep -->
             <form method="post" th:action="@{'/admin/silas-administration/role/assignRestrictions/check-answers'}">
                 <div class="govuk-button-group">
                     <button type="submit" class="govuk-button" data-module="govuk-button">

--- a/src/main/resources/templates/silas-administration/edit-role-details-check-answers.html
+++ b/src/main/resources/templates/silas-administration/edit-role-details-check-answers.html
@@ -109,6 +109,7 @@
 
             </dl>
 
+            <!-- nosemgrep -->
             <form method="post" th:action="@{'/admin/silas-administration/role/' + ${appRole.id} + '/check-answers'}">
                 <div class="govuk-button-group">
                     <button type="submit" class="govuk-button" data-module="govuk-button">

--- a/src/main/resources/templates/switch-firm.html
+++ b/src/main/resources/templates/switch-firm.html
@@ -28,7 +28,7 @@
         </div>
 
         <!-- Important banner -->
-        <div class="govuk-notification-banner govuk-notification-banner--important" role="region" 
+        <div class="govuk-notification-banner govuk-notification-banner--important" role="region"
              aria-labelledby="important-banner-title" data-module="govuk-notification-banner">
             <div class="govuk-notification-banner__header">
                 <h2 class="govuk-notification-banner__title" id="important-banner-title">
@@ -50,6 +50,7 @@
 
         <h1 class="govuk-heading-l">Search</h1>
 
+        <!-- nosemgrep -->
         <form method="get" th:action="@{/switch-firm}">
             <input type="hidden" name="page" th:value="1">
             <input type="hidden" name="pageSize" th:value="${pageSize}">
@@ -150,6 +151,7 @@
                 <tbody class="govuk-table__body">
                     <tr class="govuk-table__row" th:each="userFirm : ${userFirmList}">
                         <td class="govuk-table__cell">
+                            <!-- nosemgrep -->
                             <form th:action="@{/switch-firm}" method="post" style="display: inline;">
                                 <input type="hidden" id="firmid" name="firmid" th:value="${userFirm.firmId}">
                                 <button type="submit" class="govuk-link"
@@ -172,7 +174,7 @@
             <nav class="govuk-pagination" role="navigation" aria-label="Pagination" th:if="${totalPages > 1}">
                 <!-- Previous page link -->
                 <div class="govuk-pagination__prev" th:if="${currentPage > 1}">
-                    <a class="govuk-link govuk-pagination__link" 
+                    <a class="govuk-link govuk-pagination__link"
                        th:href="@{/switch-firm(page=${currentPage - 1}, pageSize=${pageSize}, sort=${sort}, direction=${direction}, search=${search})}"
                        rel="prev">
                         <svg class="govuk-pagination__icon govuk-pagination__icon--prev" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
@@ -185,7 +187,7 @@
                 <ul class="govuk-pagination__list">
                     <!-- First page -->
                     <li class="govuk-pagination__item" th:classappend="${currentPage == 1} ? 'govuk-pagination__item--current'">
-                        <a class="govuk-link govuk-pagination__link" 
+                        <a class="govuk-link govuk-pagination__link"
                            th:href="@{/switch-firm(page=1, pageSize=${pageSize}, sort=${sort}, direction=${direction}, search=${search})}"
                            th:attr="aria-label='Page 1', aria-current=${currentPage == 1 ? 'page' : null}"
                            th:text="1">
@@ -199,10 +201,10 @@
 
                     <!-- Pages around current page (only show middle pages, not first or last) -->
                     <th:block th:if="${totalPages > 2}" th:each="pageNum : ${#numbers.sequence(2, totalPages - 1)}">
-                        <li class="govuk-pagination__item" 
+                        <li class="govuk-pagination__item"
                             th:if="${pageNum >= currentPage - 1 and pageNum <= currentPage + 1}"
                             th:classappend="${pageNum == currentPage} ? 'govuk-pagination__item--current'">
-                            <a class="govuk-link govuk-pagination__link" 
+                            <a class="govuk-link govuk-pagination__link"
                                th:href="@{/switch-firm(page=${pageNum}, pageSize=${pageSize}, sort=${sort}, direction=${direction}, search=${search})}"
                                th:attr="aria-label='Page ' + ${pageNum}, aria-current=${pageNum == currentPage ? 'page' : null}"
                                th:text="${pageNum}">
@@ -216,10 +218,10 @@
                     </li>
 
                     <!-- Last page (only if different from first page) -->
-                    <li class="govuk-pagination__item" 
+                    <li class="govuk-pagination__item"
                         th:if="${totalPages > 1}"
                         th:classappend="${currentPage == totalPages} ? 'govuk-pagination__item--current'">
-                        <a class="govuk-link govuk-pagination__link" 
+                        <a class="govuk-link govuk-pagination__link"
                            th:href="@{/switch-firm(page=${totalPages}, pageSize=${pageSize}, sort=${sort}, direction=${direction}, search=${search})}"
                            th:attr="aria-label='Page ' + ${totalPages}, aria-current=${currentPage == totalPages ? 'page' : null}"
                            th:text="${totalPages}">
@@ -229,7 +231,7 @@
 
                 <!-- Next page link -->
                 <div class="govuk-pagination__next" th:if="${currentPage < totalPages}">
-                    <a class="govuk-link govuk-pagination__link" 
+                    <a class="govuk-link govuk-pagination__link"
                        th:href="@{/switch-firm(page=${currentPage + 1}, pageSize=${pageSize}, sort=${sort}, direction=${direction}, search=${search})}"
                        rel="next">
                         <span class="govuk-pagination__link-title">Next</span>
@@ -242,8 +244,8 @@
 
             <!-- Results summary -->
             <p class="govuk-body govuk-!-margin-top-4">
-                Showing <span th:text="${(currentPage - 1) * pageSize + 1}"></span> 
-                to <span th:text="${currentPage * pageSize > totalItems ? totalItems : currentPage * pageSize}"></span> 
+                Showing <span th:text="${(currentPage - 1) * pageSize + 1}"></span>
+                to <span th:text="${currentPage * pageSize > totalItems ? totalItems : currentPage * pageSize}"></span>
                 of <span th:text="${totalItems}"></span> firms
             </p>
         </div>
@@ -258,20 +260,20 @@
                 console.log('Sort script loaded');
                 const sortButtons = document.querySelectorAll('.sort-button');
                 console.log('Found ' + sortButtons.length + ' sort buttons');
-                
+
                 sortButtons.forEach(button => {
                     button.addEventListener('click', function (e) {
                         e.preventDefault();
                         console.log('Sort button clicked');
-                        
+
                         const sort = this.getAttribute('data-sort');
                         const direction = this.getAttribute('data-direction');
                         console.log('Sort:', sort, 'Direction:', direction);
-                        
+
                         const urlParams = new URLSearchParams(window.location.search);
                         const currentSearch = urlParams.get('search') || '';
                         const currentPageSize = urlParams.get('pageSize') || '5';
-                        
+
                         // Build URL with sort and pagination parameters
                         // Reset to page 1 when sorting
                         let url = '/switch-firm?page=1';
@@ -280,7 +282,7 @@
                         }
                         url += '&sort=' + sort + '&direction=' + direction;
                         url += '&pageSize=' + currentPageSize;
-                        
+
                         console.log('Navigating to:', url);
                         window.location.href = url;
                     });

--- a/src/main/resources/templates/user-audit/delete-user-without-profile-reason.html
+++ b/src/main/resources/templates/user-audit/delete-user-without-profile-reason.html
@@ -31,6 +31,7 @@
 
     <p class="govuk-body">This user has no firm profile or service assignments. This will remove the user's account from SiLAS right away and notify Microsoft Entra to remove their access. Their account may still be active for a short time until Microsoft fully processes the deletion.</p>
 
+    <!-- nosemgrep -->
     <form th:action="@{'/admin/users/audit/entra/' + ${user.userId} + '/delete'}" method="post" novalidate>
         <div class="govuk-form-group" th:classappend="${fieldErrorMessage} ? ' govuk-form-group--error'">
             <label class="govuk-label" for="reason" th:if="${fieldErrorMessage == null || fieldErrorMessage == ''}">Please enter a reason (minimum 10 characters).</label>


### PR DESCRIPTION
### Description :pencil:

Added <!-- nosemgrep --> comments before all form tags in 18 Thymeleaf templates to suppress false-positive CSRF Opengrep findings. Removed four dead-code CSRF hidden inputs misplaced after closing </form> tags.

---

### Changes Made :pencil:

This pull request adds `<!-- nosemgrep -->` comments before form elements in multiple HTML templates throughout the project. This is done to suppress Semgrep static analysis warnings related to these forms. Additionally, it removes some redundant CSRF token hidden input fields from certain templates, likely because CSRF protection is handled elsewhere or is unnecessary in these contexts.

The most important changes are:

**Static Analysis Suppression:**
* Added `<!-- nosemgrep -->` comments before `<form>` tags in many templates to suppress Semgrep warnings, improving static analysis workflow and reducing noise in code review. [[1]](diffhunk://#diff-ff55f2126ec8140e1133fd1ad665f209515ce3fcc5e442b6a6c90478264560e8R34) [[2]](diffhunk://#diff-c582451dfda84118861c7e80244fee0d6de0c7ce0b306b63c3c6dcc93cb9acd1R34) [[3]](diffhunk://#diff-3057ce20a9f8d23c09e11d63ca7ecd48a04b871bab6ee7f9b97c5db30b1de35eR34) [[4]](diffhunk://#diff-74d89a1276f5744cc5ed2fb8539330fd408d12c1756539ea5c20346331def021R21) [[5]](diffhunk://#diff-dce5037ca59f91a501819f7f56f1c6c1425519e96cb2fdde9c7dbce971c179e9R57) [[6]](diffhunk://#diff-48552309ea94d9fdfe57851842c9a83d30202c6bad15edc6d759159b649480b0R31) [[7]](diffhunk://#diff-e687d7fb36c1e4429780d9d4c1569e1332afd69837e881337c296ff589df4c15R107) [[8]](diffhunk://#diff-5d77b256172b4177ee4fb3cd7adcaba162ba3e6089c31f283f46766cea5e62e0R113) [[9]](diffhunk://#diff-9041dafe0a1ef448bc3e19aa9a43af4a05b0ab92c1122778f775f133274827d1R145) [[10]](diffhunk://#diff-8b1a3d5cb21c1a0a427e11df2f52f5afa730e585a51491c8debd8d05f27d43a1R117) [[11]](diffhunk://#diff-92e6c4cbd76766ed0f33ac920d4129dc2733686f9dce9f4ba1148df37fe0aea0R70) [[12]](diffhunk://#diff-114a4a466fafaad2cfa7d84c78d9f09db00362759808cca2eb90352f7489160fR112) [[13]](diffhunk://#diff-849a7166fdcee09b6074cb63928b8de06e00300c666f0a1a7253de9f37892baeR59) [[14]](diffhunk://#diff-1bd85f211003a853b3f35fa5d03fbcdb804bda8007fa629f005ec4980ba55899R59) [[15]](diffhunk://#diff-df622f5ed920ac56237b8b1083cdd2c35b23167bf7f336c5b2b2af8ae0abae16R92) [[16]](diffhunk://#diff-2759a62d2eaa8192d89177928c8d189dfd5198d73be22a0c30973d94f4d2abc3R112) [[17]](diffhunk://#diff-019954d43a60eb7b7e30ed55441e30c6acd9357f6fa40220a55ff1a69ce33f4bR53) [[18]](diffhunk://#diff-019954d43a60eb7b7e30ed55441e30c6acd9357f6fa40220a55ff1a69ce33f4bR154) [[19]](diffhunk://#diff-68f812da4aee277c745892dc3b55c12898ac735cdf9700f37c220ac54904901aR34)

**Form Security and Cleanup:**
* Removed explicit CSRF token hidden input fields from several form templates, possibly to centralize CSRF handling or because they are no longer required. [[1]](diffhunk://#diff-ff55f2126ec8140e1133fd1ad665f209515ce3fcc5e442b6a6c90478264560e8L42) [[2]](diffhunk://#diff-c582451dfda84118861c7e80244fee0d6de0c7ce0b306b63c3c6dcc93cb9acd1L42) [[3]](diffhunk://#diff-74d89a1276f5744cc5ed2fb8539330fd408d12c1756539ea5c20346331def021L29) [[4]](diffhunk://#diff-48552309ea94d9fdfe57851842c9a83d30202c6bad15edc6d759159b649480b0L39)

These changes help streamline static analysis and reduce unnecessary code in the templates.
---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [ ] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [x] I have a corresponding JIRA ticket for this change 
- [ ] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:

Please fill in.

---