### PR TITLE
STB-4342: Fixed bug where role selection was being cleared too early in grant access flow.

### DIFF
--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
@@ -2148,8 +2148,6 @@ public class UserController {
 
         // Clear role selections
         session.removeAttribute("grantAccessUserRolesModel");
-        session.removeAttribute("grantAccessAllSelectedRoles");
-        session.removeAttribute("allSelectedRoles");
         session.removeAttribute("nonEditableRoles");
 
         // Store the model in session to handle validation errors later


### PR DESCRIPTION
### Description :pencil:

Role selections were being cleared every time the user goes back to the app selection stage of the grant user flow. With the new check your answers refactor this causes a bug where role selections are cleared too early.

---

### Changes Made :pencil:

- Removed session clearing after app selection.

---

### Checklist :pencil:

- [X] I have added the relevant Liquibase changelog files for any entity changes
- [X] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [X] I have taken into account the application runs as 3 replicas in live environments
- [X] I have created any relevant documentation for this change
- [X] I have a corresponding JIRA ticket for this change 
- [X] I have added relevant unit & integration tests where applicable

---