### PR TITLE
STB-4294: Trufflehog bump

### DIFF
--- a/.github/workflows/secret_scan_trufflehog.yml
+++ b/.github/workflows/secret_scan_trufflehog.yml
@@ -23,6 +23,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: TruffleHog scan
-      uses: trufflesecurity/trufflehog@88c7519a4728f4d8daddc01da8a1406d354f0dfe # main
+      uses: trufflesecurity/trufflehog@d411fff7b8879a62509f3fa98c07f247ac089a51 # 3.95.4
       with:
+        version: 3.95.4
         extra_args: --results=verified

--- a/.github/workflows/secret_scan_trufflehog.yml
+++ b/.github/workflows/secret_scan_trufflehog.yml
@@ -25,5 +25,5 @@ jobs:
     - name: TruffleHog scan
       uses: trufflesecurity/trufflehog@d411fff7b8879a62509f3fa98c07f247ac089a51 # 3.95.4
       with:
-        version: 3.95.4
+        version: 3.95.4@sha256:2df7b5f8ec308946dff88927d4a2c3426ebc4efed15fed9c63294e13f3ccbb29
         extra_args: --results=verified


### PR DESCRIPTION
### Description :pencil:

Replacing the dependabot trufflehog PR with this one to mitigate an issue with the GitHub Action workflow, which by default downloads the trufflehog  latest image. 

---

### Changes Made :pencil:

- Update trufflehog workflow to set version

---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [x] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [ ] I have a corresponding JIRA ticket for this change 
- [ ] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:

trufflehog issue - https://github.com/trufflesecurity/trufflehog/issues/4857
---