### PR TITLE
STB-3863 - Add rules file for ZAP scans and update workflow configurations

### DIFF
--- a/.github/workflows/zap_dast_daily_dev.yml
+++ b/.github/workflows/zap_dast_daily_dev.yml
@@ -14,6 +14,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - name: Run ZAP Daily Baseline Scan
         id: baseline_run
         uses: zaproxy/action-baseline@de8ad967d3548d44ef623df22cf95c3b0baf8b25 # v0.15.0

--- a/.github/workflows/zap_dast_daily_dev.yml
+++ b/.github/workflows/zap_dast_daily_dev.yml
@@ -20,20 +20,21 @@ jobs:
         with:
           target: 'https://dev.your-legal-aid-services.service.justice.gov.uk/'
           cmd_options: '-a -j'
+          rules_file_name: '.zap/rules.tsv'
           fail_action: false
           issue_title: ZAP Scan Baseline Report - dev
-          
+
       - name: Parse summary
         run: |
           #!/bin/bash -xe
-          
+
           # Read directly from the markdown file.
           # -m 1 ensures we only grab the first match (which is the summary table at the top of the report)
           high_value=$(grep -a -m 1 "| High |" report_md.md | awk -F'|' '{print $3}' | xargs)
           medium_value=$(grep -a -m 1 "| Medium |" report_md.md | awk -F'|' '{print $3}' | xargs)
           low_value=$(grep -a -m 1 "| Low |" report_md.md | awk -F'|' '{print $3}' | xargs)
           info_value=$(grep -a -m 1 "| Informational |" report_md.md | awk -F'|' '{print $3}' | xargs)
-          
+
           # Fallback to 0 if grep returns empty (e.g., if the ZAP report is totally empty/failed)
           high_value=${high_value:-0}
           medium_value=${medium_value:-0}

--- a/.github/workflows/zap_dast_daily_dev.yml
+++ b/.github/workflows/zap_dast_daily_dev.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run ZAP Daily Baseline Scan
         id: baseline_run

--- a/.github/workflows/zap_dast_daily_prd.yml
+++ b/.github/workflows/zap_dast_daily_prd.yml
@@ -14,25 +14,26 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Run ZAP Daily Homepage Baseline Scan 
+      - name: Run ZAP Daily Homepage Baseline Scan
         id: homepage_baseline_run
         uses: zaproxy/action-baseline@de8ad967d3548d44ef623df22cf95c3b0baf8b25 # v0.15.0
         with:
           target: 'https://your-legal-aid-services.service.justice.gov.uk/'
           cmd_options: '-a -j'
+          rules_file_name: '.zap/rules.tsv'
           fail_action: false
           issue_title: ZAP Scan Baseline Report - prd
-          
+
       - name: Parse summary
         run: |
           #!/bin/bash -xe
-          
+
           # Read directly from the markdown file, stopping after the first match (-m 1)
           high_value=$(grep -a -m 1 "| High |" report_md.md | awk -F'|' '{print $3}' | xargs)
           medium_value=$(grep -a -m 1 "| Medium |" report_md.md | awk -F'|' '{print $3}' | xargs)
           low_value=$(grep -a -m 1 "| Low |" report_md.md | awk -F'|' '{print $3}' | xargs)
           info_value=$(grep -a -m 1 "| Informational |" report_md.md | awk -F'|' '{print $3}' | xargs)
-          
+
           # Fallback to 0 if grep returns empty
           high_value=${high_value:-0}
           medium_value=${medium_value:-0}

--- a/.github/workflows/zap_dast_daily_prd.yml
+++ b/.github/workflows/zap_dast_daily_prd.yml
@@ -14,6 +14,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - name: Run ZAP Daily Homepage Baseline Scan
         id: homepage_baseline_run
         uses: zaproxy/action-baseline@de8ad967d3548d44ef623df22cf95c3b0baf8b25 # v0.15.0

--- a/.github/workflows/zap_dast_daily_prd.yml
+++ b/.github/workflows/zap_dast_daily_prd.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run ZAP Daily Homepage Baseline Scan
         id: homepage_baseline_run

--- a/.github/workflows/zap_dast_daily_test.yml
+++ b/.github/workflows/zap_dast_daily_test.yml
@@ -14,6 +14,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - name: Run ZAP Daily Homepage Baseline Scan
         id: homepage_baseline_run
         uses: zaproxy/action-baseline@de8ad967d3548d44ef623df22cf95c3b0baf8b25 # v0.15.0

--- a/.github/workflows/zap_dast_daily_test.yml
+++ b/.github/workflows/zap_dast_daily_test.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run ZAP Daily Homepage Baseline Scan
         id: homepage_baseline_run

--- a/.github/workflows/zap_dast_daily_test.yml
+++ b/.github/workflows/zap_dast_daily_test.yml
@@ -14,25 +14,26 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Run ZAP Daily Homepage Baseline Scan 
+      - name: Run ZAP Daily Homepage Baseline Scan
         id: homepage_baseline_run
         uses: zaproxy/action-baseline@de8ad967d3548d44ef623df22cf95c3b0baf8b25 # v0.15.0
         with:
           target: 'https://test.your-legal-aid-services.service.justice.gov.uk/'
           cmd_options: '-a -j'
+          rules_file_name: '.zap/rules.tsv'
           fail_action: false
           issue_title: ZAP Scan Baseline Report - test
-          
+
       - name: Parse summary
         run: |
           #!/bin/bash -xe
