### PR TITLE
STB-4185: bug UI alignment issue resend activation code

### DIFF
--- a/src/main/resources/templates/user-audit/details.html
+++ b/src/main/resources/templates/user-audit/details.html
@@ -105,7 +105,7 @@
                                     <div class="govuk-summary-list__row">
                                         <dt class="govuk-summary-list__key">Email</dt>
                                         <dd class="govuk-summary-list__value" th:text="${user.email}"></dd>
-                                        <dd class="govuk-summary-list__actions">
+                                        <dd class="govuk-summary-list__actions" style="width: 30%">
                                             <a th:if="${showResendVerificationLink}"  class="govuk-link"
                                                th:href="@{/admin/users/manage/{id}(id=${profileId},resendVerification=true)}">Resend Activation Code</a>
                                         </dd>
@@ -113,10 +113,12 @@
                                     <div class="govuk-summary-list__row">
                                         <dt class="govuk-summary-list__key">First name</dt>
                                         <dd class="govuk-summary-list__value" th:text="${user.firstName}"></dd>
+                                        <dd class="govuk-summary-list__actions" style="width: 30%"></dd>
                                     </div>
                                     <div class="govuk-summary-list__row">
                                         <dt class="govuk-summary-list__key">Last name</dt>
                                         <dd class="govuk-summary-list__value" th:text="${user.lastName}"></dd>
+                                        <dd class="govuk-summary-list__actions" style="width: 30%"></dd>
                                     </div>
                                 </dl>
                             </div>

--- a/src/main/resources/templates/user-audit/details.html
+++ b/src/main/resources/templates/user-audit/details.html
@@ -113,12 +113,12 @@
                                     <div class="govuk-summary-list__row">
                                         <dt class="govuk-summary-list__key">First name</dt>
                                         <dd class="govuk-summary-list__value" th:text="${user.firstName}"></dd>
-                                        <dd class="govuk-summary-list__actions" style="width: 30%"></dd>
+                                        <dd style="width: 30%"></dd>
                                     </div>
                                     <div class="govuk-summary-list__row">
                                         <dt class="govuk-summary-list__key">Last name</dt>
                                         <dd class="govuk-summary-list__value" th:text="${user.lastName}"></dd>
-                                        <dd class="govuk-summary-list__actions" style="width: 30%"></dd>
+                                        <dd style="width: 30%"></dd>
                                     </div>
                                 </dl>
                             </div>


### PR DESCRIPTION
### Description :pencil:

https://dsdmoj.atlassian.net/browse/STB-4185

Adjusted column width to prevent double line wrapping too soon.

Issue in Safari where border was not full length when above rows had more columns.

---

### Changes Made :pencil:

- Increased column width to 30%
- Added empty columns to subsequent rows to prevent Safari border bug
- 

---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [ ] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [x] I have a corresponding JIRA ticket for this change 
- [ ] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:

Please fill in.

---