### PR TITLE
STB-3863: Added GH action workflow permissions to write to issues

### DIFF
--- a/.github/workflows/zap_dast_daily_dev.yml
+++ b/.github/workflows/zap_dast_daily_dev.yml
@@ -5,7 +5,8 @@ on:
     - cron: '0 8 * * 1-5' # At 08:00 on Monday through Friday
 
 permissions:
-  contents: none
+  contents: read
+  issues: write
 
 jobs:
   zap_scan:

--- a/.github/workflows/zap_dast_daily_prd.yml
+++ b/.github/workflows/zap_dast_daily_prd.yml
@@ -5,7 +5,8 @@ on:
     - cron: '0 3 * * 1-5' # At 03:00 on Monday through Friday
 
 permissions:
-  contents: none
+  contents: read
+  issues: write
 
 jobs:
   zap_scan:

--- a/.github/workflows/zap_dast_daily_test.yml
+++ b/.github/workflows/zap_dast_daily_test.yml
@@ -5,7 +5,8 @@ on:
     - cron: '0 8 * * 1-5' # At 08:00 on Monday through Friday
 
 permissions:
-  contents: none
+  contents: read
+  issues: write
 
 jobs:
   zap_scan:

--- a/.github/workflows/zap_dast_weekly_dev.yml
+++ b/.github/workflows/zap_dast_weekly_dev.yml
@@ -5,7 +5,8 @@ on:
     - cron: '0 8 * * SUN'
 
 permissions:
-  contents: none
+  contents: read
+  issues: write
 
 jobs:
   zap_scan:


### PR DESCRIPTION
### Description :pencil:

ZAP scans are failing due to permissions. 

---

### Changes Made :pencil:

- Update to GA action workflow permissions for ZAP scans
- 
- 

---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [x] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [x] I have a corresponding JIRA ticket for this change 
- [ ] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:


---