### PR TITLE
STB-4260: disable link in silas audit section

### DIFF
--- a/src/main/resources/templates/user-audit/details.html
+++ b/src/main/resources/templates/user-audit/details.html
@@ -128,6 +128,17 @@
                         <div class="govuk-summary-card">
                             <div class="govuk-summary-card__title-wrapper">
                                 <h3 class="govuk-summary-card__title">SiLAS Audit Data</h3>
+                                <ul th:if="${canDisableUser or canEnableUser or cannotEnableUser}" class="govuk-summary-card__actions">
+                                    <li th:if="${canDisableUser and userIsEnabled}" class="govuk-summary-card__action">
+                                        <a class="govuk-link" th:href="@{/admin/users/manage/{id}/disable(id=${user.userId}, referer='audit')}">Disable user</a>
+                                    </li>
+                                    <li th:if="${canEnableUser and !userIsEnabled}" class="govuk-summary-card__action">
+                                        <a class="govuk-link" th:href="@{/admin/users/manage/{id}/enable(id=${user.userId}, referer='audit')}">Enable user</a>
+                                    </li>
+                                    <li th:if="${cannotEnableUser and !userIsEnabled}" class="govuk-summary-card__action">
+                                        <span>You cannot enable this user</span>
+                                    </li>
+                                </ul>
                             </div>
                             <div class="govuk-summary-card__content">
                                 <dl class="govuk-summary-list">
@@ -181,17 +192,6 @@
                         <div class="govuk-summary-card">
                             <div class="govuk-summary-card__title-wrapper">
                                 <h3 class="govuk-summary-card__title">Entra Audit data</h3>
-                                <ul th:if="${canDisableUser or canEnableUser or cannotEnableUser}" class="govuk-summary-card__actions">
-                                    <li th:if="${canDisableUser and userIsEnabled}" class="govuk-summary-card__action">
-                                        <a class="govuk-link" th:href="@{/admin/users/manage/{id}/disable(id=${user.userId}, referer='audit')}">Disable user</a>
-                                    </li>
-                                    <li th:if="${canEnableUser and !userIsEnabled}" class="govuk-summary-card__action">
-                                        <a class="govuk-link" th:href="@{/admin/users/manage/{id}/enable(id=${user.userId}, referer='audit')}">Enable user</a>
-                                    </li>
-                                    <li th:if="${cannotEnableUser and !userIsEnabled}" class="govuk-summary-card__action">
-                                        <span>You cannot enable this user</span>
-                                    </li>
-                                </ul>
                             </div>
                             <div class="govuk-summary-card__content">
                                 <dl class="govuk-summary-list">


### PR DESCRIPTION
### Description :pencil:

Disable/Enable user button was incorrectly sitting in Entra Audit Data section, not aligning with where the SILAS Account Status was displayed

https://dsdmoj.atlassian.net/browse/STB-4260

---

### Changes Made :pencil:

- Moved element to SILAS Audit Data Section
- 
- 

---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [ ] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [x] I have a corresponding JIRA ticket for this change 
- [ ] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:

Please fill in.

---