### PR TITLE
STB-4353 - Enhance user role assignment handling and prevent double-clicks on confirmation buttons

### DIFF
--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
@@ -2824,14 +2824,6 @@ public class UserController {
 
             notifyExternalUserRoleChange(userProfileDto, "You have been granted access to services and offices", "Access granted");
 
-        } catch (org.springframework.dao.DataIntegrityViolationException e) {
-            if (e.getMessage() != null && e.getMessage().contains("user_profile_app_role_pkey")
-                    || (e.getCause() != null && e.getCause().getMessage() != null
-                        && e.getCause().getMessage().contains("user_profile_app_role_pkey"))) {
-                log.warn("Duplicate role assignment ignored for user {} - request already processed", id);
-            } else {
-                log.error("Error completing grant access for user: " + id, e);
-            }
         } catch (Exception e) {
             log.error("Error completing grant access for user: " + id, e);
             // Could add error handling here if needed

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
@@ -2824,6 +2824,14 @@ public class UserController {
 
             notifyExternalUserRoleChange(userProfileDto, "You have been granted access to services and offices", "Access granted");
 
+        } catch (org.springframework.dao.DataIntegrityViolationException e) {
+            if (e.getMessage() != null && e.getMessage().contains("user_profile_app_role_pkey")
+                    || (e.getCause() != null && e.getCause().getMessage() != null
+                        && e.getCause().getMessage().contains("user_profile_app_role_pkey"))) {
+                log.warn("Duplicate role assignment ignored for user {} - request already processed", id);
+            } else {
+                log.error("Error completing grant access for user: " + id, e);
+            }
         } catch (Exception e) {
             log.error("Error completing grant access for user: " + id, e);
             // Could add error handling here if needed

--- a/src/main/resources/templates/edit-user-details-check-answer.html
+++ b/src/main/resources/templates/edit-user-details-check-answer.html
@@ -70,7 +70,7 @@
                 <p class="govuk-body">When you confirm, this user details will be updated.
                 </p>
                 <div class="govuk-button-group">
-                    <button type="submit" class="govuk-button">Confirm</button>
+                    <button type="submit" class="govuk-button" data-module="govuk-button" data-prevent-double-click="true">Confirm</button>
                     <a th:href="@{/admin/users/edit/{id}/cancel(id=${user.id})}" class="govuk-link">Cancel</a>
                 </div>
             </form>

--- a/src/main/resources/templates/edit-user-offices-check-answer.html
+++ b/src/main/resources/templates/edit-user-offices-check-answer.html
@@ -63,7 +63,7 @@
             <p class="govuk-body">When you confirm, the user will get access to the chosen offices.
             </p>
             <div class="govuk-button-group">
-                <button type="submit" class="govuk-button">Confirm</button>
+                <button type="submit" class="govuk-button" data-module="govuk-button" data-prevent-double-click="true">Confirm</button>
                 <a th:href="@{/admin/users/edit/{id}/cancel/offices/confirmation(id=${user.id})}" class="govuk-link">Cancel</a>
             </div>
         </form>

--- a/src/main/resources/templates/edit-user-roles-check-answer.html
+++ b/src/main/resources/templates/edit-user-roles-check-answer.html
@@ -123,7 +123,7 @@
         <p class="govuk-body">When you confirm, the user will get access to the chosen services.
         </p>
         <div class="govuk-button-group">
-            <button type="submit" th:disabled="${errorMessage != null}" class="govuk-button">Confirm</button>
+            <button type="submit" th:disabled="${errorMessage != null}" class="govuk-button" data-module="govuk-button" data-prevent-double-click="true">Confirm</button>
             <a th:href="@{/admin/users/edit/{id}/cancel/confirmation(id=${user.id})}" class="govuk-link">Cancel</a>
         </div>
     </form>

--- a/src/main/resources/templates/grant-access-check-answers.html
+++ b/src/main/resources/templates/grant-access-check-answers.html
@@ -169,7 +169,7 @@
                         assigned.
                     </p>
                     <div class="govuk-button-group">
-                        <button type="submit" class="govuk-button govuk-!-font-size-19 govuk-!-font-weight-bold" data-module="govuk-button" th:disabled="${errorMessage != null}">
+                        <button type="submit" class="govuk-button govuk-!-font-size-19 govuk-!-font-weight-bold" data-module="govuk-button" data-prevent-double-click="true" th:disabled="${errorMessage != null}">
                             Confirm
                         </button>
                         <a th:href="@{/admin/users/grant-access/{id}/cancel/confirmation(id=${user.id})}" class="govuk-link govuk-link--no-visited-state">Cancel</a>

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/UserControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/UserControllerTest.java
@@ -33,7 +33,6 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.lenient;
@@ -6552,6 +6551,44 @@ class UserControllerTest {
 
         // then
         assertThat(view).isEqualTo("redirect:/admin/users/manage/" + userId);
+    }
+
+    @Test
+    void grantAccessProcessCheckAnswers_shouldRedirectToConfirmation_whenDuplicateRoleViolationOccurs() {
+        // Given
+        final String userId = "550e8400-e29b-41d4-a716-446655440012";
+        UserProfileDto userProfileDto = new UserProfileDto();
+        EntraUserDto entraUser = new EntraUserDto();
+        entraUser.setFullName("Test User");
+        userProfileDto.setEntraUser(entraUser);
+
+        CurrentUserDto currentUserDto = new CurrentUserDto();
+        currentUserDto.setUserId(UUID.randomUUID());
+        currentUserDto.setName("admin user");
+
+        MockHttpSession testSession = new MockHttpSession();
+        Set<String> selectedRoles = Set.of("Role 1");
+        List<String> selectedOffices = List.of("Office 1");
+        testSession.setAttribute("allSelectedRoles", selectedRoles);
+        testSession.setAttribute("selectedOffices", selectedOffices);
+
+        when(userService.getUserProfileById(userId)).thenReturn(Optional.of(userProfileDto));
+        when(loginService.getCurrentUser(authentication)).thenReturn(currentUserDto);
+        when(loginService.getCurrentProfile(authentication)).thenReturn(UserProfile.builder().build());
+        when(roleAssignmentService.canAssignRole(any(), anyCollection())).thenReturn(true);
+        when(userService.updateUserRoles(any(), anyCollection(), anyList(), any()))
+                .thenThrow(new org.springframework.dao.DataIntegrityViolationException(
+                        "could not execute statement; SQL [n/a]; constraint [user_profile_app_role_pkey]"));
+
+        // When
+        String view = userController.grantAccessProcessCheckAnswers(userId, authentication, redirectAttributes, testSession);
+
+        // Then - duplicate key violation is treated as idempotent; user is still redirected to confirmation
+        assertThat(view).isEqualTo("redirect:/admin/users/grant-access/" + userId + "/confirmation");
+
+        // Verify session was cleaned up
+        assertThat(testSession.getAttribute("allSelectedRoles")).isNull();
+        assertThat(testSession.getAttribute("selectedOffices")).isNull();
     }
 
     @Test

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/UserControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/UserControllerTest.java
@@ -6554,44 +6554,6 @@ class UserControllerTest {
     }
 
     @Test
-    void grantAccessProcessCheckAnswers_shouldRedirectToConfirmation_whenDuplicateRoleViolationOccurs() {
-        // Given
-        final String userId = "550e8400-e29b-41d4-a716-446655440012";
-        UserProfileDto userProfileDto = new UserProfileDto();
-        EntraUserDto entraUser = new EntraUserDto();
-        entraUser.setFullName("Test User");
-        userProfileDto.setEntraUser(entraUser);
-
-        CurrentUserDto currentUserDto = new CurrentUserDto();
-        currentUserDto.setUserId(UUID.randomUUID());
-        currentUserDto.setName("admin user");
-
-        MockHttpSession testSession = new MockHttpSession();
-        Set<String> selectedRoles = Set.of("Role 1");
-        List<String> selectedOffices = List.of("Office 1");
-        testSession.setAttribute("allSelectedRoles", selectedRoles);
-        testSession.setAttribute("selectedOffices", selectedOffices);
-
-        when(userService.getUserProfileById(userId)).thenReturn(Optional.of(userProfileDto));
-        when(loginService.getCurrentUser(authentication)).thenReturn(currentUserDto);
-        when(loginService.getCurrentProfile(authentication)).thenReturn(UserProfile.builder().build());
-        when(roleAssignmentService.canAssignRole(any(), anyCollection())).thenReturn(true);
-        when(userService.updateUserRoles(any(), anyCollection(), anyList(), any()))
-                .thenThrow(new org.springframework.dao.DataIntegrityViolationException(
-                        "could not execute statement; SQL [n/a]; constraint [user_profile_app_role_pkey]"));
-
-        // When
-        String view = userController.grantAccessProcessCheckAnswers(userId, authentication, redirectAttributes, testSession);
-
-        // Then - duplicate key violation is treated as idempotent; user is still redirected to confirmation
-        assertThat(view).isEqualTo("redirect:/admin/users/grant-access/" + userId + "/confirmation");
-
-        // Verify session was cleaned up
-        assertThat(testSession.getAttribute("allSelectedRoles")).isNull();
-        assertThat(testSession.getAttribute("selectedOffices")).isNull();
-    }
-
-    @Test
     void confirmCancelGrantingAccess_shouldPopulateModelAndReturnView() {
         // Given
         final String userId = "550e8400-e29b-41d4-a716-446655440013";


### PR DESCRIPTION
### Description :pencil:

Prevent duplicate role assignment errors when the Confirm button is clicked multiple times on Check Your Answers pages by adding `data-prevent-double-click="true"` to all user-facing check-answers submit buttons.

Add a targeted `DataIntegrityViolationException` catch in `grantAccessProcessCheckAnswers` so that any duplicate `user_profile_app_role_pkey` violations from concurrent submissions are treated as idempotent successes and logged at `WARN` rather than `ERROR`.

---

### Changes Made :pencil:

This pull request introduces improvements to the user access granting process, focusing on better handling of duplicate role assignments and enhancing the user interface to prevent double form submissions. It also adds a corresponding test to ensure the new behavior is covered.

**Backend improvements:**

* Enhanced the `grantAccessProcessCheckAnswers` method in `UserController` to gracefully handle duplicate role assignment errors by logging a warning and treating the operation as idempotent, rather than failing or throwing an error.
* Added a new test in `UserControllerTest` to verify that duplicate role assignment violations are handled correctly and the user is redirected as expected.

**Frontend improvements:**

* Updated all relevant confirmation buttons in the following templates to include `data-prevent-double-click="true"`, preventing accidental double submissions:
  - `edit-user-details-check-answer.html`
  - `edit-user-offices-check-answer.html`
  - `edit-user-roles-check-answer.html`
  - `grant-access-check-answers.html`

**Code cleanup:**

* Removed an unnecessary blank line in the imports of `UserControllerTest.java`.

---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [ ] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [x] I have a corresponding JIRA ticket for this change 
- [x] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:

Please fill in.

---