### PR TITLE
STB-4140 - streamline hex string conversion in HashUtil and add security audit comments

### DIFF
--- a/pa11y-auth-test.js
+++ b/pa11y-auth-test.js
@@ -21,6 +21,12 @@ const puppeteer = require('puppeteer');
     process.exit(1);
   }
 
+  // Validate namespace is a safe Kubernetes name (lowercase alphanumeric and hyphens only)
+  if (!/^[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$/.test(namespace)) {
+    console.error(`Invalid NAMESPACE value: '${namespace}'. Must be a valid Kubernetes namespace (lowercase alphanumeric and hyphens).`);
+    process.exit(1);
+  }
+
   const urls = [
     `https://${namespace}.apps.live.cloud-platform.service.justice.gov.uk`,
     `https://${namespace}.apps.live.cloud-platform.service.justice.gov.uk/home`,

--- a/pa11y-auth-test.js
+++ b/pa11y-auth-test.js
@@ -9,7 +9,7 @@ const puppeteer = require('puppeteer');
   console.log('NAMESPACE:', process.env.NAMESPACE ? '[SET]' : '[MISSING]');
   console.log('ENTRA_USERNAME:', process.env.ENTRA_USERNAME ? '[SET]' : '[MISSING]');
   console.log('ENTRA_PASSWORD:', process.env.ENTRA_PASSWORD ? '[SET]' : '[MISSING]');
-  
+
   ['NAMESPACE', 'ENTRA_USERNAME', 'ENTRA_PASSWORD'].forEach((key) => {
     if (!process.env[key]) {
       console.error(`Missing required env var: ${key}`);
@@ -34,6 +34,7 @@ const puppeteer = require('puppeteer');
   const page = await browser.newPage();
   try {
     console.log('Step 1: Navigating to login page...');
+    // nosemgrep: javascript.puppeteer.security.audit.puppeteer-goto-injection.puppeteer-goto-injection — namespace is a controlled CI environment variable, not end-user input; URL is constrained to a known domain
     await page.goto(`https://${namespace}.apps.live.cloud-platform.service.justice.gov.uk`, { waitUntil: 'networkidle2' });
 
     // === FIRST LOGIN ATTEMPT ===
@@ -59,7 +60,7 @@ const puppeteer = require('puppeteer');
     try {
         console.log('Step 7: Checking for "Stay signed in?" prompt...');
         await page.waitForSelector('#idBtn_Back', { timeout: 5000 });
-  
+
         console.log('"Stay signed in?" prompt detected. Clicking "No"...');
         await page.click('#idBtn_Back');
         await page.waitForNavigation({ waitUntil: 'networkidle2' });
@@ -112,13 +113,13 @@ const puppeteer = require('puppeteer');
     console.log('Accessibility results:');
     console.log(results);
 
-  
+
   } catch (error) {
     console.error('Login automation failed:', error);
     await page.screenshot({ path: 'login-failure.png' });
     process.exit(1);
-  }  
-  
+  }
+
 
   // Loop through URLs after login
   for (const url of urls) {

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/MultiFirmUserController.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/MultiFirmUserController.java
@@ -384,6 +384,7 @@ public class MultiFirmUserController {
 
         model.addAttribute("userProfile", userProfile);
         model.addAttribute("user", entraUser);
+        // nosemgrep: java.spring.security.injection.tainted-sql-string.tainted-sql-string — not SQL; setting a view model page title attribute
         model.addAttribute(ModelAttributes.PAGE_TITLE, "Delete firm access - " + entraUser.getFullName());
 
         return "multi-firm-user/delete-profile-confirm";

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/utils/HashUtil.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/utils/HashUtil.java
@@ -3,6 +3,7 @@ package uk.gov.justice.laa.portal.landingpage.utils;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
 import java.util.UUID;
 
 /**
@@ -26,13 +27,7 @@ public class HashUtil {
             MessageDigest digest = MessageDigest.getInstance("SHA-256");
             byte[] encodedHash = digest.digest(
                     input.getBytes(StandardCharsets.UTF_8));
-
-
-            StringBuilder hexString = new StringBuilder(2 * encodedHash.length);
-            for (byte hash : encodedHash) {
-                hexString.append(String.format("%02x", 0xff & hash));
-            }
-            return hexString.toString();
+            return HexFormat.of().formatHex(encodedHash);
         } catch (NoSuchAlgorithmException nsaEx) {
             throw new RuntimeException("Unable to perform hashing", nsaEx);
         }

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/utils/HashUtil.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/utils/HashUtil.java
@@ -30,11 +30,7 @@ public class HashUtil {
 
             StringBuilder hexString = new StringBuilder(2 * encodedHash.length);
             for (byte hash : encodedHash) {
-                String hex = Integer.toHexString(0xff & hash);
-                if (hex.length() == 1) {
-                    hexString.append('0');
-                }
-                hexString.append(hex);
+                hexString.append(String.format("%02x", 0xff & hash));
             }
             return hexString.toString();
         } catch (NoSuchAlgorithmException nsaEx) {
@@ -43,4 +39,3 @@ public class HashUtil {
     }
 
 }
-


### PR DESCRIPTION
### Description :pencil:
Fix HashUtil hex conversion to use `String.format`; suppress two false positive OpenGrep findings in MultiFirmUserController and pa11y-auth-test with justification comments.

---

### Changes Made :pencil:

This pull request contains a few targeted improvements and clarifications across the codebase. The main changes include a small code simplification for hash formatting, and the explicit documentation of security-related decisions to suppress false-positive static analysis warnings.

Code simplification:

* Refactored the `sha256` method in `HashUtil.java` to use `String.format("%02x", ...)` for hexadecimal conversion, making the code more concise and readable.

Security documentation and static analysis suppressions:

* Added a `no semgrep` comment in `pa11y-auth-test.js` to clarify that the Puppeteer `goto` URL is safe due to being constrained to a known domain in a CI environment.
* Added a `no semgrep` comment in `MultiFirmUserController.java` to clarify that a dynamic string is used only for setting a view model attribute, not for SQL.

---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [ ] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [x] I have a corresponding JIRA ticket for this change 
- [ ] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:

Please fill in.

---