### PR TITLE
STB-4337: prevent information disclosure in headers and responses

### DIFF
--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/config/ErrorPageConfig.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/config/ErrorPageConfig.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.laa.portal.landingpage.config;
 
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
 import org.springframework.boot.web.server.ErrorPage;
 import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.boot.web.servlet.server.ConfigurableServletWebServerFactory;
@@ -53,5 +54,16 @@ public class ErrorPageConfig {
                 new ErrorPage(HttpStatus.GATEWAY_TIMEOUT, "/error")
             );
         };
+    }
+
+    /**
+     *
+     * Disable Tomcat's X-Powered-By header
+     *
+     */
+    @Bean
+    public WebServerFactoryCustomizer<TomcatServletWebServerFactory> tomcatCustomizer() {
+        return factory -> factory.addConnectorCustomizers( connector ->
+                connector.setXpoweredBy(false));
     }
 }

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/config/ErrorPageConfig.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/config/ErrorPageConfig.java
@@ -63,7 +63,7 @@ public class ErrorPageConfig {
      */
     @Bean
     public WebServerFactoryCustomizer<TomcatServletWebServerFactory> tomcatCustomizer() {
-        return factory -> factory.addConnectorCustomizers( connector ->
+        return factory -> factory.addConnectorCustomizers(connector ->
                 connector.setXpoweredBy(false));
     }
 }

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/config/HeaderResponseConfig.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/config/HeaderResponseConfig.java
@@ -1,0 +1,27 @@
+package uk.gov.justice.laa.portal.landingpage.config;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class HeaderResponseConfig implements Filter {
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+        throws IOException, ServletException {
+
+        HttpServletResponse res = (HttpServletResponse) response;
+
+        res.setHeader("X-Powered-By", "");
+        res.setHeader("Server", "");
+
+        chain.doFilter(request, response);
+    }
+}

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/exception/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import java.util.stream.Collectors;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.validation.FieldError;
@@ -32,18 +33,14 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ClaimEnrichmentResponse> handleValidationExceptions(MethodArgumentNotValidException ex) {
-        String errorMessage = ex.getBindingResult()
-                .getFieldErrors()
-                .stream()
-                .map(FieldError::getDefaultMessage)
-                .collect(Collectors.joining("; "));
-
-        return createErrorResponse(HttpStatus.BAD_REQUEST, "Validation error: " + errorMessage);
+        log.warn("Validation exception occurred", ex);
+        return createErrorResponse(HttpStatus.BAD_REQUEST, "Invalid request");
     }
 
     @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<ClaimEnrichmentResponse> handleConstraintViolation(ConstraintViolationException ex) {
-        return createErrorResponse(HttpStatus.BAD_REQUEST, "Validation error: " + ex.getMessage());
+        log.warn("Constraint violation occurred", ex);
+        return createErrorResponse(HttpStatus.BAD_REQUEST, "Invalid request");
     }
 
     @ExceptionHandler(CreateUserDetailsIncompleteException.class)
@@ -65,10 +62,10 @@ public class GlobalExceptionHandler {
         String contentType = request.getHeader("Content-Type");
 
         if (isApiRequest(acceptHeader, contentType, request.getRequestURI())) {
-            log.warn("Access denied in API request: {}", ex.getMessage());
+            log.warn("Access denied in API request", ex);
             return createErrorResponse(
                     HttpStatus.UNAUTHORIZED,
-                    "An unauthorized error occurred: " + ex.getMessage());
+                    "Access denied");
         }
 
         // Let web requests be handled by Spring Security's error handling
@@ -77,12 +74,14 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler({ UserNotFoundException.class})
     public ResponseEntity<ClaimEnrichmentResponse> handleUserNotFoundExceptionException(Exception ex) {
-        return createErrorResponse(HttpStatus.NOT_FOUND, ex.getMessage());
+        log.warn("User not found", ex);
+        return createErrorResponse(HttpStatus.NOT_FOUND, "Resource not found");
     }
 
     @ExceptionHandler({ BadRequestException.class})
     public ResponseEntity<ClaimEnrichmentResponse> handleBadRequestExceptionException(Exception ex) {
-        return createErrorResponse(HttpStatus.BAD_REQUEST, ex.getMessage());
+        log.warn("Bad request", ex);
+        return createErrorResponse(HttpStatus.BAD_REQUEST, "Invalid request");
     }
 
     /**
@@ -93,6 +92,25 @@ public class GlobalExceptionHandler {
     public ResponseEntity<Void> handleNoResourceFoundException(NoResourceFoundException ex) {
         // Browsers automatically request favicon.ico, return clean 404
         return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+    }
+
+
+    /**
+     * Handle malformed JSON requests.
+     * Returns a generic 400 response without exposing parsing details.
+     */
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ClaimEnrichmentResponse> handleMalformedJson(HttpMessageNotReadableException ex,
+                                                                       HttpServletRequest request) {
+        if (isApiRequest(request.getHeader("Accept"), request.getHeader("Content-Type"), request.getRequestURI())) {
+            log.warn("Malformed JSON request", ex);
+            return createErrorResponse(
+                    HttpStatus.BAD_REQUEST,
+                    "Invalid request"
+            );
+        }
+        throw ex;
     }
 
     /**
@@ -109,7 +127,7 @@ public class GlobalExceptionHandler {
             log.error("Unexpected error in API request", ex);
             return createErrorResponse(
                     HttpStatus.INTERNAL_SERVER_ERROR,
-                    "An unexpected error occurred: " + ex.getMessage());
+                    "An error occurred");
         }
 
         // Let web requests be handled by the error controller

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -67,6 +67,13 @@ spring.profiles.active=${SPRING_PROFILE:local}
 
 # Network
 server.forward-headers-strategy=FRAMEWORK
+server.server-header=
+
+# Error handling - prevent information disclosure
+server.error.include-exception=false
+server.error.include-stacktrace=never
+server.error.include-message=never
+server.error.include-binding-errors=never
 
 # Session cookie security
 server.servlet.session.cookie.same-site=lax

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/config/ErrorPageConfigTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/config/ErrorPageConfigTest.java
@@ -8,12 +8,16 @@ import static org.mockito.Mockito.verify;
 
 import java.util.Arrays;
 
+import org.apache.catalina.connector.Connector;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.web.embedded.tomcat.TomcatConnectorCustomizer;
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
 import org.springframework.boot.web.server.ErrorPage;
 import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.boot.web.servlet.server.ConfigurableServletWebServerFactory;
@@ -24,6 +28,11 @@ class ErrorPageConfigTest {
 
     private ErrorPageConfig errorPageConfig;
     private ConfigurableServletWebServerFactory mockFactory;
+
+
+    @Mock
+    private TomcatServletWebServerFactory tomcatFactory;
+
 
     @Captor
     private ArgumentCaptor<ErrorPage[]> errorPagesCaptor;
@@ -159,5 +168,22 @@ class ErrorPageConfigTest {
     private boolean containsStatusCode(ErrorPage[] errorPages, HttpStatus status) {
         return Arrays.stream(errorPages)
             .anyMatch(page -> page.getStatus() == status);
+    }
+
+    @Test
+    void tomcatCustomizer_setsXpoweredByFalse() {
+        Connector connector = mock(Connector.class);
+        ArgumentCaptor<TomcatConnectorCustomizer> customizerCaptor =
+                ArgumentCaptor.forClass(TomcatConnectorCustomizer.class);
+        WebServerFactoryCustomizer<TomcatServletWebServerFactory> customizer =
+                errorPageConfig.tomcatCustomizer();
+        customizer.customize(tomcatFactory);
+
+        verify(tomcatFactory).addConnectorCustomizers(customizerCaptor.capture());
+        TomcatConnectorCustomizer connectorCustomizer = customizerCaptor.getValue();
+        connectorCustomizer.customize(connector);
+
+        // Assert
+        verify(connector).setXpoweredBy(false);
     }
 }

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/config/HeaderResponseConfigTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/config/HeaderResponseConfigTest.java
@@ -1,0 +1,54 @@
+package uk.gov.justice.laa.portal.landingpage.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class HeaderResponseConfigTest {
+
+    private HeaderResponseConfig filter;
+
+    @Mock
+    private ServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private FilterChain chain;
+
+    @BeforeEach
+    void setUp() {
+        filter = new HeaderResponseConfig();
+    }
+
+    @Test
+    void doFilter_setsHeaders_andContinuesChain() throws Exception {
+        filter.doFilter(request, response, chain);
+        verify(response).setHeader("X-Powered-By", "");
+        verify(response).setHeader("Server", "");
+        verify(chain).doFilter(request, response);
+    }
+
+    @Test
+    void doFilter_callsChainExactlyOnce() throws Exception {
+        filter.doFilter(request, response, chain);
+        verify(chain, times(1)).doFilter(request, response);
+    }
+
+    @Test
+    void doFilter_setsHeadersExactlyOnce() throws Exception {
+        filter.doFilter(request, response, chain);
+        verify(response, times(1)).setHeader("X-Powered-By", "");
+        verify(response, times(1)).setHeader("Server", "");
+    }
+}

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/exception/GlobalExceptionHandlerTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.validation.BindingResult;
@@ -40,7 +41,7 @@ class GlobalExceptionHandlerTest {
     @Test
     void handleUserNotFoundException() {
         // Arrange
-        String errorMessage = "Test error message";
+        String errorMessage = "Resource not found";
         UserNotFoundException exception = new UserNotFoundException(errorMessage);
 
         // Act
@@ -56,7 +57,7 @@ class GlobalExceptionHandlerTest {
     @Test
     void handleBadRequestException() {
         // Arrange
-        String errorMessage = "Test error message";
+        String errorMessage = "Invalid request";
         BadRequestException exception = new BadRequestException(errorMessage);
 
         // Act
@@ -89,37 +90,36 @@ class GlobalExceptionHandlerTest {
     void handleMethodArgumentNotValidException() {
         // Arrange
         MethodArgumentNotValidException exception = mock(MethodArgumentNotValidException.class);
-        BindingResult bindingResult = mock(BindingResult.class);
-        FieldError fieldError = new FieldError("object", "field", "Field validation failed");
-
-        when(exception.getBindingResult()).thenReturn(bindingResult);
-        when(bindingResult.getFieldErrors()).thenReturn(List.of(fieldError));
 
         // Act
-        ResponseEntity<ClaimEnrichmentResponse> response = exceptionHandler.handleValidationExceptions(exception);
+        ResponseEntity<ClaimEnrichmentResponse> response =
+                exceptionHandler.handleValidationExceptions(exception);
 
         // Assert
         assertNotNull(response);
         assertEquals(400, response.getStatusCode().value());
         assertFalse(response.getBody().isSuccess());
-        assertTrue(response.getBody().getMessage().contains("Validation error"));
-        assertTrue(response.getBody().getMessage().contains("Field validation failed"));
+
+        assertEquals("Invalid request", response.getBody().getMessage());
     }
 
     @Test
     void handleConstraintViolation() {
         // Arrange
         Set<ConstraintViolation<?>> violations = new HashSet<>();
-        ConstraintViolationException exception = new ConstraintViolationException("Constraint violation", violations);
+        ConstraintViolationException exception =
+                new ConstraintViolationException("Constraint violation", violations);
 
         // Act
-        ResponseEntity<ClaimEnrichmentResponse> response = exceptionHandler.handleConstraintViolation(exception);
+        ResponseEntity<ClaimEnrichmentResponse> response =
+                exceptionHandler.handleConstraintViolation(exception);
 
         // Assert
         assertNotNull(response);
         assertEquals(400, response.getStatusCode().value());
         assertFalse(response.getBody().isSuccess());
-        assertTrue(response.getBody().getMessage().contains("Validation error"));
+
+        assertEquals("Invalid request", response.getBody().getMessage());
     }
 
     @Test
@@ -141,7 +141,7 @@ class GlobalExceptionHandlerTest {
     @Test
     void handleGenericException() {
         // Arrange
-        String errorMessage = "Unexpected error";
+        String errorMessage = "An error occurred";
         Exception exception = new Exception(errorMessage);
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.addHeader("Accept", "application/json"); // Make it an API request
@@ -153,13 +153,13 @@ class GlobalExceptionHandlerTest {
         assertNotNull(response);
         assertEquals(500, response.getStatusCode().value());
         assertFalse(response.getBody().isSuccess());
-        assertTrue(response.getBody().getMessage().contains(errorMessage));
+        assertEquals(errorMessage, response.getBody().getMessage());
     }
 
     @Test
     void handleAccessException() {
         // Arrange
-        String errorMessage = "unauthorized error";
+        String errorMessage = "Access denied";
         AccessDeniedException exception = new AccessDeniedException(errorMessage);
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.addHeader("Accept", "application/json"); // Make it an API request
@@ -171,7 +171,7 @@ class GlobalExceptionHandlerTest {
         assertNotNull(response);
         assertEquals(401, response.getStatusCode().value());
         assertFalse(response.getBody().isSuccess());
-        assertTrue(response.getBody().getMessage().contains(errorMessage));
+        assertEquals(errorMessage, response.getBody().getMessage());
     }
 
     @Test
@@ -209,7 +209,7 @@ class GlobalExceptionHandlerTest {
     @Test
     void handleAccessException_apiRequestByContentType() {
         // Arrange
-        String errorMessage = "unauthorized error";
+        String errorMessage = "Access denied";
         AccessDeniedException exception = new AccessDeniedException(errorMessage);
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.addHeader("Content-Type", "application/json"); // API request via Content-Type
@@ -221,13 +221,13 @@ class GlobalExceptionHandlerTest {
         assertNotNull(response);
         assertEquals(401, response.getStatusCode().value());
         assertFalse(response.getBody().isSuccess());
-        assertTrue(response.getBody().getMessage().contains(errorMessage));
+        assertEquals(errorMessage, response.getBody().getMessage());
     }
 
     @Test
     void handleAccessException_apiRequestByUri() {
         // Arrange
-        String errorMessage = "unauthorized error";
+        String errorMessage = "Access denied";
         AccessDeniedException exception = new AccessDeniedException(errorMessage);
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.setRequestURI("/api/pda/report"); // API request via URI
@@ -239,13 +239,13 @@ class GlobalExceptionHandlerTest {
         assertNotNull(response);
         assertEquals(401, response.getStatusCode().value());
         assertFalse(response.getBody().isSuccess());
-        assertTrue(response.getBody().getMessage().contains(errorMessage));
+        assertEquals(errorMessage, response.getBody().getMessage());
     }
 
     @Test
     void handleGenericException_apiRequestByContentType() {
         // Arrange
-        String errorMessage = "Unexpected error";
+        String errorMessage = "An error occurred";
         Exception exception = new Exception(errorMessage);
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.addHeader("Content-Type", "application/json"); // API request via Content-Type
@@ -257,13 +257,13 @@ class GlobalExceptionHandlerTest {
         assertNotNull(response);
         assertEquals(500, response.getStatusCode().value());
         assertFalse(response.getBody().isSuccess());
-        assertTrue(response.getBody().getMessage().contains(errorMessage));
+        assertEquals(errorMessage, response.getBody().getMessage());
     }
 
     @Test
     void handleGenericException_apiRequestByUri() {
         // Arrange
-        String errorMessage = "Unexpected error";
+        String errorMessage = "An error occurred";
         Exception exception = new Exception(errorMessage);
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.setRequestURI("/api/claim/enrich"); // API request via URI
@@ -275,7 +275,7 @@ class GlobalExceptionHandlerTest {
         assertNotNull(response);
         assertEquals(500, response.getStatusCode().value());
         assertFalse(response.getBody().isSuccess());
-        assertTrue(response.getBody().getMessage().contains(errorMessage));
+        assertEquals(errorMessage, response.getBody().getMessage());
     }
 
     @Test
@@ -296,7 +296,7 @@ class GlobalExceptionHandlerTest {
     @Test
     void handleAuthorizationDeniedException_apiRequest() {
         // Arrange
-        String errorMessage = "authorization denied";
+        String errorMessage = "Access denied";
         org.springframework.security.authorization.AuthorizationDeniedException exception =
             new org.springframework.security.authorization.AuthorizationDeniedException(
                 errorMessage,
@@ -311,7 +311,7 @@ class GlobalExceptionHandlerTest {
         assertNotNull(response);
         assertEquals(401, response.getStatusCode().value());
         assertFalse(response.getBody().isSuccess());
-        assertTrue(response.getBody().getMessage().contains(errorMessage));
+        assertEquals(errorMessage, response.getBody().getMessage());
     }
 
     @Test
@@ -331,5 +331,26 @@ class GlobalExceptionHandlerTest {
             () -> exceptionHandler.handleAccessException(exception, request)
         );
         assertEquals(exception, thrown.getCause());
+    }
+
+    @Test
+    void handleMalformedJson_apiRequest() {
+        // Arrange
+        HttpMessageNotReadableException exception =
+                mock(HttpMessageNotReadableException.class);
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("/api/test");
+        request.addHeader("Content-Type", "application/json");
+
+        // Act
+        ResponseEntity<ClaimEnrichmentResponse> response =
+                exceptionHandler.handleMalformedJson(exception, request);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(400, response.getStatusCode().value());
+        assertFalse(response.getBody().isSuccess());
+        assertEquals("Invalid request", response.getBody().getMessage());
     }
 }


### PR DESCRIPTION
### Description :pencil:

Improve application security by preventing information disclosure in HTTP responses and error handling.

https://dsdmoj.atlassian.net/browse/STB-4337


---

### Changes Made :pencil:

- Removed/suppressed sensitive response headers (X-Powered-By, Server)
- Updated global exception handling with generic error responses
- Removed exposure of exception messages and validation details from API responses

---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [ ] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [x] I have a corresponding JIRA ticket for this change 
- [x] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:

Please fill in.

---