### PR TITLE
STB-4353 - Add error handling for duplicate role assignments in UserController

### DIFF
--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
@@ -21,6 +21,7 @@ import java.util.stream.Collectors;
 import org.jetbrains.annotations.NotNull;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
@@ -1678,19 +1679,23 @@ public class UserController {
             return String.format("redirect:/admin/users/edit/%s/roles-check-answer?errorMessage=%s", uuid, ccmsErrorMsg);
         }
         if (roleAssignmentService.canAssignRole(editorProfile.getAppRoles(), allSelectedRoles)) {
-            Map<String, String> updateResult = userService.updateUserRoles(id, allSelectedRoles,
-                    nonEditableRoles, currentUserDto.getUserId());
-            if (updateResult.get("error") != null) {
-                String errorMessage = updateResult.get("error");
-                return "redirect:/admin/users/edit/" + uuid + "/roles-check-answer?errorMessage=" + errorMessage;
+            try {
+                Map<String, String> updateResult = userService.updateUserRoles(id, allSelectedRoles,
+                        nonEditableRoles, currentUserDto.getUserId());
+                if (updateResult.get("error") != null) {
+                    String errorMessage = updateResult.get("error");
+                    return "redirect:/admin/users/edit/" + uuid + "/roles-check-answer?errorMessage=" + errorMessage;
+                }
+                UpdateUserAuditEvent updateUserAuditEvent = new UpdateUserAuditEvent(
+                        editorProfile.getId(),
+                        currentUserDto,
+                        user.getEntraUser(), updateResult.get("diff"),
+                        "role");
+                eventService.logEvent(updateUserAuditEvent);
+                notifyExternalUserRoleChange(user, updateResult.get("diff"), "Service roles");
+            } catch (DataIntegrityViolationException e) {
+                log.warn("Duplicate role assignment detected for user {} - continuing to confirmation", id);
             }
-            UpdateUserAuditEvent updateUserAuditEvent = new UpdateUserAuditEvent(
-                    editorProfile.getId(),
-                    currentUserDto,
-                    user.getEntraUser(), updateResult.get("diff"),
-                    "role");
-            eventService.logEvent(updateUserAuditEvent);
-            notifyExternalUserRoleChange(user, updateResult.get("diff"), "Service roles");
         }
         // Clear the session
         session.removeAttribute("editUserAllSelectedRoles");

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/UserControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/UserControllerTest.java
@@ -43,6 +43,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.security.access.AccessDeniedException;
@@ -2054,7 +2055,7 @@ class UserControllerTest {
         session.setAttribute("editUserAllSelectedRoles", new HashMap<>());
         when(roleAssignmentService.canAssignRole(any(), any())).thenReturn(true);
         when(userService.updateUserRoles(any(), any(), any(), any()))
-                .thenThrow(new org.springframework.dao.DataIntegrityViolationException(
+                .thenThrow(new DataIntegrityViolationException(
                         "could not execute statement; constraint [user_profile_app_role_pkey]"));
 
         // When

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/UserControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/UserControllerTest.java
@@ -2035,6 +2035,35 @@ class UserControllerTest {
                 userId, "Attempt to remove own External User Manager, from user profile " + userId));
     }
 
+    @Test
+    public void editUserRolesCheckAnswerSubmit_shouldRedirectToConfirmation_whenDuplicateRoleViolationOccurs() {
+        // Given
+        CurrentUserDto currentUserDto = new CurrentUserDto();
+        currentUserDto.setUserId(UUID.randomUUID());
+        currentUserDto.setName("tester");
+        when(loginService.getCurrentUser(authentication)).thenReturn(currentUserDto);
+        when(loginService.getCurrentProfile(authentication))
+                .thenReturn(UserProfile.builder().appRoles(new HashSet<>()).build());
+        UUID userId = UUID.randomUUID();
+        UserProfileDto userProfile = UserProfileDto.builder()
+                .id(userId)
+                .userType(UserType.EXTERNAL)
+                .build();
+        when(userService.getUserProfileById(userId.toString())).thenReturn(Optional.ofNullable(userProfile));
+        HttpSession session = new MockHttpSession();
+        session.setAttribute("editUserAllSelectedRoles", new HashMap<>());
+        when(roleAssignmentService.canAssignRole(any(), any())).thenReturn(true);
+        when(userService.updateUserRoles(any(), any(), any(), any()))
+                .thenThrow(new org.springframework.dao.DataIntegrityViolationException(
+                        "could not execute statement; constraint [user_profile_app_role_pkey]"));
+
+        // When
+        String redirect = userController.editUserRolesCheckAnswerSubmit(userId.toString(), session, authentication);
+
+        // Then - duplicate key violation is handled gracefully; user still reaches confirmation
+        assertThat(redirect).isEqualTo("redirect:/admin/users/edit/" + userId + "/confirmation");
+    }
+
     // ===== NEW EDIT USER FUNCTIONALITY TESTS =====
 
     @Test


### PR DESCRIPTION
### Description :pencil:

Frontend (data-prevent-double-click) — stops the common case of impatient rapid clicking
Backend (catch DataIntegrityViolationException) — handles the race condition that gets through anyway when the server is slow

---

### Changes Made :pencil:

This pull request improves the robustness of the user role assignment process by handling duplicate role assignment errors gracefully. Specifically, it ensures that if a duplicate role assignment occurs due to a database constraint violation, the user is still redirected to the confirmation page without interruption. Additionally, a new test verifies this behavior.

Error handling improvements in user role assignment:

* Updated `UserController` to catch `DataIntegrityViolationException` during user role updates, logging a warning and allowing the process to continue to the confirmation step if a duplicate role assignment is detected. [[1]](diffhunk://#diff-1c3931784714b5992966f392b56dad9140ea42ba7303dfce45c2cb8533ed3885R24) [[2]](diffhunk://#diff-1c3931784714b5992966f392b56dad9140ea42ba7303dfce45c2cb8533ed3885R1682) [[3]](diffhunk://#diff-1c3931784714b5992966f392b56dad9140ea42ba7303dfce45c2cb8533ed3885R1696-R1698)

Testing enhancements:

* Added a test (`editUserRolesCheckAnswerSubmit_shouldRedirectToConfirmation_whenDuplicateRoleViolationOccurs`) in `UserControllerTest.java` to ensure that duplicate role assignment violations are handled gracefully and the user is redirected to the confirmation page.

---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [ ] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [x] I have a corresponding JIRA ticket for this change 
- [x] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:

Please fill in.

---