### PR TITLE
STB-3863 - Update ingress configuration and enhance security headers in Security Config

### DIFF
--- a/deployments/templates/landing-page-ingress.yml
+++ b/deployments/templates/landing-page-ingress.yml
@@ -10,6 +10,8 @@ metadata:
     nginx.ingress.kubernetes.io/session-cookie-hash: sha1
     nginx.ingress.kubernetes.io/session-cookie-expires: "172800"
     nginx.ingress.kubernetes.io/session-cookie-max-age: "172800"
+    nginx.ingress.kubernetes.io/session-cookie-samesite: "Lax"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/ssl-ciphers: "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-CHACHA20-POLY1305"
     nginx.ingress.kubernetes.io/ssl-protocols: "TLSv1.2 TLSv1.3"

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/config/SecurityConfig.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/config/SecurityConfig.java
@@ -200,7 +200,8 @@ public class SecurityConfig {
                                 + " object-src 'none';"
                                 + " frame-src 'none';"
                                 + " frame-ancestors 'none';"))
-                .addHeaderWriter(new StaticHeadersWriter("Cross-Origin-Embedder-Policy-Report-Only", "require-corp"))
+                .addHeaderWriter(new StaticHeadersWriter("Cross-Origin-Embedder-Policy", "require-corp"))
+                .addHeaderWriter(new StaticHeadersWriter("Permissions-Policy", "geolocation=(), camera=(), microphone=(), payment=(), usb=(), interest-cohort=()"))
         );
         return http.build();
     }

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/config/SecurityConfigTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/config/SecurityConfigTest.java
@@ -71,7 +71,8 @@ class SecurityConfigTest {
         MvcResult mvcResult = mockMvc.perform(get("/")).andReturn();
         String sts = mvcResult.getResponse().getHeader("Strict-Transport-Security");
         String csp = mvcResult.getResponse().getHeader("Content-Security-Policy");
-        String coep = mvcResult.getResponse().getHeader("Cross-Origin-Embedder-Policy-Report-Only");
+        String coep = mvcResult.getResponse().getHeader("Cross-Origin-Embedder-Policy");
+        String permissionsPolicy = mvcResult.getResponse().getHeader("Permissions-Policy");
         assertThat(sts).isEqualTo("max-age=63072000 ; includeSubDomains ; preload");
         assertThat(csp).isEqualTo("default-src 'self';"
                 + " script-src 'self' 'unsafe-inline' https://code.jquery.com;"
@@ -83,6 +84,7 @@ class SecurityConfigTest {
                 + " frame-src 'none';"
                 + " frame-ancestors 'none';");
         assertThat(coep).isEqualTo("require-corp");
+        assertThat(permissionsPolicy).isEqualTo("geolocation=(), camera=(), microphone=(), payment=(), usb=(), interest-cohort=()");
     }
 
     /*


### PR DESCRIPTION
Fix ZAP scan warnings: add ssl-redirect, Permissions-Policy header, enforce COEP, and set sticky cookie SameSite=Lax.
### Description :pencil:

STB-3863 - Update ingress configuration and enhance security headers in Security Config

---

### Changes Made :pencil:

This pull request introduces several important security enhancements to both the Kubernetes ingress configuration and the Spring Security HTTP headers. The main focus is on tightening cookie security, enforcing HTTPS, and strengthening browser security policies.

**Ingress and cookie security improvements:**

* Added `session-cookie-samesite: "Lax"` to the ingress annotations in `landing-page-ingress.yml` to mitigate CSRF attacks by restricting when cookies are sent.
* Enforced HTTPS by adding `ssl-redirect: "true"` to the ingress annotations, ensuring all requests are redirected to HTTPS.

**HTTP response header and browser policy enhancements:**

* Changed the `Cross-Origin-Embedder-Policy` header from "Report-Only" to enforcement mode, increasing cross-origin security for embedded resources in `SecurityConfig.java`.
* Added a `Permissions-Policy` header to explicitly disable potentially sensitive browser features such as geolocation, camera, microphone, payment, USB, and interest-cohort, further reducing attack surface.

---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [ ] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [ ] I have a corresponding JIRA ticket for this change 
- [x] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:

Please fill in.

---