### PR TITLE
STB-4358: restrict enable on null disable type

### DIFF
--- a/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/RoleBasedAccessEnableUserTest.java
+++ b/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/RoleBasedAccessEnableUserTest.java
@@ -2,6 +2,7 @@ package uk.gov.justice.laa.portal.landingpage.controller;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.test.web.servlet.ResultMatcher;
+import uk.gov.justice.laa.portal.landingpage.entity.DisableType;
 import uk.gov.justice.laa.portal.landingpage.entity.EntraUser;
 import uk.gov.justice.laa.portal.landingpage.entity.UserProfile;
 
@@ -79,6 +80,7 @@ public class RoleBasedAccessEnableUserTest extends RoleBasedAccessIntegrationTes
         UserProfile disabledByProfile = firmUserManagers.getLast().getUserProfiles().stream()
                 .filter(UserProfile::isActiveProfile).findFirst().orElseThrow();
         accessedUser.setDisabledBy(disabledByProfile.getId());
+        accessedUser.setDisableType(DisableType.FIRM);
         entraUserRepository.saveAndFlush(accessedUser);
         EntraUser loggedInUser = firmUserManagers.getFirst();
         sendEnableUserPost(loggedInUser, accessedUser, status().isOk());

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/entity/DisableType.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/entity/DisableType.java
@@ -15,7 +15,8 @@ package uk.gov.justice.laa.portal.landingpage.entity;
  * </ol>
  *
  * <p>A {@code NULL} value in the database means the disable was not attributed to a known
