### PR TITLE
STB-4288: Added server snippet to return 426 for HTTP 1.1

### DIFF
--- a/deployments/templates/landing-page-ingress.yml
+++ b/deployments/templates/landing-page-ingress.yml
@@ -21,6 +21,10 @@ metadata:
       SecDefaultAction "phase:2,pass,log,tag:github_team=laa-portal-stabilisation-tech"
       SecDebugLogLevel 1
       SecRule REQUEST_URI "@beginsWith /api/v1/claims/enrich" "id:10001,phase:2,pass,nolog,ctl:ruleRemoveById=942100,ctl:ruleRemoveById=942151"
+    nginx.ingress.kubernetes.io/server-snippet: |
+      if ($server_protocol = "HTTP/1.1") {
+        return 426;
+      }
 spec:
   ingressClassName: ${INGRESS_CLASS_NAME}
   tls:


### PR DESCRIPTION
### Description :pencil:

Added ingress server snippet to block HTTP/1.1. This deployment is working in isolation, so hopefully previous deployment issue is resolved.

---

### Changes Made :pencil:

- Added server-snippet to ingress to block HTTP/1.1
- 
- 

---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [x] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [x] I have a corresponding JIRA ticket for this change 
- [ ] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:


---