### PR TITLE
STB-4065: Allow the user to come back to where they left off when creating user.

### DIFF
--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
@@ -649,6 +649,7 @@ public class UserController {
 
         // Store the model in session to handle validation errors later
         session.setAttribute("createUserDetailsModel", model);
+        session.setAttribute("createUserFlowStage", "user/create/details");
         model.addAttribute(ModelAttributes.PAGE_TITLE, "Add user details");
         return "add-user-details";
     }
@@ -723,6 +724,7 @@ public class UserController {
             multiFirmForm.setMultiFirmUser(isMultiFirmUser);
         }
 
+        session.setAttribute("createUserFlowStage", "user/create/multi-firm");
         model.addAttribute("multiFirmForm", multiFirmForm);
         model.addAttribute(ModelAttributes.PAGE_TITLE, "Allow multi-firm access");
         return "add-user-multi-firm";
@@ -791,6 +793,7 @@ public class UserController {
         model.addAttribute("firmSearchResultCount", validatedCount);
         model.addAttribute("showSkipFirmSelection", showSkipFirmSelection);
         model.addAttribute(ModelAttributes.PAGE_TITLE, "Select firm");
+        session.setAttribute("createUserFlowStage", "user/create/firm");
         return "add-user-firm";
     }
 
@@ -861,6 +864,7 @@ public class UserController {
         model.addAttribute("isMultiFirmUser", isMultiFirmUser != null ? isMultiFirmUser : false);
 
         model.addAttribute(ModelAttributes.PAGE_TITLE, "Check your answers");
+        session.setAttribute("createUserFlowStage", "user/create/check-answers");
         return "add-user-check-answers";
     }
 
@@ -967,12 +971,15 @@ public class UserController {
         session.removeAttribute("user");
         session.removeAttribute("userProfile");
         session.removeAttribute("isMultiFirmUser");
+        session.removeAttribute("createUserFlowStage");
         model.addAttribute(ModelAttributes.PAGE_TITLE, "User created");
         return "add-user-created";
     }
 
     @GetMapping("/user/create/cancel/confirmation")
-    public String confirmCancelCreateUser() {
+    public String confirmCancelCreateUser(HttpSession session, Model model) {
+        String stageUrl = getObjectFromHttpSession(session, "createUserFlowStage", String.class).orElse("user/create/details");
+        model.addAttribute("stageUrl", stageUrl);
         return "cancel-add-user-confirmation";
     }
 
@@ -989,6 +996,7 @@ public class UserController {
         session.removeAttribute("officeData");
         session.removeAttribute("firmSearchForm");
         session.removeAttribute("firmSearchTerm");
+        session.removeAttribute("createUserFlowStage");
         return "redirect:/admin/users";
     }
 

--- a/src/main/resources/templates/cancel-add-user-confirmation.html
+++ b/src/main/resources/templates/cancel-add-user-confirmation.html
@@ -32,7 +32,7 @@
         If you cancel, any information you’ve entered will be lost.
     </p>
     <!-- nosemgrep -->
-    <form th:action="@{/admin/user/create/details}" method="post" style="display: inline;">
+    <form th:action="@{|/admin/${stageUrl}|}" method="get" style="display: inline;">
         <div class="moj-button-group">
             <button type="submit" class="govuk-button" data-module="govuk-button">
                 Continue creating a new user


### PR DESCRIPTION
### Description :pencil:

When creating a user, if the user clicks "cancel" at any stage, changes their mind, and wants to resume creating the user, they are bounced back to the initial "Add User Details" page. This change moves them back to where they were in the flow. 

---

### Changes Made :pencil:

- Added a new session attribute "createUserFlowStage" to track create user flow progress.
- Changed UI code to come back to the user's current stage rather than defaulting to the details page on cancel.

---

### Checklist :pencil:

- [X] I have added the relevant Liquibase changelog files for any entity changes
- [X] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [X] I have taken into account the application runs as 3 replicas in live environments
- [X] I have created any relevant documentation for this change
- [X] I have a corresponding JIRA ticket for this change 
- [X] I have added relevant unit & integration tests where applicable