### PR TITLE
STB-4235 - Enhance link visibility and button styling in grant access confirmation page

### DIFF
--- a/src/main/resources/templates/grant-access-check-answers.html
+++ b/src/main/resources/templates/grant-access-check-answers.html
@@ -101,7 +101,7 @@
                                     </dd>
 
                                     <dd class="govuk-summary-list__actions">
-                                        <a class="govuk-link govuk-link--no-visited-state"
+                                        <a class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold"
                                            th:if="${!appEntry.value.isEmpty() and appEntry.value.size() > 1}"
                                            th:href="@{/admin/users/grant-access/{id}/roles(id=${user.id}, selectedAppIndex=${iterStat.index})}">
                                             Change<span class="govuk-visually-hidden"> roles for <th:block th:text="${appEntry.key}">App</th:block></span>

--- a/src/main/resources/templates/grant-access-check-answers.html
+++ b/src/main/resources/templates/grant-access-check-answers.html
@@ -44,7 +44,7 @@
                             </h2>
                             <ul class="govuk-summary-card__actions">
                                 <li class="govuk-summary-card__action">
-                                    <a class="govuk-link"
+                                    <a class="govuk-link govuk-link--no-visited-state"
                                        th:href="@{/admin/users/grant-access/{id}/apps(id=${user.id})}">
                                         Change
                                         <span class="govuk-visually-hidden"> services assignment</span>
@@ -100,8 +100,9 @@
                                         </th:block>
                                     </dd>
 
-                                    <dd class="govuk-summary-list__actions" th:if="${!appEntry.value.isEmpty() and appEntry.value.size() > 1}">
-                                        <a class="govuk-link"
+                                    <dd class="govuk-summary-list__actions">
+                                        <a class="govuk-link govuk-link--no-visited-state"
+                                           th:if="${!appEntry.value.isEmpty() and appEntry.value.size() > 1}"
                                            th:href="@{/admin/users/grant-access/{id}/roles(id=${user.id}, selectedAppIndex=${iterStat.index})}">
                                             Change<span class="govuk-visually-hidden"> roles for <th:block th:text="${appEntry.key}">App</th:block></span>
                                         </a>
@@ -123,7 +124,7 @@
                             </h2>
                             <ul class="govuk-summary-card__actions">
                                 <li class="govuk-summary-card__action">
-                                    <a class="govuk-link"
+                                    <a class="govuk-link govuk-link--no-visited-state"
                                         th:href="@{/admin/users/grant-access/{id}/offices(id=${user.id})}">Change</a>
                                 </li>
                             </ul>
@@ -168,10 +169,10 @@
                         assigned.
                     </p>
                     <div class="govuk-button-group">
-                        <button type="submit" class="govuk-button" data-module="govuk-button" th:disabled="${errorMessage != null}">
+                        <button type="submit" class="govuk-button govuk-!-font-size-19 govuk-!-font-weight-bold" data-module="govuk-button" th:disabled="${errorMessage != null}">
                             Confirm
                         </button>
-                        <a th:href="@{/admin/users/grant-access/{id}/cancel/confirmation(id=${user.id})}" class="govuk-link">Cancel</a>
+                        <a th:href="@{/admin/users/grant-access/{id}/cancel/confirmation(id=${user.id})}" class="govuk-link govuk-link--no-visited-state">Cancel</a>
                     </div>
                 </form>
             </div>


### PR DESCRIPTION
### Description :pencil:

Fixed "Change"/"Cancel" link colours from purple (visited) to consistent blue by adding govuk-link--no-visited-state to all summary card and button group links
Fixed Confirm button font to 19pt bold (govuk-!-font-size-19 govuk-!-font-weight-bold) and resolved broken Roles table separator lines by moving the conditional from the <dd> element to the <a> tag within it

<img width="1071" height="959" alt="Screenshot 2026-06-16 at 12 54 06" src="https://github.com/user-attachments/assets/1efae248-a7b7-4ef2-a97e-efae1a5532ed" />


---

### Changes Made :pencil:

This pull request updates the `grant-access-check-answers.html` template to improve the visual consistency and accessibility of action links and buttons. The main focus is on applying the `govuk-link--no-visited-state` class to relevant links and enhancing the styling of the confirmation button.

**Styling and accessibility improvements:**

* All action links now include the `govuk-link--no-visited-state` class to prevent visited link color changes and ensure a consistent appearance across the page. [[1]](diffhunk://#diff-e754d3f165de717dfc3bbb8d91223484668b5722d1a0050d76033eac52755009L47-R47) [[2]](diffhunk://#diff-e754d3f165de717dfc3bbb8d91223484668b5722d1a0050d76033eac52755009L103-R105) [[3]](diffhunk://#diff-e754d3f165de717dfc3bbb8d91223484668b5722d1a0050d76033eac52755009L126-R127) [[4]](diffhunk://#diff-e754d3f165de717dfc3bbb8d91223484668b5722d1a0050d76033eac52755009L171-R175)
* The "Confirm" button is updated with `govuk-!-font-size-19` and `govuk-!-font-weight-bold` classes for improved visibility and emphasis.

---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [ ] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [x] I have a corresponding JIRA ticket for this change 
- [ ] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:

Please fill in.

---