### PR TITLE
STB-4164 - Add export button update logic for firm selection in user audit

### DIFF
--- a/src/main/resources/templates/user-audit/users.html
+++ b/src/main/resources/templates/user-audit/users.html
@@ -590,6 +590,7 @@
 
                     if (query.length < 3) {
                         firmSearchIdInput.value = '';
+                        updateExportButton();
                         hideResults();
                         return;
                     }
@@ -732,6 +733,7 @@
                 function selectFirm(firm) {
                     firmSearchInput.value = firm.name;
                     firmSearchIdInput.value = firm.id;
+                    updateExportButton();
                     hideResults();
                     updateStatus(`${firm.name} selected`);
                 }
@@ -772,6 +774,35 @@
                 function updateStatus(message) {
                     currentStatusElement = currentStatusElement === statusA ? statusB : statusA;
                     currentStatusElement.textContent = message;
+                }
+
+                function updateExportButton() {
+                    const exportLink = document.querySelector('.js-export-csv');
+                    if (!exportLink) return;
+
+                    const firmId = firmSearchIdInput.value;
+                    const firmName = firmSearchInput.value.trim();
+                    const currentUrl = new URL(window.location.href);
+                    const selectedUserType = currentUrl.searchParams.get('selectedUserType') || '';
+                    const firmSelected = firmId !== '' || selectedUserType === 'INTERNAL';
+
+                    exportLink.setAttribute('data-firm-selected', firmSelected ? 'true' : 'false');
+
+                    if (firmSelected) {
+                        const params = {
+                            search: currentUrl.searchParams.get('search'),
+                            selectedFirmId: firmId || currentUrl.searchParams.get('selectedFirmId'),
+                            silasRole: currentUrl.searchParams.get('silasRole'),
+                            selectedAppId: currentUrl.searchParams.get('selectedAppId'),
+                            selectedUserType: currentUrl.searchParams.get('selectedUserType'),
+                            selectedFirmName: firmId ? firmName : currentUrl.searchParams.get('selectedFirmName'),
+                            neverActivated: currentUrl.searchParams.get('neverActivated'),
+                            inactiveSinceDate: currentUrl.searchParams.get('inactiveSinceDate')
+                        };
+                        exportLink.href = buildCleanUrl('/admin/users/audit/download', params);
+                    } else {
+                        exportLink.href = '#';
+                    }
                 }
 
                 // SiLAS Role filter auto-submit

--- a/src/main/resources/templates/user-audit/users.html
+++ b/src/main/resources/templates/user-audit/users.html
@@ -588,9 +588,10 @@
                     clearTimeout(searchTimeout);
                     const query = this.value.trim();
 
+                    firmSearchIdInput.value = '';
+                    updateExportButton();
+
                     if (query.length < 3) {
-                        firmSearchIdInput.value = '';
-                        updateExportButton();
                         hideResults();
                         return;
                     }
@@ -789,13 +790,14 @@
                     exportLink.setAttribute('data-firm-selected', firmSelected ? 'true' : 'false');
 
                     if (firmSelected) {
+                        const isInternal = selectedUserType === 'INTERNAL';
                         const params = {
                             search: currentUrl.searchParams.get('search'),
-                            selectedFirmId: firmId || currentUrl.searchParams.get('selectedFirmId'),
+                            selectedFirmId: isInternal ? null : (firmId || currentUrl.searchParams.get('selectedFirmId')),
                             silasRole: currentUrl.searchParams.get('silasRole'),
                             selectedAppId: currentUrl.searchParams.get('selectedAppId'),
                             selectedUserType: currentUrl.searchParams.get('selectedUserType'),
-                            selectedFirmName: firmId ? firmName : currentUrl.searchParams.get('selectedFirmName'),
+                            selectedFirmName: isInternal ? null : (firmId ? firmName : currentUrl.searchParams.get('selectedFirmName')),
                             neverActivated: currentUrl.searchParams.get('neverActivated'),
                             inactiveSinceDate: currentUrl.searchParams.get('inactiveSinceDate')
                         };
@@ -804,6 +806,8 @@
                         exportLink.href = '#';
                     }
                 }
+
+                updateExportButton();
 
                 // SiLAS Role filter auto-submit
                 const silasRoleFilter = document.getElementById('silasRoleFilter');

--- a/src/playwrightTest/java/uk/gov/justice/laa/portal/landingpage/playwright/tests/AuditPageTest.java
+++ b/src/playwrightTest/java/uk/gov/justice/laa/portal/landingpage/playwright/tests/AuditPageTest.java
@@ -172,14 +172,14 @@ public class AuditPageTest extends BaseFrontEndTest {
     }
 
     @Test
-    @DisplayName("Selecting a firm in the autocomplete without submitting still shows the CSV error banner")
-    void exportCsv_withFirmSelectedButNotApplied_showsErrorBanner() {
-        // data-firm-selected is rendered server-side; filling the autocomplete client-side
-        // does not reload the page, so the button still considers no firm selected.
+    @DisplayName("Selecting a firm in the autocomplete enables the CSV export button (no error banner)")
+    void exportCsv_withFirmSelectedViaAutocomplete_doesNotShowErrorBanner() {
+        // updateExportButton() is called when a firm is selected via the autocomplete,
+        // so data-firm-selected becomes true client-side and clicking export should not show the error banner.
         AuditPage auditPage = loginAndGetAuditPage(TestUser.GLOBAL_ADMIN);
         auditPage.searchAndSelectFirm("90001");
         auditPage.clickExportCsv();
-        auditPage.assertCsvErrorBannerVisible();
+        auditPage.assertCsvErrorBannerHidden();
     }
 
     @Test


### PR DESCRIPTION
### Description :pencil:

Add export button update logic for firm selection in user audit

---

### Changes Made :pencil:

This pull request enhances the user audit page by ensuring the export button's state and link are always in sync with the current firm selection and user type. The main improvement is the introduction of an `updateExportButton` function, which updates the export link's enabled state and URL parameters whenever the firm search input changes or a firm is selected.

**Export button behavior improvements:**

* Added a new `updateExportButton` function to dynamically update the export CSV link's `href` and a `data-firm-selected` attribute based on the current firm selection and user type. This ensures users can only export data when a firm is selected or the user type is "INTERNAL".
* Called `updateExportButton` after clearing the firm search input if the query is too short, ensuring the export button is disabled when appropriate.
* Called `updateExportButton` after a firm is selected, ensuring the export button is enabled and its link is updated with the correct parameters.

---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [ ] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [ ] I have a corresponding JIRA ticket for this change 
- [x] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:

Please fill in.

---