### PR TITLE
STB-4353 - Refactor role assignment error handling and enhance button functionality in user role management forms

### DIFF
--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
@@ -1693,8 +1693,10 @@ public class UserController {
                         "role");
                 eventService.logEvent(updateUserAuditEvent);
                 notifyExternalUserRoleChange(user, updateResult.get("diff"), "Service roles");
-            } catch (Exception e) {
-                log.warn("Duplicate or concurrent role assignment detected for user {} - continuing to confirmation", id);
+            } catch (DataIntegrityViolationException e) {
+                log.warn("Duplicate role assignment detected for user {} - continuing to confirmation", id);
+            } catch (TechServicesClientException e) {
+                log.warn("Concurrent Tech Services request detected for user {} - continuing to confirmation", id);
             }
         }
         // Clear the session

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
@@ -1693,8 +1693,8 @@ public class UserController {
                         "role");
                 eventService.logEvent(updateUserAuditEvent);
                 notifyExternalUserRoleChange(user, updateResult.get("diff"), "Service roles");
-            } catch (DataIntegrityViolationException e) {
-                log.warn("Duplicate role assignment detected for user {} - continuing to confirmation", id);
+            } catch (Exception e) {
+                log.warn("Duplicate or concurrent role assignment detected for user {} - continuing to confirmation", id);
             }
         }
         // Clear the session
