### PR TITLE
STB-4149: Stop Internal User Manager and Security Response from assigning Security Response role.g…

### DIFF
--- a/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/RoleBaseAccessEditUserRoleTest.java
+++ b/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/RoleBaseAccessEditUserRoleTest.java
@@ -264,6 +264,21 @@ public class RoleBaseAccessEditUserRoleTest extends RoleBasedAccessIntegrationTe
 
     @Test
     @Transactional
+    public void testInternalUserManagerCannotAssignSecurityResponseRoleToThemselves() throws Exception {
+        EntraUser loggedInUser = internalUserManagers.getFirst();
+        assignAuthzRoleToUser(loggedInUser, loggedInUser, AuthzRole.SECURITY_RESPONSE.getRoleName(), false, false, false);
+    }
+
+    @Test
+    @Transactional
+    public void testSecurityResponseCannotAssignSecurityResponseRole() throws Exception {
+        EntraUser loggedInUser = securityResponseUsers.getFirst();
+        EntraUser editedUser = internalUsersNoRoles.getFirst();
+        assignAuthzRoleToUser(loggedInUser, editedUser, AuthzRole.SECURITY_RESPONSE.getRoleName(), false, false, false);
+    }
+
+    @Test
+    @Transactional
     public void testExternalUserRolesCannotBeAssignedToInternalUsers() throws Exception {
         // Build test app
         App testExternalApp = buildLaaApp("Test External App", generateEntraId(), "TestExternalAppSecurityGroupOid");

--- a/src/main/resources/db/changelog/changesets/db.changesets-5.49.yaml
+++ b/src/main/resources/db/changelog/changesets/db.changesets-5.49.yaml
@@ -1,0 +1,17 @@
+databaseChangeLog:
+  - changeSet:
+      id: remove-ium-security-response-role-assignment
+      author: niall.mcmahon
+      changes:
+        - sql:
+            sql: |
+              DELETE FROM role_assignment
+              WHERE assigning_role_id = (SELECT id FROM app_role where authz_role = true and name = 'Internal User Manager')
+              AND assignable_role_id = (SELECT id FROM app_role where authz_role = true and name = 'Security Response');
+            dbms: postgresql
+        - sql:
+            sql: |
+              DELETE FROM role_assignment
+              WHERE assigning_role_id = (SELECT id FROM app_role where authz_role = true and name = 'Security Response')
+              AND assignable_role_id = (SELECT id FROM app_role where authz_role = true and name = 'Security Response');
+            dbms: postgresql


### PR DESCRIPTION
### Description :pencil:

Added a DB migration to stop privilege escalation by only allowing Global Admins to assign the Security Response role.

---

### Changes Made :pencil:

- Added a migration to stop internal user managers and security response users from assigning the security response role.
- Added integration tests to verify.

---

### Checklist :pencil:

- [X] I have added the relevant Liquibase changelog files for any entity changes
- [x] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [X] I have taken into account the application runs as 3 replicas in live environments
- [X] I have created any relevant documentation for this change
- [X] I have a corresponding JIRA ticket for this change 
- [X] I have added relevant unit & integration tests where applicable

---