### PR TITLE
STB-4035: Move validation for CCMS user migration solely to POST request for grant access and edit roles.

### DIFF
--- a/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/CcmsEbsValidationTest.java
+++ b/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/CcmsEbsValidationTest.java
@@ -5,9 +5,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.mock.web.MockHttpSession;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.web.servlet.ModelAndView;
 import uk.gov.justice.laa.portal.landingpage.dto.CcmsUserDetailsResponse;
@@ -15,7 +13,6 @@ import uk.gov.justice.laa.portal.landingpage.entity.App;
 import uk.gov.justice.laa.portal.landingpage.entity.AppRole;
 import uk.gov.justice.laa.portal.landingpage.entity.EntraUser;
 import uk.gov.justice.laa.portal.landingpage.entity.UserProfile;
-import uk.gov.justice.laa.portal.landingpage.service.CcmsUserDetailsService;
 
 import java.util.List;
 import java.util.Map;
@@ -23,7 +20,6 @@ import java.util.Set;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -62,7 +58,7 @@ public class CcmsEbsValidationTest extends RoleBasedAccessIntegrationTest {
 
     @Test
     @Transactional
-    public void testEditRoleCheckAnswersGetHasErrorWhenInternalUserIsNotMigrated() throws Exception {
+    public void testEditRoleCheckAnswersGetHasNoErrorsWhenInternalUserIsNotMigrated() throws Exception {
         EntraUser loggedInUser = globalAdmins.getFirst();
         EntraUser editedUser = internalUsersNoRoles.getFirst();
 
@@ -74,7 +70,7 @@ public class CcmsEbsValidationTest extends RoleBasedAccessIntegrationTest {
         assertThat(result.getResponse().getStatus()).isEqualTo(200);
         assertThat(result.getModelAndView()).isNotNull();
         ModelAndView modelAndView = result.getModelAndView();
-        assertThat(modelAndView.getModel().get("errorMessage")).isNotNull();
+        assertThat(modelAndView.getModel().get("errorMessage")).isNull();
     }
 
     @Test
@@ -111,7 +107,9 @@ public class CcmsEbsValidationTest extends RoleBasedAccessIntegrationTest {
         // Assert request was not success
         assertThat(result.getResponse()).isNotNull();
         assertThat(result.getResponse().getStatus()).isEqualTo(302);
-        assertThat(result.getResponse().getRedirectedUrl()).contains("/error");
+        assertThat(result.getResponse().getRedirectedUrl()).contains("/roles-check-answer");
+        assertThat(result.getResponse().getRedirectedUrl()).contains("errorMessage");
+
 
         // Assert user does not have role.
         assertThat(userHasAppRole(editedUser, legacySyncRole)).isFalse();
@@ -143,7 +141,7 @@ public class CcmsEbsValidationTest extends RoleBasedAccessIntegrationTest {
 
     @Test
     @Transactional
-    public void testGrantAccessCheckAnswersGetHasErrorWhenInternalUserIsNotMigrated() throws Exception {
+    public void testGrantAccessCheckAnswersGetHasNoErrorsWhenInternalUserIsNotMigrated() throws Exception {
         EntraUser loggedInUser = globalAdmins.getFirst();
         EntraUser editedUser = internalUsersNoRoles.getFirst();
 
@@ -155,7 +153,7 @@ public class CcmsEbsValidationTest extends RoleBasedAccessIntegrationTest {
         assertThat(result.getResponse().getStatus()).isEqualTo(200);
         assertThat(result.getModelAndView()).isNotNull();
         ModelAndView modelAndView = result.getModelAndView();
-        assertThat(modelAndView.getModel().get("errorMessage")).isNotNull();
+        assertThat(modelAndView.getModel().get("errorMessage")).isNull();
     }
 
     @Test
@@ -192,7 +190,9 @@ public class CcmsEbsValidationTest extends RoleBasedAccessIntegrationTest {
         // Assert request was not success
         assertThat(result.getResponse()).isNotNull();
         assertThat(result.getResponse().getStatus()).isEqualTo(302);
-        assertThat(result.getResponse().getRedirectedUrl()).contains("/confirmation");
+        assertThat(result.getResponse().getRedirectedUrl()).contains("/check-answers");
+        assertThat(result.getResponse().getRedirectedUrl()).contains("errorMessage");
+
 
         // Assert user does not have role.
         assertThat(userHasAppRole(editedUser, legacySyncRole)).isFalse();

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
@@ -1608,12 +1608,6 @@ public class UserController {
                 }
             }
         }
-        // If any apps are marked as legacy sync, make sure user exists in ccms.
-        if (user.getUserType() == UserType.INTERNAL && selectedAppRole.stream().anyMatch(UserRole::isLegacySync)
-                && !user.getEntraUser().isCcmsEbsUser()) {
-            final String ccmsErrorMsg = "This user has not been migrated, so is unable to access CCMS. Remove any CCMS or PUI role before saving.";
-            errorMessage = errorMessage == null ? ccmsErrorMsg : errorMessage + "\n" + ccmsErrorMsg;
-        }
         if (errorMessage != null) {
             model.addAttribute("errorMessage", errorMessage);
         }
@@ -1652,9 +1646,8 @@ public class UserController {
         Collection<AppRoleDto> roles = userService.getRolesByIdIn(roleUuids).values();
         if (user.getUserType() == UserType.INTERNAL && roles.stream().anyMatch(AppRoleDto::isLegacySync)
             && !user.getEntraUser().isCcmsEbsUser()) {
-            log.error("Role update blocked for user profile ID {}."
-                    + "A POST request was attempted to add CCMS/PUI roles to a non-migrated user. This may have been done to bypass UI validation.", user.getId());
-            throw new RuntimeException();
+            final String ccmsErrorMsg = "This user has not been migrated, so is unable to access CCMS. Remove any CCMS or PUI role before saving.";
+            return String.format("redirect:/admin/users/edit/%s/roles-check-answer?errorMessage=%s", uuid, ccmsErrorMsg);
         }
         if (roleAssignmentService.canAssignRole(editorProfile.getAppRoles(), allSelectedRoles)) {
             Map<String, String> updateResult = userService.updateUserRoles(id, allSelectedRoles,
@@ -2574,6 +2567,7 @@ public class UserController {
     @GetMapping("/users/grant-access/{id}/check-answers")
     @PreAuthorize("@accessControlService.canGrantUserAccess(#id)")
     public String grantAccessCheckAnswers(@PathVariable String id,
+                                          @RequestParam(value = "errorMessage", required = false) String errorMessage,
                                           Model model,
                                           HttpSession session,
                                           Authentication authentication) {
@@ -2601,11 +2595,6 @@ public class UserController {
                 || selectedOffices.contains(NO_OFFICES))) {
             userOffices = officeService.getOfficesByIds(selectedOffices);
 
-        }
-        String errorMessage = null;
-        if (user.getUserType() == UserType.INTERNAL && userAppRoles.stream().anyMatch(AppRoleDto::isLegacySync)
-                && !user.getEntraUser().isCcmsEbsUser()) {
-            errorMessage = "This user has not been migrated, so is unable to access CCMS. Remove any CCMS or PUI role before saving.";
         }
         UserProfile editorUserProfile = loginService.getCurrentProfile(authentication);
         List<AppRoleDto> editableUserAppRoles = userAppRoles.stream()
@@ -2703,9 +2692,8 @@ public class UserController {
             List<AppRoleDto> roles = appRoleService.getByIds(allSelectedRoles);
             if (userProfileDto.getUserType() == UserType.INTERNAL && roles.stream().anyMatch(AppRoleDto::isLegacySync)
                     && !userProfileDto.getEntraUser().isCcmsEbsUser()) {
-                log.error("Role update blocked for user profile ID {}."
-                        + "A POST request was attempted to add CCMS/PUI roles to a non-migrated user. This may have been done to bypass UI validation.", userProfileDto.getId());
-                throw new RuntimeException();
+                String ccmsErrorMsg = "This user has not been migrated, so is unable to access CCMS. Remove any CCMS or PUI role before saving.";
+                return String.format("redirect:/admin/users/grant-access/%s/check-answers?errorMessage=%s", id, ccmsErrorMsg);
             }
 
             UserProfile editorProfile = loginService.getCurrentProfile(authentication);

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/UserControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/UserControllerTest.java
@@ -6200,7 +6200,7 @@ class UserControllerTest {
         when(roleAssignmentService.canUserAssignRolesForApp(any(), any())).thenReturn(true);
 
         // When
-        String view = userController.grantAccessCheckAnswers(userId, model, testSession, authentication);
+        String view = userController.grantAccessCheckAnswers(userId, null, model, testSession, authentication);
 
         // Then
         assertThat(view).isEqualTo("grant-access-check-answers");
@@ -6258,7 +6258,7 @@ class UserControllerTest {
         when(roleAssignmentService.canUserAssignRolesForApp(any(), any())).thenReturn(true);
 
         // When
-        String view = userController.grantAccessCheckAnswers(userId, model, testSession, authentication);
+        String view = userController.grantAccessCheckAnswers(userId, null, model, testSession, authentication);
 
         // Then
         assertThat(view).isEqualTo("grant-access-check-answers");
@@ -6325,7 +6325,7 @@ class UserControllerTest {
         when(roleAssignmentService.canUserAssignRolesForApp(any(), any())).thenReturn(true);
 
         // When
-        String view = userController.grantAccessCheckAnswers(userId, model, testSession, authentication);
+        String view = userController.grantAccessCheckAnswers(userId, null, model, testSession, authentication);
 
         // Then
         assertThat(view).isEqualTo("grant-access-check-answers");


### PR DESCRIPTION
### Description :pencil:

Removed the CCMS migration validation from GET endpoints for check answers. Validation is now solely done after the user submits the check answers form.

---

### Changes Made :pencil:

- Removed validation logic from GET endpoints
- Changed POST logic to redirect and display error rather than throw exception
- Update integration tests.

---

### Checklist :pencil:

- [X] I have added the relevant Liquibase changelog files for any entity changes
- [X] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [X] I have taken into account the application runs as 3 replicas in live environments
- [X] I have created any relevant documentation for this change
- [X] I have a corresponding JIRA ticket for this change 
- [X] I have added relevant unit & integration tests where applicable