### PR TITLE
STB-3863 - ZAP scans

### DIFF
--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/config/SecurityConfig.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/config/SecurityConfig.java
@@ -27,6 +27,7 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtAut
 import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.header.writers.StaticHeadersWriter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.AnyRequestMatcher;
 import org.springframework.security.web.util.matcher.IpAddressMatcher;
@@ -193,7 +194,8 @@ public class SecurityConfig {
                         .policyDirectives("default-src * self blob: data: gap:; style-src * self 'unsafe-inline' blob: data: gap:;"
                                 + " script-src * 'self' 'unsafe-eval' 'unsafe-inline' blob: data: gap:; object-src * 'self' blob: data: gap:;"
                                 + " img-src * self 'unsafe-inline' blob: data: gap:; connect-src self * 'unsafe-inline' blob: data: gap:;"
-                                + " frame-src * self blob: data: gap:;"))
+                                + " frame-src * self blob: data: gap:; frame-ancestors 'none';"))
+                .addHeaderWriter(new StaticHeadersWriter("Cross-Origin-Embedder-Policy-Report-Only", "require-corp"))
         );
         return http.build();
     }

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/config/SecurityConfig.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/config/SecurityConfig.java
@@ -191,10 +191,15 @@ public class SecurityConfig {
                         .requestMatcher(AnyRequestMatcher.INSTANCE)
                 )
                 .contentSecurityPolicy(contentSecurityPolicyConfig -> contentSecurityPolicyConfig
-                        .policyDirectives("default-src * self blob: data: gap:; style-src * self 'unsafe-inline' blob: data: gap:;"
-                                + " script-src * 'self' 'unsafe-eval' 'unsafe-inline' blob: data: gap:; object-src * 'self' blob: data: gap:;"
-                                + " img-src * self 'unsafe-inline' blob: data: gap:; connect-src self * 'unsafe-inline' blob: data: gap:;"
-                                + " frame-src * self blob: data: gap:; frame-ancestors 'none';"))
+                        .policyDirectives("default-src 'self';"
+                                + " script-src 'self' 'unsafe-inline' https://code.jquery.com;"
+                                + " style-src 'self' 'unsafe-inline';"
+                                + " img-src 'self' data:;"
+                                + " connect-src 'self';"
+                                + " font-src 'self';"
+                                + " object-src 'none';"
+                                + " frame-src 'none';"
+                                + " frame-ancestors 'none';"))
                 .addHeaderWriter(new StaticHeadersWriter("Cross-Origin-Embedder-Policy-Report-Only", "require-corp"))
         );
         return http.build();

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/config/SecurityConfigTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/config/SecurityConfigTest.java
@@ -1,60 +1,90 @@
 package uk.gov.justice.laa.portal.landingpage.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
-import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import java.util.Arrays;
-import java.util.stream.Collectors;
-
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
-import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.mock.web.MockHttpSession;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
-import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
-import org.springframework.security.oauth2.core.AuthorizationGrantType;
-import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
-import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
-import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.context.WebApplicationContext;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
 import uk.gov.justice.laa.portal.landingpage.config.jwt.DevJwtDecoderConfig;
-import uk.gov.justice.laa.portal.landingpage.entity.Permission;
 import uk.gov.justice.laa.portal.landingpage.service.AuthzOidcUserDetailsService;
 import uk.gov.justice.laa.portal.landingpage.service.CustomLogoutHandler;
-import uk.gov.justice.laa.portal.landingpage.service.UserService;
+import uk.gov.justice.laa.portal.landingpage.service.LoginService;
 
 @WebMvcTest(controllers = TestController.class)
-//@Import({SecurityConfig.class, DevJwtDecoderConfig.class, SecurityConfigTest.OauthClientTestConfig.class})
+@Import({SecurityConfig.class, DevJwtDecoderConfig.class, SecurityConfigTest.OauthClientTestConfig.class})
 @ActiveProfiles("test")
 class SecurityConfigTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private AuthzOidcUserDetailsService authzOidcUserDetailsService;