-          
+
           # Read directly from the markdown file, stopping after the first match (-m 1)
           high_value=$(grep -a -m 1 "| High |" report_md.md | awk -F'|' '{print $3}' | xargs)
           medium_value=$(grep -a -m 1 "| Medium |" report_md.md | awk -F'|' '{print $3}' | xargs)
           low_value=$(grep -a -m 1 "| Low |" report_md.md | awk -F'|' '{print $3}' | xargs)
           info_value=$(grep -a -m 1 "| Informational |" report_md.md | awk -F'|' '{print $3}' | xargs)
-          
+
           # Fallback to 0 if grep returns empty
           high_value=${high_value:-0}
           medium_value=${medium_value:-0}

--- a/.github/workflows/zap_dast_weekly_dev.yml
+++ b/.github/workflows/zap_dast_weekly_dev.yml
@@ -14,6 +14,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - name: Run ZAP Weekly Full Scan
         uses: zaproxy/action-baseline@de8ad967d3548d44ef623df22cf95c3b0baf8b25 # v0.15.0
         with:

--- a/.github/workflows/zap_dast_weekly_dev.yml
+++ b/.github/workflows/zap_dast_weekly_dev.yml
@@ -19,20 +19,21 @@ jobs:
         with:
           target: 'https://dev.your-legal-aid-services.service.justice.gov.uk/'
           cmd_options: '-a -j -m 120'
+          rules_file_name: '.zap/rules.tsv'
           fail_action: false
           issue_title: ZAP Full Scan Report - dev
 
       - name: Parse summary
         run: |
           #!/bin/bash -xe
-          
+
           # Read directly from the markdown file.
           # -m 1 ensures we only grab the first match (which is the summary table at the top of the report)
           high_value=$(grep -a -m 1 "| High |" report_md.md | awk -F'|' '{print $3}' | xargs)
           medium_value=$(grep -a -m 1 "| Medium |" report_md.md | awk -F'|' '{print $3}' | xargs)
           low_value=$(grep -a -m 1 "| Low |" report_md.md | awk -F'|' '{print $3}' | xargs)
           info_value=$(grep -a -m 1 "| Informational |" report_md.md | awk -F'|' '{print $3}' | xargs)
-          
+
           # Fallback to 0 if grep returns empty (e.g., if the ZAP report is totally empty/failed)
           high_value=${high_value:-0}
           medium_value=${medium_value:-0}

--- a/.github/workflows/zap_dast_weekly_dev.yml
+++ b/.github/workflows/zap_dast_weekly_dev.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run ZAP Weekly Full Scan
         uses: zaproxy/action-baseline@de8ad967d3548d44ef623df22cf95c3b0baf8b25 # v0.15.0

--- a/.zap/rules.tsv
+++ b/.zap/rules.tsv
@@ -1,0 +1,9 @@
+10015	IGNORE	Cache-Control headers are correctly set (no-cache, no-store). ZAP flags this on the unauthenticated login page which intentionally prevents caching.
+10020	IGNORE	X-Frame-Options: DENY is set by Spring Security. ZAP incorrectly flags this on OAuth redirect responses where the header is not included.
+10038	IGNORE	Content-Security-Policy is set by Spring Security. ZAP incorrectly flags this on OAuth redirect responses where the header is not included.
+10049	IGNORE	Non-storable 302 redirects to Azure AD OAuth are expected and intentional. These are authentication redirects that must not be cached.
+10094	IGNORE	Base64 values are CSRF tokens and OAuth state parameters in authentication redirect URLs. These are expected and do not represent information disclosure.
+10096	IGNORE	Unix timestamps are OAuth state parameters in authentication redirect URLs. These are expected and do not represent information disclosure.
+10109	IGNORE	Informational notice only - ZAP identifying this as a modern web application. Not a vulnerability.
+10112	IGNORE	Informational notice only - ZAP identifying session management cookies. Session cookies are correctly configured with HttpOnly, Secure and SameSite=Lax.
+90005	IGNORE	ZAP's own scanner does not send the Sec-Fetch-Dest header. This is a false positive about ZAP's own behaviour, not the server.


### PR DESCRIPTION
### Description :pencil:

9 false positives suppressed by the rules file.

---

### Changes Made :pencil:

This pull request updates the configuration for ZAP DAST (Dynamic Application Security Testing) GitHub Actions workflows by introducing a centralized rules file to ignore known false positives and expected findings. This helps ensure that the ZAP scan results are more relevant, reducing noise from issues that are already understood or intentional.

Key changes:

**ZAP Workflow Configuration Updates:**

* All ZAP DAST GitHub Actions workflows (`zap_dast_daily_dev.yml`, `zap_dast_daily_test.yml`, `zap_dast_daily_prd.yml`, `zap_dast_weekly_dev.yml`) are updated to use a new `rules_file_name` parameter, pointing to `.zap/rules.tsv`. This ensures that the same set of ignore rules is applied across all environments. [[1]](diffhunk://#diff-a97edef4b77b7e1b9755e3e772659d3ca9db073764dc4a6ea44278cdaee73bbfR23) [[2]](diffhunk://#diff-4c90a6b2c7280c07904385f044782ff11d4399726277f4a21119c3fd71a88ef8R23) [[3]](diffhunk://#diff-069f2b54c9a39abd07ee8e84fd9492b09ba9b3fc68ff76137707434ba6ea2335R23) [[4]](diffhunk://#diff-f6502fc8fa83f36046a11f5c4ddda003240617aa93c73f7fdceb25be1e679797R22)

**Rules File Addition:**

* A new `.zap/rules.tsv` file is introduced, specifying which ZAP findings should be ignored and providing justifications for each. This includes various headers, authentication redirects, informational notices, and known scanner behaviors that are not vulnerabilities in this context.

---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [ ] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [x] I have a corresponding JIRA ticket for this change 
- [ ] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:

Please fill in.

---