### PR TITLE
STB-4432: Changed resend verification link behaviour to show for disabled users.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 ext {
     springDocVersion = "3.0.0"
     playwrightVersion = "1.52.0"
-    testcontainersVersion = "1.20.4"
+    testcontainersVersion = "1.21.4"
     apiGuardianVersion = "1.1.2"
 }
 

--- a/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/ResendActivationCodeIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/ResendActivationCodeIntegrationTest.java
@@ -1,0 +1,85 @@
+package uk.gov.justice.laa.portal.landingpage.controller;
+
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.web.servlet.ModelAndView;
+import uk.gov.justice.laa.portal.landingpage.entity.EntraUser;
+import uk.gov.justice.laa.portal.landingpage.entity.InvitationStatus;
+import uk.gov.justice.laa.portal.landingpage.entity.UserProfile;
+
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class ResendActivationCodeIntegrationTest extends RoleBasedAccessIntegrationTest {
+
+    @Test
+    public void testResendActivationCodeInAuditDetailIsShownWhenUserIsDisabled() throws Exception {
+        testResendVerificationLink(this::userAuditDetailsGet);
+    }
+
+    @Test
+    public void testResendActivationCodeInManageUserIsShownWhenUserIsDisabled() throws Exception {
+        testResendVerificationLink(this::manageUserGet);
+    }
+
+    private void testResendVerificationLink(BiFunction<EntraUser, EntraUser, MvcResult> pageGetSupplier) {
+        EntraUser accessedUser = externalUsersNoRoles.getFirst();
+
+        // Disable User and set invitation status to INVITE_SENT.
+        accessedUser.setEnabled(false);
+        accessedUser.setInvitationStatus(InvitationStatus.INVITE_SENT);
+        accessedUser = entraUserRepository.save(accessedUser);
+
+        // Fetch audit details page.
+        EntraUser loggedInUser = globalAdmins.getFirst();
+        MvcResult result = pageGetSupplier.apply(loggedInUser, accessedUser);
+
+        // Assert response params are populated.
+        ModelAndView modelAndView = result.getModelAndView();
+        assertThat(modelAndView).isNotNull();
+        Map<String, Object> model = modelAndView.getModel();
+        assertThat(model).isNotNull();
+
+        // Assert resend link is visible.
+        boolean showResendVerificationLink = (boolean) model.get("showResendVerificationLink");
+        assertThat(showResendVerificationLink).isTrue();
+
+        // Teardown - re-enable user and change invitation status back.
+        accessedUser.setEnabled(true);
+        accessedUser.setInvitationStatus(InvitationStatus.VERIFICATION_SUCCESS);
+        entraUserRepository.save(accessedUser);
+    }
+
+
+    private MvcResult userAuditDetailsGet(EntraUser loggedInUser, EntraUser accessedUser) {
+        try {
+            return this.mockMvc.perform(get(String.format("/admin/users/audit/%s", accessedUser.getId()))
+                            .with(userOauth2Login(loggedInUser)))
+                            .andExpect(status().isOk())
+                            .andReturn();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private MvcResult manageUserGet(EntraUser loggedInUser, EntraUser accessedUser) {
+        UserProfile accessedUserProfile = accessedUser.getUserProfiles().stream().findFirst().orElseThrow();
+        try {
+            return this.mockMvc.perform(get(String.format("/admin/users/manage/%s", accessedUserProfile.getId()))
+                            .with(userOauth2Login(loggedInUser)))
+                    .andExpect(status().isOk())
+                    .andReturn();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+
+}

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/service/AccessControlService.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/service/AccessControlService.java
@@ -692,7 +692,6 @@ public class AccessControlService {
 
         return userService.isInternal(authenticatedUser.getId())
                 && !userService.isInternal(accessedUser.getId())
-                && accessedUser.isEnabled()
                 && !InvitationStatus.VERIFICATION_SUCCESS.equals(accessedUser.getInvitationStatus())
                 && userHasAnyGivenPermissions(authenticatedUser, Permission.RESEND_VERIFICATION_EMAIL);
     }
@@ -713,7 +712,6 @@ public class AccessControlService {
 
         return userService.isInternal(authenticatedUser.getId())
                 && !isAccessedUserInternal
-                && accessedUser.isEnabled()
                 && !InvitationStatus.VERIFICATION_SUCCESS.equals(accessedUser.getInvitationStatus())
                 && userHasAnyGivenPermissions(authenticatedUser, Permission.RESEND_VERIFICATION_EMAIL);
     }


### PR DESCRIPTION
### Description :pencil:

Allowed the "Resend Activation Code" link to be shown for disabled users on the audit details page and manage user page.

---

### Changes Made :pencil:

- Removed enabled user check from audit details page. 
- Removed enabled user check from manage user page.
- Added integration tests.
- Bumped testcontainers version for local docker compatibility.

---

### Checklist :pencil:

- [X] I have added the relevant Liquibase changelog files for any entity changes
- [X] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [X] I have taken into account the application runs as 3 replicas in live environments
- [X] I have created any relevant documentation for this change
- [X] I have a corresponding JIRA ticket for this change 
- [X] I have added relevant unit & integration tests where applicable