- * actor (legacy data before this field existed). In that case all role levels may re-enable the user.
+ * actor (legacy data before this field existed). In that case only internal/LAA delegation
+ * roles may re-enable the user.
  */
 public enum DisableType {
 
@@ -27,7 +28,7 @@ public enum DisableType {
 
     /**
      * Disabled by a manual user sync process, or an unattributed disable before full tracking was introduced.
-     * All roles are permitted to re-enable (identical behaviour to a {@code null} disable type).
+     * All roles are permitted to re-enable.
      */
     NONE("None"),
 

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/service/UserEnablementPolicy.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/service/UserEnablementPolicy.java
@@ -15,7 +15,7 @@ import uk.gov.justice.laa.portal.landingpage.entity.DisableType;
  *
  * <table border="1">
  *   <tr><th>disable_type</th><th>FUM</th><th>EUM / EUA</th><th>SR / GA</th></tr>
- *   <tr><td>NULL (unknown/legacy)</td><td>✅</td><td>✅</td><td>✅</td></tr>
+ *   <tr><td>NULL (unknown/legacy)</td><td>❌</td><td>✅</td><td>✅</td></tr>
  *   <tr><td>NONE (manual sync)</td><td>✅</td><td>✅</td><td>✅</td></tr>
  *   <tr><td>SYNC (automated sync)</td><td>❌</td><td>✅</td><td>✅</td></tr>
  *   <tr><td>FIRM</td><td>✅ (same-firm check required separately)</td><td>✅</td><td>✅</td></tr>
@@ -46,18 +46,19 @@ public class UserEnablementPolicy {
      * @return {@code true} if enabling is permitted at the role level
      */
     public boolean canEnable(DisableType disableType, List<String> actorRoles) {
-        // Legacy / not-logged case: all roles permitted
-        if (disableType == null) {
-            return true;
-        }
-
         boolean isGlobalAdminOrSecurityResponse = actorRoles.contains(AuthzRole.GLOBAL_ADMIN.getRoleName())
                 || actorRoles.contains(AuthzRole.SECURITY_RESPONSE.getRoleName());
 
         boolean isEuaLevel = actorRoles.contains(AuthzRole.EXTERNAL_USER_MANAGER.getRoleName())
                 || actorRoles.contains(AuthzRole.EXTERNAL_USER_ADMIN.getRoleName());
 
+        boolean isInternalUserManager = actorRoles.contains(AuthzRole.INTERNAL_USER_MANAGER.getRoleName());
+
         boolean isFirmUserManager = actorRoles.contains(AuthzRole.FIRM_USER_MANAGER.getRoleName());
+
+        if (disableType == null) {
+            return isInternalUserManager || isEuaLevel || isGlobalAdminOrSecurityResponse;
+        }
 
         return switch (disableType) {
             case SYNC ->

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/service/UserEnablementPolicyTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/service/UserEnablementPolicyTest.java
@@ -209,13 +209,13 @@ class UserEnablementPolicyTest {
 
         @Test
         void none_fumWithEumRole_canEnable() {
-            // NONE-disabled users can be re-enabled by all roles.
+            // FUM alone cannot re-enable a NONE-disabled user, but EUM (higher delegation) can
             assertThat(policy.canEnable(DisableType.NONE, List.of(FUM, EUM))).isTrue();
         }
 
         @Test
         void none_fumWithSrRole_canEnable() {
-            // NONE-disabled users can be re-enabled by all roles.
+            // FUM alone cannot re-enable a NONE-disabled user, but SR (higher delegation) can
             assertThat(policy.canEnable(DisableType.NONE, List.of(FUM, SR))).isTrue();
         }
 

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/service/UserEnablementPolicyTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/service/UserEnablementPolicyTest.java
@@ -21,18 +21,28 @@ class UserEnablementPolicyTest {
     private static final String EUM = AuthzRole.EXTERNAL_USER_MANAGER.getRoleName();
     private static final String EUA = AuthzRole.EXTERNAL_USER_ADMIN.getRoleName();
     private static final String FUM = AuthzRole.FIRM_USER_MANAGER.getRoleName();
+    private static final String IUM = AuthzRole.INTERNAL_USER_MANAGER.getRoleName();
 
     @Nested
     class CanEnable {
 
         @Test
-        void nullDisableType_anyRole_returnsTrue() {
-            assertThat(policy.canEnable(null, List.of(FUM))).isTrue();
+        void nullDisableType_internalDelegationRoles_returnTrue() {
+            assertThat(policy.canEnable(null, List.of(IUM))).isTrue();
             assertThat(policy.canEnable(null, List.of(EUM))).isTrue();
             assertThat(policy.canEnable(null, List.of(EUA))).isTrue();
             assertThat(policy.canEnable(null, List.of(SR))).isTrue();
             assertThat(policy.canEnable(null, List.of(GA))).isTrue();
-            assertThat(policy.canEnable(null, List.of())).isTrue();
+        }
+
+        @Test
+        void nullDisableType_providerAdminCannotEnable() {
+            assertThat(policy.canEnable(null, List.of(FUM))).isFalse();
+        }
+
+        @Test
+        void nullDisableType_noRoleCannotEnable() {
+            assertThat(policy.canEnable(null, List.of())).isFalse();
         }
 
         // --- NONE disable type (Manual User Sync — all roles permitted) ---
@@ -199,13 +209,13 @@ class UserEnablementPolicyTest {
 
         @Test
         void none_fumWithEumRole_canEnable() {
-            // FUM alone cannot re-enable a NONE-disabled user, but EUM (higher delegation) can
+            // NONE-disabled users can be re-enabled by all roles.
             assertThat(policy.canEnable(DisableType.NONE, List.of(FUM, EUM))).isTrue();
         }
 
         @Test
         void none_fumWithSrRole_canEnable() {
-            // FUM alone cannot re-enable a NONE-disabled user, but SR (higher delegation) can
+            // NONE-disabled users can be re-enabled by all roles.
             assertThat(policy.canEnable(DisableType.NONE, List.of(FUM, SR))).isTrue();
         }
 


### PR DESCRIPTION
### Description :pencil:

Restrict enablement on null user type for any external users.

---

### Changes Made :pencil:

- Changed null disable type from defaulting canEnable to true
- Added logic to check if user is internal, returning true for canEnable if so
- 

---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [ ] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [x] I have a corresponding JIRA ticket for this change 
- [x] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:

Please fill in.

---