### PR TITLE
STB-4320: Fixed bug where users with no profiles cannot access account details.

### DIFF
--- a/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/BaseIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/BaseIntegrationTest.java
@@ -1,7 +1,9 @@
 package uk.gov.justice.laa.portal.landingpage.controller;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -161,12 +163,17 @@ public abstract class BaseIntegrationTest extends BaseRepositoryTest {
         EntraUser freshUser = entraUserRepository.findByIdWithAssociations(user.getId())
                 .orElseThrow(() -> new RuntimeException("User not found: " + user.getId()));
 
-        Set<Permission> userPermissions = freshUser.getUserProfiles().stream()
-                .findFirst()
-                .orElseThrow()
-                .getAppRoles().stream()
-                .flatMap(appRole -> appRole.getPermissions().stream())
-                .collect(Collectors.toSet());
+        Optional<UserProfile> profile = freshUser.getUserProfiles().stream()
+                .findFirst();
+
+        Set<Permission> userPermissions = new HashSet<>();
+
+        if (profile.isPresent()) {
+            userPermissions = profile.get()
+                    .getAppRoles().stream()
+                    .flatMap(appRole -> appRole.getPermissions().stream())
+                    .collect(Collectors.toSet());
+        }
 
         Set<SimpleGrantedAuthority> authorities = userPermissions.stream()
                 .map(permission -> new SimpleGrantedAuthority(permission.name()))

--- a/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/HomeControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/HomeControllerIntegrationTest.java
@@ -1,0 +1,55 @@
+package uk.gov.justice.laa.portal.landingpage.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MvcResult;
+import uk.gov.justice.laa.portal.landingpage.entity.EntraUser;
+import uk.gov.justice.laa.portal.landingpage.entity.UserProfile;
+import uk.gov.justice.laa.portal.landingpage.entity.UserType;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+public class HomeControllerIntegrationTest extends BaseIntegrationTest {
+
+    @Test
+    public void testUserWithProfileGetsAccountDetails() throws Exception {
+        // Set up user with a user profile.
+        EntraUser userWithProfile = buildEntraUser(UUID.randomUUID().toString(), "userWithProfile@test.com", "Test", "User");
+        userWithProfile = entraUserRepository.saveAndFlush(userWithProfile);
+        UserProfile profile = buildLaaUserProfile(userWithProfile, UserType.INTERNAL, true);
+        profile = userProfileRepository.saveAndFlush(profile);
+
+        // Access account details and assert success
+        MvcResult result = sendMyAccountDetailsGet(userWithProfile);
+        assertThat(result.getResponse()).isNotNull();
+        assertThat(result.getResponse().getStatus()).isEqualTo(200);
+
+        // Teardown
+        userProfileRepository.delete(profile);
+        entraUserRepository.delete(userWithProfile);
+    }
+
+    @Test
+    public void testUserWithoutProfileGetsAccountDetails() throws Exception {
+        // Set up user with no user profile
+        EntraUser userWithoutProfile = buildEntraUser(UUID.randomUUID().toString(), "userWithProfile@test.com", "Test", "User");
+        userWithoutProfile = entraUserRepository.saveAndFlush(userWithoutProfile);
+
+        // Access account details and assert success
+        MvcResult result = sendMyAccountDetailsGet(userWithoutProfile);
+        assertThat(result.getResponse()).isNotNull();
+        assertThat(result.getResponse().getStatus()).isEqualTo(200);
+
+        // Teardown
+        entraUserRepository.delete(userWithoutProfile);
+    }
+
+
+    private MvcResult sendMyAccountDetailsGet(EntraUser loggedInUser) throws Exception {
+        return this.mockMvc.perform(get("/home/my-account-details")
+                        .with(userOauth2Login(loggedInUser)))
+                        .andReturn();
+    }
+}

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/HomeController.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/HomeController.java
@@ -1,6 +1,8 @@
 package uk.gov.justice.laa.portal.landingpage.controller;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -51,39 +53,49 @@ public class HomeController {
 
     @GetMapping("/my-account-details")
     public String myAccountDetails(Model model, Authentication authentication) {
-        UserProfile currentUserProfile = loginService.getCurrentProfile(authentication);
-        EntraUser entraUser = currentUserProfile.getEntraUser();
-        Set<Office> userOffices = currentUserProfile.getOffices();
-
+        EntraUser entraUser = loginService.getCurrentEntraUser(authentication);
+        Optional<UserProfile> currentUserProfileOptional = Optional.ofNullable(loginService.getCurrentProfile(authentication));
         EntraUserDto user = mapper.map(entraUser, EntraUserDto.class);
+        boolean isMultiFirmUser = entraUser.isMultiFirmUser();
 
-        Set<AppDto> userAssignedApps = userService.getUserAppsByUserId(currentUserProfile.getId().toString());
-        List<AppRoleDto> userAssignedAppRoles = userService
-                .getUserAppRolesByUserId(currentUserProfile.getId().toString());
-
-        List<String> accessPermission = List.of("Access");
+        // Default values which require a profile for users with no profiles.
         Map<String, List<String>> appAssignments = new HashMap<>();
-        for (AppDto appDto : userAssignedApps) {
-            Optional<App> optionalApp = appService.getById(UUID.fromString(appDto.getId()));
-            if (optionalApp.isPresent()) {
-                App app = optionalApp.get();
-                List<String> appRoles = userAssignedAppRoles.stream()
-                        .filter(ar -> ar.getApp().getName().equals(app.getName()))
-                        .map(AppRoleDto::getName).toList();
-                if (app.getAppRoles().size() > 1) {
-                    appAssignments.put(appDto.getName(), appRoles);
-                } else {
-                    appAssignments.put(appDto.getName(), accessPermission);
+        FirmDto firmDto = null;
+        List<OfficeDto> offices = new ArrayList<>();
+        boolean isUserManager = false;
+        boolean isInternalUser = false;
+        boolean unrestrictedOfficeAccess = false;
+
+        if (currentUserProfileOptional.isPresent()) {
+            UserProfile currentUserProfile = currentUserProfileOptional.get();
+            Set<AppDto> userAssignedApps = userService.getUserAppsByUserId(currentUserProfile.getId().toString());
+            List<AppRoleDto> userAssignedAppRoles = userService
+                    .getUserAppRolesByUserId(currentUserProfile.getId().toString());
+            List<String> accessPermission = List.of("Access");
+            for (AppDto appDto : userAssignedApps) {
+                Optional<App> optionalApp = appService.getById(UUID.fromString(appDto.getId()));
+                if (optionalApp.isPresent()) {
+                    App app = optionalApp.get();
+                    List<String> appRoles = userAssignedAppRoles.stream()
+                            .filter(ar -> ar.getApp().getName().equals(app.getName()))
+                            .map(AppRoleDto::getName).toList();
+                    if (app.getAppRoles().size() > 1) {
+                        appAssignments.put(appDto.getName(), appRoles);
+                    } else {
+                        appAssignments.put(appDto.getName(), accessPermission);
+                    }
                 }
             }
-        }
 
-        boolean isMultiFirmUser = user.isMultiFirmUser();
-        boolean isUserManager = currentUserProfile.getAppRoles().stream()
-                .anyMatch(role -> "Firm User Manager".equals(role.getName()));
-        Firm userFirm = currentUserProfile.getFirm();
-        FirmDto firmDto = userFirm != null ? mapper.map(userFirm, FirmDto.class) : null;
-        List<OfficeDto> offices = userOffices.stream().map(office -> mapper.map(office, OfficeDto.class)).toList();
+            isUserManager = currentUserProfile.getAppRoles().stream()
+                    .anyMatch(role -> "Firm User Manager".equals(role.getName()));
+            Firm userFirm = currentUserProfile.getFirm();
+            firmDto = userFirm != null ? mapper.map(userFirm, FirmDto.class) : null;
+            Set<Office> userOffices = currentUserProfile.getOffices();
+            offices = userOffices.stream().map(office -> mapper.map(office, OfficeDto.class)).toList();
+            isInternalUser = currentUserProfile.getUserType().equals(UserType.INTERNAL);
+            unrestrictedOfficeAccess = currentUserProfile.isUnrestrictedOfficeAccess();
+        }
 
         model.addAttribute("user", user);
         model.addAttribute("isMultiFirmUser", isMultiFirmUser);
@@ -91,8 +103,8 @@ public class HomeController {
         model.addAttribute("userOffices", offices);
         model.addAttribute("firm", firmDto);
         model.addAttribute("appAssignments", appAssignments);
-        model.addAttribute("isInternalUser", currentUserProfile.getUserType().equals(UserType.INTERNAL));
-        model.addAttribute("unrestrictedOfficeAccess", currentUserProfile.isUnrestrictedOfficeAccess());
+        model.addAttribute("isInternalUser", isInternalUser);
+        model.addAttribute("unrestrictedOfficeAccess", unrestrictedOfficeAccess);
 
         model.addAttribute(ModelAttributes.PAGE_TITLE, "My Account - " + user.getFullName());
 

--- a/src/main/resources/templates/home/my-account-details.html
+++ b/src/main/resources/templates/home/my-account-details.html
@@ -96,7 +96,7 @@
                         <h2 class="govuk-summary-card__title">Services</h2>
                     </div>
                     <div class="govuk-summary-card__content">
-                        <dl th:if="${!#lists.isEmpty(appAssignments)}" class="govuk-summary-list">
+                        <dl th:if="${!#maps.isEmpty(appAssignments)}" class="govuk-summary-list">
                             <div th:each="appAssignment : ${appAssignments}" class="govuk-summary-list__row">
                                 <dt class="govuk-summary-list__key" th:text="${appAssignment.key}">Service name</dt>
                                 <dd class="govuk-summary-list__value">
@@ -106,7 +106,7 @@
                                 </dd>
                             </div>
                         </dl>
-                        <p th:if="${#lists.isEmpty(appAssignments)}" class="govuk-body">No services assigned</p>
+                        <p th:if="${#maps.isEmpty(appAssignments)}" class="govuk-body">No services assigned</p>
                     </div>
                 </div>
 

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/HomeControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/HomeControllerTest.java
@@ -116,6 +116,7 @@ class HomeControllerTest {
 
         // Arrange: Mock service responses
         when(loginService.getCurrentProfile(authentication)).thenReturn(userProfile);
+        when(loginService.getCurrentEntraUser(authentication)).thenReturn(entraUser);
         when(userService.getUserAppsByUserId(any())).thenReturn(Set.of(appDto));
         when(userService.getUserAppRolesByUserId(any())).thenReturn(List.of(appRoleDto));
         when(appService.getById(any())).thenReturn(Optional.of(app));
@@ -200,6 +201,7 @@ class HomeControllerTest {
 
         // Arrange: Mock service responses
         when(loginService.getCurrentProfile(authentication)).thenReturn(userProfile);
+        when(loginService.getCurrentEntraUser(authentication)).thenReturn(entraUser);
         when(userService.getUserAppsByUserId(any())).thenReturn(Set.of(appDto));
         when(userService.getUserAppRolesByUserId(any())).thenReturn(List.of(appRoleDto));
         when(appService.getById(any())).thenReturn(Optional.of(app));
@@ -291,6 +293,7 @@ class HomeControllerTest {
 
         // Mock service responses
         when(loginService.getCurrentProfile(authentication)).thenReturn(userProfile);
+        when(loginService.getCurrentEntraUser(authentication)).thenReturn(entraUser);
         when(userService.getUserAppsByUserId(any())).thenReturn(Set.of(appDto));
         when(userService.getUserAppRolesByUserId(any())).thenReturn(List.of(appRoleDto));
         when(appService.getById(appId)).thenReturn(Optional.of(app));


### PR DESCRIPTION
### Description :pencil:

Multi-firm users with no profile would get sent to an error page due to NPE if they try to access the account details page. This refactor fixes that.

---

### Changes Made :pencil:

- Changed controller logic to default profile-specific values.
- Fixed minor bug in template where "no services assigned" would not appear.
- Updated integration test login logic to allow users with no profiles to log in.
- Added integration tests for account details page.

---

### Checklist :pencil:

- [X] I have added the relevant Liquibase changelog files for any entity changes
- [X] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [X] I have taken into account the application runs as 3 replicas in live environments
- [X] I have created any relevant documentation for this change
- [X] I have a corresponding JIRA ticket for this change 
- [X] I have added relevant unit & integration tests where applicable

---