@@ -2829,6 +2829,8 @@ public class UserController {
 
             notifyExternalUserRoleChange(userProfileDto, "You have been granted access to services and offices", "Access granted");
 
+        } catch (DataIntegrityViolationException e) {
+            log.warn("Duplicate role assignment detected for user {} during grant access - continuing to confirmation", id);
         } catch (Exception e) {
             log.error("Error completing grant access for user: " + id, e);
             // Could add error handling here if needed

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/service/LiveTechServicesClient.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/service/LiveTechServicesClient.java
@@ -1,8 +1,16 @@
 package uk.gov.justice.laa.portal.landingpage.service;
 
-import com.azure.core.credential.TokenRequestContext;
-import com.azure.identity.ClientSecretCredential;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -18,6 +26,11 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestClient;
+
+import com.azure.core.credential.TokenRequestContext;
+import com.azure.identity.ClientSecretCredential;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import uk.gov.justice.laa.portal.landingpage.config.CachingConfig;
 import uk.gov.justice.laa.portal.landingpage.dto.EntraUserDto;
 import uk.gov.justice.laa.portal.landingpage.entity.EntraUser;
@@ -38,17 +51,6 @@ import uk.gov.justice.laa.portal.landingpage.techservices.TechServicesErrorRespo
 import uk.gov.justice.laa.portal.landingpage.techservices.UpdateSecurityGroupsRequest;
 import uk.gov.justice.laa.portal.landingpage.techservices.UpdateSecurityGroupsResponse;
 import uk.gov.justice.laa.portal.landingpage.techservices.UpdateUserDetailsRequest;
-
-import java.time.Duration;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
-import java.util.UUID;
-import java.util.stream.Collectors;
 
 public class LiveTechServicesClient implements TechServicesClient {
 
@@ -136,7 +138,7 @@ public class LiveTechServicesClient implements TechServicesClient {
             throw new BadRequestException(e);
         } catch (Exception ex) {
             logger.error("Error while sending security group changes to Tech Services.", ex);
-            throw new RuntimeException("Error while sending security group changes to Tech Services.", ex);
+            throw new TechServicesClientException("Error while sending security group changes to Tech Services.", ex);
         }
 
     }

--- a/src/main/resources/templates/edit-user-roles-check-answer.html
+++ b/src/main/resources/templates/edit-user-roles-check-answer.html
@@ -123,7 +123,7 @@
         <p class="govuk-body">When you confirm, the user will get access to the chosen services.
         </p>
         <div class="govuk-button-group">
-            <button type="submit" th:disabled="${errorMessage != null}" class="govuk-button" data-module="govuk-button" data-prevent-double-click="true">Confirm</button>
+            <button type="submit" th:disabled="${errorMessage != null}" class="govuk-button" data-module="govuk-button" onclick="this.disabled=true; this.form.submit();">Confirm</button>
             <a th:href="@{/admin/users/edit/{id}/cancel/confirmation(id=${user.id})}" class="govuk-link">Cancel</a>
         </div>
     </form>

--- a/src/main/resources/templates/grant-access-check-answers.html
+++ b/src/main/resources/templates/grant-access-check-answers.html
@@ -169,7 +169,7 @@
                         assigned.
                     </p>
                     <div class="govuk-button-group">
-                        <button type="submit" class="govuk-button govuk-!-font-size-19 govuk-!-font-weight-bold" data-module="govuk-button" data-prevent-double-click="true" th:disabled="${errorMessage != null}">
+                        <button type="submit" class="govuk-button govuk-!-font-size-19 govuk-!-font-weight-bold" data-module="govuk-button" th:disabled="${errorMessage != null}" onclick="this.disabled=true; this.form.submit();">
                             Confirm
                         </button>
                         <a th:href="@{/admin/users/grant-access/{id}/cancel/confirmation(id=${user.id})}" class="govuk-link govuk-link--no-visited-state">Cancel</a>

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/UserControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/UserControllerTest.java
@@ -2065,6 +2065,34 @@ class UserControllerTest {
         assertThat(redirect).isEqualTo("redirect:/admin/users/edit/" + userId + "/confirmation");
     }
 
+    @Test
+    public void editUserRolesCheckAnswerSubmit_shouldRedirectToConfirmation_whenTechServicesExceptionOccurs() {
+        // Given
+        CurrentUserDto currentUserDto = new CurrentUserDto();
+        currentUserDto.setUserId(UUID.randomUUID());
+        currentUserDto.setName("tester");
+        when(loginService.getCurrentUser(authentication)).thenReturn(currentUserDto);
+        when(loginService.getCurrentProfile(authentication))
+                .thenReturn(UserProfile.builder().appRoles(new HashSet<>()).build());
+        UUID userId = UUID.randomUUID();
+        UserProfileDto userProfile = UserProfileDto.builder()
+                .id(userId)
+                .userType(UserType.EXTERNAL)
+                .build();
+        when(userService.getUserProfileById(userId.toString())).thenReturn(Optional.ofNullable(userProfile));
+        HttpSession session = new MockHttpSession();
+        session.setAttribute("editUserAllSelectedRoles", new HashMap<>());
+        when(roleAssignmentService.canAssignRole(any(), any())).thenReturn(true);
+        when(userService.updateUserRoles(any(), any(), any(), any()))
+                .thenThrow(new TechServicesClientException("Error while sending security group changes to Tech Services."));
+
+        // When
+        String redirect = userController.editUserRolesCheckAnswerSubmit(userId.toString(), session, authentication);
+
+        // Then - concurrent Tech Services failure is handled gracefully; user still reaches confirmation
+        assertThat(redirect).isEqualTo("redirect:/admin/users/edit/" + userId + "/confirmation");
+    }
+
     // ===== NEW EDIT USER FUNCTIONALITY TESTS =====
 
     @Test
@@ -6581,6 +6609,40 @@ class UserControllerTest {
 
         // then
         assertThat(view).isEqualTo("redirect:/admin/users/manage/" + userId);
+    }
+
+    @Test
+    void grantAccessProcessCheckAnswers_shouldRedirectToConfirmation_whenDuplicateRoleViolationOccurs() {
+        // Given
+        final String userId = "550e8400-e29b-41d4-a716-446655440012";
+        UserProfileDto userProfileDto = new UserProfileDto();
+        EntraUserDto entraUser = new EntraUserDto();
+        entraUser.setFullName("Test User");
+        userProfileDto.setEntraUser(entraUser);
+
+        CurrentUserDto currentUserDto = new CurrentUserDto();
+        currentUserDto.setUserId(UUID.randomUUID());
+        currentUserDto.setName("admin user");
+
+        MockHttpSession testSession = new MockHttpSession();
+        testSession.setAttribute("allSelectedRoles", Set.of("Role 1"));
+        testSession.setAttribute("selectedOffices", List.of("Office 1"));
+
+        when(userService.getUserProfileById(userId)).thenReturn(Optional.of(userProfileDto));
+        when(loginService.getCurrentUser(authentication)).thenReturn(currentUserDto);
+        when(loginService.getCurrentProfile(authentication)).thenReturn(UserProfile.builder().build());
+        when(roleAssignmentService.canAssignRole(any(), anyCollection())).thenReturn(true);
+        when(userService.updateUserRoles(any(), anyCollection(), anyList(), any()))
+                .thenThrow(new DataIntegrityViolationException(
+                        "could not execute statement; constraint [user_profile_app_role_pkey]"));
+
+        // When
+        String view = userController.grantAccessProcessCheckAnswers(userId, authentication, redirectAttributes, testSession);
+
+        // Then - duplicate key violation from concurrent submit is handled gracefully; user still reaches confirmation
+        assertThat(view).isEqualTo("redirect:/admin/users/grant-access/" + userId + "/confirmation");
+        assertThat(testSession.getAttribute("allSelectedRoles")).isNull();
+        assertThat(testSession.getAttribute("selectedOffices")).isNull();
     }
 
     @Test


### PR DESCRIPTION
### Description :pencil:

Fix spam-click double submit on Manage Access and Edit Apps check-answers pages by disabling the submit button on click.
Add backend exception handling to prevent error pages when concurrent requests cause duplicate role assignments or Tech Services conflicts.


https://github.com/user-attachments/assets/569402f0-50bb-41db-b858-8bb70a5a13a3



---

### Changes Made :pencil:

This pull request improves the handling of duplicate or concurrent role assignments and enhances the user interface to prevent double form submissions on confirmation actions. The changes ensure a smoother user experience and more robust error handling during user role updates and access grants.

**Error handling improvements:**

* Broadened the exception handling in `editUserRolesCheckAnswerSubmit` (in `UserController.java`) to catch all exceptions, updating the log message to indicate both duplicate and concurrent role assignments.
* Added a specific catch for `DataIntegrityViolationException` in `grantAccessProcessCheckAnswers` (in `UserController.java`) to log duplicate role assignment attempts during access grants, allowing the process to continue to confirmation.

**User interface enhancements:**

* Updated the "Confirm" button in both `edit-user-roles-check-answer.html` and `grant-access-check-answers.html` templates to disable the button and submit the form on click, preventing double submissions from users. [[1]](diffhunk://#diff-2e7247015f748e65a2d95d69ff754b3f40b6be9404ce858aa56feab88d78c03aL126-R126) [[2]](diffhunk://#diff-e754d3f165de717dfc3bbb8d91223484668b5722d1a0050d76033eac52755009L172-R172)

---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [ ] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [x] I have a corresponding JIRA ticket for this change 
- [ ] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:

Please fill in.

---