### PR TITLE
STB-4139 -Fix CSRF risk by restricting admin endpoints to POST; suppress false positive on error handler.

### DIFF
--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/CustomErrorController.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/CustomErrorController.java
@@ -21,13 +21,16 @@ public class CustomErrorController implements ErrorController {
     /**
      * Handle all error requests and route to appropriate error page
      */
+    // Spring Boot ErrorController must accept all HTTP methods — errors can be dispatched from any original request
+    // method (GET, POST, PUT, DELETE, etc.). This handler only renders error views and performs no state changes,
+    // so there is no CSRF risk. nosemgrep: java.spring.security.unrestricted-request-mapping.unrestricted-request-mapping
     @RequestMapping("/error")
     public String handleError(HttpServletRequest request, Model model) {
         Object status = request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE);
         Object exception = request.getAttribute(RequestDispatcher.ERROR_EXCEPTION);
         String requestUri = (String) request.getAttribute(RequestDispatcher.ERROR_REQUEST_URI);
-        
-        log.debug("Error occurred - Status: {}, URI: {}, Exception: {}", status, requestUri, 
+
+        log.debug("Error occurred - Status: {}, URI: {}, Exception: {}", status, requestUri,
                 exception != null ? exception.getClass().getSimpleName() : "None");
 
         if (status != null) {

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/OneTimeTaskController.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/OneTimeTaskController.java
@@ -1,12 +1,14 @@
 package uk.gov.justice.laa.portal.landingpage.controller;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import org.springframework.web.servlet.view.RedirectView;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import uk.gov.justice.laa.portal.landingpage.service.RoleChangeNotificationService;
 import uk.gov.justice.laa.portal.landingpage.service.UserService;
 
@@ -20,7 +22,7 @@ public class OneTimeTaskController {
 
     private final UserService userService;
 
-    @RequestMapping("/ccms-role-sync")
+    @PostMapping("/ccms-role-sync")
     @PreAuthorize("@accessControlService"
             + ".authenticatedUserHasPermission(T(uk.gov.justice.laa.portal.landingpage.entity.Permission).TRIGGER_CCMS_ROLE_SYNC)")
     public RedirectView oneTimeTasks(RedirectAttributes redirectAttributes) {
@@ -31,7 +33,7 @@ public class OneTimeTaskController {
         return new RedirectView("/admin/users");
     }
 
-    @RequestMapping("/update-profile-status")
+    @PostMapping("/update-profile-status")
     @PreAuthorize("@accessControlService"
             + ".authenticatedUserHasPermission(T(uk.gov.justice.laa.portal.landingpage.entity.Permission).UPDATE_USER_PROFILE_SILAS_STATUS)")
     public RedirectView updateUserProfileSilasStatus(RedirectAttributes redirectAttributes) {

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/OneTimeTaskControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/OneTimeTaskControllerTest.java
@@ -1,19 +1,25 @@
 package uk.gov.justice.laa.portal.landingpage.controller;
 
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import static org.mockito.ArgumentMatchers.eq;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.web.servlet.mvc.support.RedirectAttributes;
-import org.springframework.web.servlet.view.RedirectView;
-import uk.gov.justice.laa.portal.landingpage.service.RoleChangeNotificationService;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import org.springframework.web.servlet.view.RedirectView;
+
+import uk.gov.justice.laa.portal.landingpage.service.RoleChangeNotificationService;
+import uk.gov.justice.laa.portal.landingpage.service.UserService;
 
 @ExtendWith(MockitoExtension.class)
 class OneTimeTaskControllerTest {
@@ -22,10 +28,20 @@ class OneTimeTaskControllerTest {
     private RoleChangeNotificationService roleChangeNotificationService;
 
     @Mock
+    private UserService userService;
+
+    @Mock
     private RedirectAttributes redirectAttributes;
 
     @InjectMocks
     private OneTimeTaskController controller;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+    }
 
     @Test
     void testOneTimeTasks_ShouldTriggerSyncAndRedirect() {
@@ -38,5 +54,16 @@ class OneTimeTaskControllerTest {
                 .addFlashAttribute(eq("successMessage"), eq("CCMS Role Sync has been triggered successfully"));
         assertEquals("/admin/users", result.getUrl());
     }
-}
 
+    @Test
+    void ccmsRoleSync_getRequest_returns405MethodNotAllowed() throws Exception {
+        mockMvc.perform(get("/admin/ccms-role-sync"))
+                .andExpect(status().isMethodNotAllowed());
+    }
+
+    @Test
+    void updateProfileStatus_getRequest_returns405MethodNotAllowed() throws Exception {
+        mockMvc.perform(get("/admin/update-profile-status"))
+                .andExpect(status().isMethodNotAllowed());
+    }
+}


### PR DESCRIPTION
### Description :pencil:

Fix CSRF risk by restricting admin endpoints to POST; suppress false positive on error handler.

---

### Changes Made :pencil:

This pull request updates the HTTP method annotations for one-time admin task endpoints to improve security and clarify intent. The two endpoints that trigger user role synchronization and profile status updates are now explicitly restricted to POST requests instead of allowing any HTTP method. Additionally, a comment was added to clarify the error handler's method mapping.

**Security and Endpoint Method Restriction:**

* Changed `@RequestMapping` to `@PostMapping` for `/ccms-role-sync` and `/update-profile-status` endpoints in `OneTimeTaskController`, ensuring these state-changing operations can only be triggered via POST requests. [[1]](diffhunk://#diff-6df6a862c986255f7a8c59fe8fcc354d806f01f6aadbf6e86c22d127f8ce01a0L23-R25) [[2]](diffhunk://#diff-6df6a862c986255f7a8c59fe8fcc354d806f01f6aadbf6e86c22d127f8ce01a0L34-R36)

**Documentation and Code Clarity:**

* Added a comment to the error handler in `CustomErrorController` explaining why all HTTP methods are accepted for the `/error` endpoint, and clarified that there is no CSRF risk.

---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [ ] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [x] I have a corresponding JIRA ticket for this change 
- [ ] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:

Please fill in.

---