### PR TITLE
STB-4081: Setting workflow run conditions and fail on findings to true

### DIFF
--- a/.github/workflows/ash.yml
+++ b/.github/workflows/ash.yml
@@ -10,8 +10,9 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+    types: [ opened, reopened, synchronize, edited ]
   schedule:
-    - cron: '0 0 * * 0'
+    - cron: '20 03 * * 6'
   workflow_dispatch:
 
 jobs:
@@ -27,7 +28,7 @@ jobs:
       ash-version: v3
       ash-mode: container
       config: .ash/ash.yaml
-      fail-on-findings: false
+      fail-on-findings: true
       collect-junit-xml-report: false
       collect-sarif-report: false
       install-grype: true


### PR DESCRIPTION
### Description :pencil:

Setting Ash scan to fail on findings now that all initial issues have been resolved or suppressed.

---

### Changes Made :pencil:

- Set workflow run conditions on PRs and cron schedule

---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [x] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [x] I have a corresponding JIRA ticket for this change 
- [ ] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:


---