+
+    @MockitoBean
+    private CustomLogoutHandler logoutHandler;
+
+    @MockitoBean
+    private UserDisabledFilter userDisabledFilter;
+
+    @MockitoBean
+    private FirmDisabledFilter firmDisabledFilter;
+
+    @MockitoBean
+    private JdbcOperations jdbcOperations;
+
+    @MockitoBean
+    private LoginService loginService;
+
+    @TestConfiguration
+    static class OauthClientTestConfig {
+        @Bean
+        public ClientRegistrationRepository clientRegistrationRepository() {
+            return new CustomRepository();
+        }
+
+        public static class CustomRepository implements ClientRegistrationRepository {
+            public CustomRepository() {
+                // Empty repository for testing
+            }
+
+            @Override
+            public ClientRegistration findByRegistrationId(String registrationId) {
+                return null;
+            }
+        }
+    }
+
+    @Test
+    void securityHeaders() throws Exception {
+        MvcResult mvcResult = mockMvc.perform(get("/")).andReturn();
+        String sts = mvcResult.getResponse().getHeader("Strict-Transport-Security");
+        String csp = mvcResult.getResponse().getHeader("Content-Security-Policy");
+        String coep = mvcResult.getResponse().getHeader("Cross-Origin-Embedder-Policy-Report-Only");
+        assertThat(sts).isEqualTo("max-age=63072000 ; includeSubDomains ; preload");
+        assertThat(csp).isEqualTo("default-src 'self';"
+                + " script-src 'self' 'unsafe-inline' https://code.jquery.com;"
+                + " style-src 'self' 'unsafe-inline';"
+                + " img-src 'self' data:;"
+                + " connect-src 'self';"
+                + " font-src 'self';"
+                + " object-src 'none';"
+                + " frame-src 'none';"
+                + " frame-ancestors 'none';");
+        assertThat(coep).isEqualTo("require-corp");
+    }
+
 /*
     @Test
     void adminEndpointsRequireAdminRole() throws Exception {
@@ -102,7 +132,7 @@ class SecurityConfigTest {
 
     @Autowired
     private WebApplicationContext context;
-    
+
     @Autowired
     private MockMvc mockMvc;
 
@@ -179,7 +209,7 @@ class SecurityConfigTest {
             }
         }
     }
-    
+
     @Test
     @WithMockUser
     void postRequestsRequireCsrfToken() throws Exception {
@@ -188,13 +218,13 @@ class SecurityConfigTest {
                 .webAppContextSetup(context)
                 .apply(springSecurity())
                 .build();
-        
+
         csrfMockMvc.perform(post("/secure")
                         .contentType(MediaType.APPLICATION_FORM_URLENCODED))
                 .andDo(MockMvcResultHandlers.print())
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("/?message=session-expired"));
-        
+
         csrfMockMvc.perform(post("/secure")
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_FORM_URLENCODED))
@@ -213,7 +243,7 @@ class SecurityConfigTest {
                 .andExpect(status().isOk())
                 .andExpect(content().string("claims-enrich"));
     }
-    
+
     @Test
     void claimsEnrichEndpointRequiresJwtAuthentication() throws Exception {
         // Without JWT - should be unauthorized (401)
@@ -266,19 +296,24 @@ class SecurityConfigTest {
         String sts = mvcResult.getResponse().getHeader("Strict-Transport-Security");
         String csp = mvcResult.getResponse().getHeader("Content-Security-Policy");
         assertThat(sts).isEqualTo("max-age=63072000 ; includeSubDomains ; preload");
-        assertThat(csp).isEqualTo("default-src * self blob: data: gap:; style-src * self 'unsafe-inline' blob: data: gap:;"
-                + " script-src * 'self' 'unsafe-eval' 'unsafe-inline' blob: data: gap:; object-src * 'self' blob: data: gap:;"
-                + " img-src * self 'unsafe-inline' blob: data: gap:; connect-src self * 'unsafe-inline' blob: data: gap:;"
-                + " frame-src * self blob: data: gap:;");
+        assertThat(csp).isEqualTo("default-src 'self';"
+                + " script-src 'self' 'unsafe-inline' https://code.jquery.com;"
+                + " style-src 'self' 'unsafe-inline';"
+                + " img-src 'self' data:;"
+                + " connect-src 'self';"
+                + " font-src 'self';"
+                + " object-src 'none';"
+                + " frame-src 'none';"
+                + " frame-ancestors 'none';");
     }
 
     @Test
     void authorizationRequestResolverBeanCreation() {
         SecurityConfig securityConfig = new SecurityConfig(authzOidcUserDetailsService, logoutHandler);
         ClientRegistrationRepository clientRegistrationRepository = createMockClientRegistrationRepository();
-        
+
         OAuth2AuthorizationRequestResolver resolver = securityConfig.authorizationRequestResolver(clientRegistrationRepository);
-        
+
         assertThat(resolver).isNotNull();
     }
 
@@ -286,16 +321,16 @@ class SecurityConfigTest {
     void authorizationRequestResolverAddsPromptSelectAccountParameter() {
         SecurityConfig securityConfig = new SecurityConfig(authzOidcUserDetailsService, logoutHandler);
         ClientRegistrationRepository clientRegistrationRepository = createMockClientRegistrationRepository();
-        
+
         OAuth2AuthorizationRequestResolver resolver = securityConfig.authorizationRequestResolver(clientRegistrationRepository);
-        
+
         // Create a mock HTTP request for testing
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.setServletPath("/oauth2/authorization/azure");
-        
+
         // Test that the resolver creates an authorization request with prompt=select_account
         OAuth2AuthorizationRequest authorizationRequest = resolver.resolve(request);
-        
+
         if (authorizationRequest != null) {
             assertThat(authorizationRequest.getAdditionalParameters())
                     .containsEntry("prompt", "select_account");
@@ -304,7 +339,7 @@ class SecurityConfigTest {
 
     private ClientRegistrationRepository createMockClientRegistrationRepository() {
         ClientRegistrationRepository repository = mock(ClientRegistrationRepository.class);
-        
+
         ClientRegistration clientRegistration = ClientRegistration.withRegistrationId("azure")
                 .clientId("test-client-id")
                 .clientSecret("test-client-secret")
@@ -316,7 +351,7 @@ class SecurityConfigTest {
                 .userNameAttributeName("sub")
                 .clientName("Azure AD")
                 .build();
-        
+
         when(repository.findByRegistrationId("azure")).thenReturn(clientRegistration);
         return repository;
     }
@@ -325,16 +360,16 @@ class SecurityConfigTest {
     void authorizationRequestResolver_shouldBeConfiguredCorrectly() {
         // Arrange
         ClientRegistrationRepository clientRegistrationRepository = mock(ClientRegistrationRepository.class);
-        
+
         // Act
         OAuth2AuthorizationRequestResolver resolver = securityConfig.authorizationRequestResolver(clientRegistrationRepository);
-        
+
         // Assert
         assertThat(resolver).isNotNull();
         // The resolver is configured to add prompt=login parameter in the SecurityConfig
         // This test verifies that the bean is properly created
     }
-    
+
     @Test
     void securityConfig_shouldBeAutowired() {
         // This test verifies that the SecurityConfig is properly configured and can be autowired

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/config/SecurityConfigTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/config/SecurityConfigTest.java
@@ -85,7 +85,7 @@ class SecurityConfigTest {
         assertThat(coep).isEqualTo("require-corp");
     }
 
-/*
+    /*
     @Test
     void adminEndpointsRequireAdminRole() throws Exception {
         // Without admin role - should be redirected


### PR DESCRIPTION
Enhance security headers by adding 'frame-ancestors' directive and Cross-Origin-Embedder-Policy-Report-Only header

### Description :pencil:

Please fill in.

---

### Changes Made :pencil:

This pull request updates the security configuration to enhance the application's security headers. The most important changes are the tightening of the Content Security Policy (CSP) and the addition of a new security-related HTTP header.

**Security configuration improvements:**

* Updated the CSP to include `frame-ancestors 'none'`, which prevents the application from being embedded in iframes on other sites, mitigating clickjacking attacks.
* Added a `Cross-Origin-Embedder-Policy-Report-Only: require-corp` HTTP header using `StaticHeadersWriter`, which is a step towards enabling cross-origin isolation for enhanced security and compatibility with certain web APIs. [[1]](diffhunk://#diff-991950b6982af74ef2fc48c077c00bc8bd31fe6e53a317295cab06bb21bad270L196-R198) [[2]](diffhunk://#diff-991950b6982af74ef2fc48c077c00bc8bd31fe6e53a317295cab06bb21bad270R30)

---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [ ] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [x] I have a corresponding JIRA ticket for this change 
- [ ] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:

Please fill in.

---