### PR TITLE
STB-4203 - Add warning log/guard for user not found during disable request

### DIFF
--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/service/LiveTechServicesClient.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/service/LiveTechServicesClient.java
@@ -369,6 +369,11 @@ public class LiveTechServicesClient implements TechServicesClient {
                             user.getEntraOid(), errorResponse.getMessage(), errorResponse.getCode(), httpEx);
                     return TechServicesApiResponse.error(errorResponse);
                 }
+                if (HttpStatus.NOT_FOUND.equals(httpEx.getStatusCode())) {
+                    logger.warn("User {} not found in tech services during disable request, the root cause is {} ({}) ",
+                            user.getEntraOid(), errorResponse.getMessage(), errorResponse.getCode());
+                    return TechServicesApiResponse.error(errorResponse);
+                }
                 logger.error("Failed to disable user {}, the root cause is {} ({}) ",
                         user.getEntraOid(), errorResponse.getMessage(), errorResponse.getCode(), httpEx);
                 return TechServicesApiResponse.error(errorResponse);

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/service/LiveTechServicesClientTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/service/LiveTechServicesClientTest.java
@@ -1215,6 +1215,33 @@ public class LiveTechServicesClientTest {
     }
 
     @Test
+    public void testDisableUserReturnsWarnWhenUserNotFound() {
+        AccessToken token = new AccessToken("token", null);
+
+        when(clientSecretCredential.getToken(any(TokenRequestContext.class))).thenReturn(Mono.just(token));
+        when(cacheManager.getCache(anyString())).thenReturn(new ConcurrentMapCache(CachingConfig.TECH_SERVICES_DETAILS_CACHE));
+        String errorBody = """
+                {
+                    "success": false,
+                    "code": "USER_NOT_FOUND",
+                    "message": "User not found"
+                }""";
+        HttpClientErrorException exception = HttpClientErrorException.create(HttpStatus.NOT_FOUND,
+                "Not Found", null, errorBody.getBytes(), null);
+
+        EntraUserDto user = EntraUserDto.builder()
+                .entraOid(UUID.randomUUID().toString())
+                .build();
+
+        when(restClient.patch()).thenThrow(exception);
+        TechServicesApiResponse<ChangeAccountEnabledResponse> response = liveTechServicesClient.disableUser(user, "Test reason");
+
+        assertThat(response.isSuccess()).isFalse();
+        assertLogMessage(Level.WARN, "User " + user.getEntraOid() + " not found in tech services during disable request");
+        verify(restClient, times(1)).patch();
+    }
+
+    @Test
     void testGetUsers_Success() {
         AccessToken token = new AccessToken("token", null);
         when(clientSecretCredential.getToken(any(TokenRequestContext.class))).thenReturn(Mono.just(token));


### PR DESCRIPTION
### Description :pencil:

When deleting a user, the `disableUser` call to tech services returned a 404 because the user didn't exist there. This was treated as an unexpected error and threw an exception, failing the deletion.

---

### Changes Made :pencil:

This pull request improves error handling and logging for user disable requests in the `LiveTechServicesClient` service. It adds specific handling for cases where a user is not found, and introduces a corresponding test to ensure this behavior is correctly logged and handled.

**Error handling and logging improvements:**

* Updated `disableUser` in `LiveTechServicesClient.java` to specifically check for `HttpStatus.NOT_FOUND` and log a warning when the user is not found, returning an appropriate error response.

**Testing enhancements:**

* Added a new test `testDisableUserReturnsWarnWhenUserNotFound` in `LiveTechServicesClientTest.java` to verify that a warning is logged and the correct error response is returned when the user is not found.
---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [ ] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [x] I have a corresponding JIRA ticket for this change 
- [x] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:

Please fill in.

---