### PR TITLE
STB-4203 - Remove duplicate NotActive entries and update FK references in user_account_status_audit

### DIFF
--- a/src/main/resources/db/changelog/changesets/db.changesets-5.53.yaml
+++ b/src/main/resources/db/changelog/changesets/db.changesets-5.53.yaml
@@ -21,7 +21,6 @@ databaseChangeLog:
   - changeSet:
       id: remove-duplicate-not-active
       author: paul.snowdon
-      validCheckSum: ANY
       comment: "Remove duplicate NotActive disable_user_reason entries.
         Keep the entry from changesets-5.51 (name='Not Active') and remove
         the entry from changesets-5.49 (name='NotActive').

--- a/src/main/resources/db/changelog/changesets/db.changesets-5.53.yaml
+++ b/src/main/resources/db/changelog/changesets/db.changesets-5.53.yaml
@@ -21,9 +21,11 @@ databaseChangeLog:
   - changeSet:
       id: remove-duplicate-not-active
       author: paul.snowdon
+      validCheckSum: ANY
       comment: "Remove duplicate NotActive disable_user_reason entries.
         Keep the entry from changesets-5.51 (name='Not Active') and remove
-        the entry from changesets-5.49 (name='NotActive')"
+        the entry from changesets-5.49 (name='NotActive').
+        Reassigns any FK references in user_account_status_audit first to avoid constraint violations."
       preConditions:
         - onFail: MARK_RAN
         - sqlCheck:
@@ -32,7 +34,11 @@ databaseChangeLog:
       changes:
         - sql:
             dbms: postgresql
-            sql: "DELETE FROM disable_user_reason WHERE entra_description = 'NotActive' AND name = 'NotActive'"
+            sql: >-
+              UPDATE user_account_status_audit
+              SET disable_user_reason_id = (SELECT id FROM disable_user_reason WHERE entra_description = 'NotActive' AND name = 'Not Active')
+              WHERE disable_user_reason_id = (SELECT id FROM disable_user_reason WHERE entra_description = 'NotActive' AND name = 'NotActive');
+              DELETE FROM disable_user_reason WHERE entra_description = 'NotActive' AND name = 'NotActive'
 
   # Fix FK references before removing duplicate NotActive entry (for envs where the delete failed due to FK constraint)
   - changeSet:


### PR DESCRIPTION
### Description :pencil:

`remove-duplicate-not-active` did a bare DELETE without first reassigning FK references in `user_account_status_audit`, causing the FK constraint violation on NLE (where those audit rows exist)
The `fix-not-active-fk-references changese`t was meant as a follow-up fix, but could never execute because the failing changeset blocked the entire migration

---

### Changes Made :pencil:

This pull request updates the database changelog to safely remove a duplicate `NotActive` entry from the `disable_user_reason` table. The changes ensure that any foreign key references are reassigned before the duplicate is deleted, preventing constraint violations.

Database migration improvements:

* Added a step to update the `user_account_status_audit` table, reassigning any foreign key references from the duplicate `disable_user_reason` entry (`name='NotActive'`) to the correct one (`name='Not Active'`) before deletion.
* Updated the change set comment to clarify that foreign key references are reassigned before removing the duplicate, and added `validCheckSum: ANY` for flexibility in migration runs.

---

### Checklist :pencil:

- [x] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [ ] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [x] I have a corresponding JIRA ticket for this change 
- [ ] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:

Please fill in.

---