### PR TITLE
STB-4203 - Update NotActive entries in disable_user_reason and user_account_status_audit

### DIFF
--- a/src/main/resources/db/changelog/changesets/db.changesets-5.53.yaml
+++ b/src/main/resources/db/changelog/changesets/db.changesets-5.53.yaml
@@ -32,6 +32,24 @@ databaseChangeLog:
       changes:
         - sql:
             dbms: postgresql
+            sql: "DELETE FROM disable_user_reason WHERE entra_description = 'NotActive' AND name = 'NotActive'"
+
+  # Fix FK references before removing duplicate NotActive entry (for envs where the delete failed due to FK constraint)
+  - changeSet:
+      id: fix-not-active-fk-references
+      author: paul.snowdon
+      comment:
+        "Reassign user_account_status_audit FK references from the duplicate
+        NotActive entry to the canonical Not Active entry, then delete the duplicate.
+        Required for environments where remove-duplicate-not-active failed due to FK constraint."
+      preConditions:
+        - onFail: MARK_RAN
+        - sqlCheck:
+            expectedResult: "1"
+            sql: "SELECT CASE WHEN COUNT(*) > 0 THEN 1 ELSE 0 END FROM disable_user_reason WHERE entra_description = 'NotActive' AND name = 'NotActive'"
+      changes:
+        - sql:
+            dbms: postgresql
             sql: >-
               UPDATE user_account_status_audit
               SET disable_user_reason_id = (SELECT id FROM disable_user_reason WHERE entra_description = 'NotActive' AND name = 'Not Active')

--- a/src/main/resources/db/changelog/changesets/db.changesets-5.53.yaml
+++ b/src/main/resources/db/changelog/changesets/db.changesets-5.53.yaml
@@ -32,7 +32,11 @@ databaseChangeLog:
       changes:
         - sql:
             dbms: postgresql
-            sql: "DELETE FROM disable_user_reason WHERE entra_description = 'NotActive' AND name = 'NotActive'"
+            sql: >-
+              UPDATE user_account_status_audit
+              SET disable_user_reason_id = (SELECT id FROM disable_user_reason WHERE entra_description = 'NotActive' AND name = 'Not Active')
+              WHERE disable_user_reason_id = (SELECT id FROM disable_user_reason WHERE entra_description = 'NotActive' AND name = 'NotActive');
+              DELETE FROM disable_user_reason WHERE entra_description = 'NotActive' AND name = 'NotActive'
 
   # Add unique constraint on entra_description to prevent future duplicates
   - changeSet:


### PR DESCRIPTION
### Description :pencil:

Reassigns audit table FK references from the duplicate NotActive entry to the canonical Not Active entry, then deletes the duplicate.

---

### Changes Made :pencil:

This pull request updates a database migration script to ensure data consistency before deleting a specific record from the `disable_user_reason` table. It first updates related entries in the `user_account_status_audit` table to reference the correct `disable_user_reason` record, then deletes the duplicate record.

**Database migration improvements:**

* In `db.changesets-5.53.yaml`, updated the SQL to first reassign any `user_account_status_audit` references from the soon-to-be-deleted `disable_user_reason` record (`entra_description = 'NotActive' AND name = 'NotActive'`) to the correct record (`entra_description = 'NotActive' AND name = 'Not Active'`), and then delete the duplicate record.
---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [ ] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [x] I have a corresponding JIRA ticket for this change 
- [ ] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:

Please fill in.

---