### PR TITLE
STB-4164 - Refactor CSV export validation. Allow CSV export with firm selection

### DIFF
--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/AuditController.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/AuditController.java
@@ -381,8 +381,14 @@ public class AuditController {
     public ResponseEntity<byte[]> downloadAuditCsv(@ModelAttribute AuditTableSearchCriteria criteria) {
 
         if (criteria.getSelectedFirmId() == null && criteria.getSelectedUserType() != UserTypeForm.INTERNAL) {
-            log.warn("Invalid search criteria provided for CSV export - selectedFirmId: {}, selectedUserType: {}",
-                    criteria.getSelectedFirmId(), criteria.getSelectedUserType());
+            log.warn("Invalid criteria provided for CSV export - firm ID must always be provided when external user type is selected. selectedUserType: {}",
+                    criteria.getSelectedUserType());
+            throw new RuntimeException("Invalid Search criteria provided");
+        }
+
+        if (criteria.getSelectedFirmId() != null && criteria.getSelectedUserType() == UserTypeForm.INTERNAL) {
+            log.warn("Invalid criteria provided for CSV export - firm ID should not be provided when internal user type is selected. selectedFirmId: {}",
+                    criteria.getSelectedFirmId());
             throw new RuntimeException("Invalid Search criteria provided");
         }
 

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/AuditController.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/AuditController.java
@@ -380,9 +380,9 @@ public class AuditController {
     @PreAuthorize("@accessControlService.authenticatedUserHasPermission('EXPORT_AUDIT_DATA')")
     public ResponseEntity<byte[]> downloadAuditCsv(@ModelAttribute AuditTableSearchCriteria criteria) {
 
-        if (criteria.getSearch() == null || (criteria.getSelectedFirmId() == null && criteria.getSelectedUserType() != UserTypeForm.INTERNAL)) {
-            log.warn("Invalid search criteria provided for CSV export - search: '{}', selectedFirmId: {}, selectedUserType: {}",
-                    criteria.getSearch(), criteria.getSelectedFirmId(), criteria.getSelectedUserType());
+        if (criteria.getSelectedFirmId() == null && criteria.getSelectedUserType() != UserTypeForm.INTERNAL) {
+            log.warn("Invalid search criteria provided for CSV export - selectedFirmId: {}, selectedUserType: {}",
+                    criteria.getSelectedFirmId(), criteria.getSelectedUserType());
             throw new RuntimeException("Invalid Search criteria provided");
         }
 

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/AuditControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/AuditControllerTest.java
@@ -1289,6 +1289,36 @@ class AuditControllerTest {
     }
 
     @Test
+    void downloadAuditCsvWithNoSearchText_shouldSucceedWhenFirmSelected() {
+
+        UUID selectedFirmId = UUID.randomUUID();
+        AuditTableSearchCriteria criteria = new AuditTableSearchCriteria();
+        // search is intentionally null – firm is selected, no text filter entered
+        criteria.setSort("name");
+        criteria.setDirection("asc");
+        criteria.setSelectedFirmId(selectedFirmId.toString());
+
+        List<AuditUserDto> users = List.of(AuditUserDto.builder().name("P1").email("p1@example.com").build());
+        PaginatedAuditUsers page = PaginatedAuditUsers.builder()
+                .users(users)
+                .currentPage(1)
+                .pageSize(500)
+                .build();
+
+        when(userService.getAuditUsers(eq(""), any(), any(), any(), any(), eq(1), eq(500), eq("name"), eq("asc"), eq(true), any(), any())).thenReturn(page);
+
+        byte[] csvBytes = "Name,Email\nP1,p1@example.com\n".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        AuditExportService.AuditCsvExport export = new AuditExportService.AuditCsvExport("audit.csv", csvBytes);
+        when(auditExportService.downloadAuditCsv(any(), any(), any())).thenReturn(export);
+
+        ResponseEntity<byte[]> response = auditController.downloadAuditCsv(criteria);
+
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(response.getBody()).isEqualTo(csvBytes);
+        verify(auditExportService, times(1)).downloadAuditCsv(any(), any(), any());
+    }
+
+    @Test
     void downloadExternalUserWithNoFirmSelectionAuditCsv_shouldReturnException() {
 
         AuditTableSearchCriteria criteria = new AuditTableSearchCriteria();

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/AuditControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/AuditControllerTest.java
@@ -1246,7 +1246,7 @@ class AuditControllerTest {
     }
 
     @Test
-    void downloadInternalUserWithFirmSelectionAuditCsv_shouldReturnSuccess() {
+    void downloadInternalUserWithFirmSelectionAuditCsv_shouldReturnException() {
 
         UUID selectedFirmId = UUID.randomUUID();
         AuditTableSearchCriteria criteria = new AuditTableSearchCriteria();
@@ -1256,36 +1256,9 @@ class AuditControllerTest {
         criteria.setSelectedUserType(UserTypeForm.INTERNAL.name());
         criteria.setSelectedFirmId(selectedFirmId.toString());
 
-        List<AuditUserDto> page1Users = Collections.emptyList();
-
-
-        PaginatedAuditUsers page1 = PaginatedAuditUsers.builder()
-                .users(page1Users)
-                .currentPage(1)
-                .pageSize(500)
-                .build();
-
-        when(userService.getAuditUsers(
-                eq("TestSearch"), any(), any(), any(), any(), eq(1), eq(500), eq("name"), eq("asc"), eq(true), any(), any())).thenReturn(page1);
-
-
-        byte[] csvBytes = "Name,Email\nP1,p1@example.com\n".getBytes(java.nio.charset.StandardCharsets.UTF_8);
-        AuditExportService.AuditCsvExport export = new AuditExportService.AuditCsvExport("audit.csv", csvBytes);
-        when(auditExportService.downloadAuditCsv(any(), any(), any())).thenReturn(export);
-
-        ResponseEntity<byte[]> response = auditController.downloadAuditCsv(criteria);
-
-        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
-        assertThat(response.getBody()).isEqualTo(csvBytes);
-
-        HttpHeaders headers = response.getHeaders();
-        assertThat(headers.getContentType()).isEqualTo(MediaType.parseMediaType("text/csv"));
-        assertThat(headers.getContentDisposition().getType()).isEqualTo("attachment");
-        assertThat(headers.getContentDisposition().getFilename()).isEqualTo("audit.csv");
-
-        verify(userService, times(1)).getAuditUsers("TestSearch", selectedFirmId,
-                null, null, UserTypeForm.INTERNAL, 1, 500, "name", "asc", true, null, null);
-        verify(auditExportService, times(1)).downloadAuditCsv(any(), any(), any());
+        assertThatThrownBy(() -> auditController.downloadAuditCsv(criteria))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("Invalid Search criteria provided");
     }
 
     @Test
@@ -1339,6 +1312,21 @@ class AuditControllerTest {
         // No search text, no firm selected, no INTERNAL user type
         criteria.setSort("name");
         criteria.setDirection("asc");
+
+        assertThatThrownBy(() -> auditController.downloadAuditCsv(criteria))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("Invalid Search criteria provided");
+    }
+
+    @Test
+    void downloadInternalUserAuditCsvWithFirmSelected_shouldReturnException() {
+
+        UUID selectedFirmId = UUID.randomUUID();
+        AuditTableSearchCriteria criteria = new AuditTableSearchCriteria();
+        criteria.setSort("name");
+        criteria.setDirection("asc");
+        criteria.setSelectedUserType(UserTypeForm.INTERNAL.name());
+        criteria.setSelectedFirmId(selectedFirmId.toString());
 
         assertThatThrownBy(() -> auditController.downloadAuditCsv(criteria))
                 .isInstanceOf(RuntimeException.class)

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/AuditControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/AuditControllerTest.java
@@ -1331,4 +1331,17 @@ class AuditControllerTest {
                 .isInstanceOf(RuntimeException.class)
                 .hasMessage("Invalid Search criteria provided");
     }
+
+    @Test
+    void downloadAuditCsvWithNoSearchTextAndNoFirmSelection_shouldReturnException() {
+
+        AuditTableSearchCriteria criteria = new AuditTableSearchCriteria();
+        // No search text, no firm selected, no INTERNAL user type
+        criteria.setSort("name");
+        criteria.setDirection("asc");
+
+        assertThatThrownBy(() -> auditController.downloadAuditCsv(criteria))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("Invalid Search criteria provided");
+    }
 }


### PR DESCRIPTION
### Description :pencil:

Fix added to make CSV export work.

---

### Changes Made :pencil:

This pull request updates the validation logic for exporting audit data as CSV and adds a new test to cover this scenario. The main change is to allow CSV export when a firm is selected, even if no search text is provided. The most important changes are:

Validation logic update:

* Modified the condition in `AuditController.downloadAuditCsv` to allow CSV export when a firm is selected, regardless of whether the search text is provided. The log message and validation now only check for the presence of `selectedFirmId` or if the user type is internal, removing the unnecessary check on the search text.

Test coverage:

* Added a new test `downloadAuditCsvWithNoSearchText_shouldSucceedWhenFirmSelected` in `AuditControllerTest.java` to verify that exporting the audit CSV succeeds when a firm is selected and no search text is provided.

---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [ ] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [x] I have a corresponding JIRA ticket for this change 
- [x] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:

Please fill in.

---