### PR TITLE
STB-4288: Update to ingress server-snippet to block HTTP/1.1

### DIFF
--- a/deployments/templates/landing-page-ingress.yml
+++ b/deployments/templates/landing-page-ingress.yml
@@ -13,10 +13,6 @@ metadata:
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/ssl-ciphers: "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-CHACHA20-POLY1305"
     nginx.ingress.kubernetes.io/ssl-protocols: "TLSv1.2 TLSv1.3"
-    nginx.ingress.kubernetes.io/server-snippet: |
-      if ($server_protocol !~ "^HTTP/2") {
-        return 426;
-      }
     nginx.ingress.kubernetes.io/configuration-snippet: |
       more_set_headers "Strict-Transport-Security: max-age=31536000; includeSubDomains; preload";
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
@@ -25,6 +21,10 @@ metadata:
       SecDefaultAction "phase:2,pass,log,tag:github_team=laa-portal-stabilisation-tech"
       SecDebugLogLevel 1
       SecRule REQUEST_URI "@beginsWith /api/v1/claims/enrich" "id:10001,phase:2,pass,nolog,ctl:ruleRemoveById=942100,ctl:ruleRemoveById=942151"
+    nginx.ingress.kubernetes.io/server-snippet: |
+      if ($server_protocol = "HTTP/1.1") {
+        return 426;
+      }
 spec:
   ingressClassName: ${INGRESS_CLASS_NAME}
   tls:


### PR DESCRIPTION
### Description :pencil:

Added Ingress server snippet to block HTTP/1.1.

---

### Changes Made :pencil:

- Update to ingress manifest to block HTTP/1.1
- 
- 

---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [x] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [x] I have a corresponding JIRA ticket for this change 
- [ ] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:

Changed condition logic to use = rather than !~, which the validation on the ingress didn't like.

---