### PR TITLE
STB-4467: Fixed bug where Tech Services API return null for account enabled threw exception.

### DIFF
--- a/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/config/JacksonMapperIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/config/JacksonMapperIntegrationTest.java
@@ -1,0 +1,55 @@
+package uk.gov.justice.laa.portal.landingpage.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import tools.jackson.databind.ObjectMapper;
+import uk.gov.justice.laa.portal.landingpage.controller.BaseIntegrationTest;
+import uk.gov.justice.laa.portal.landingpage.techservices.GetUserResponse;
+
+public class JacksonMapperIntegrationTest extends BaseIntegrationTest {
+
+    private static final String TEST_TECH_SERVICES_USER_RESPONSE =
+            """
+                    {
+                        "success": true,
+                        "user": {
+                            "id": "11111111-2222-3333-4444-555555555555",
+                            "displayName": "Test User",
+                            "givenName": "Test",
+                            "surname": "User",
+                            "email": "test@test.com",
+                            "alias": [
+                                "test@test.com"
+                            ],
+                            "accountEnabled": true,
+                            "createdDateTime": "1970-01-01T00:00:00Z",
+                            "lastSignIn": "1970-01-01T00:00:00Z",
+                            "groups": [
+                                "11111111-2222-3333-4444-555555555555"
+                            ],
+                            "customSecurityAttributes": {
+                                "GuestUserStatus": {
+                                    "@odata.type": "#microsoft.graph.customSecurityAttributeValue",
+                                    "DisabledReason": "UserRequest"
+                                }
+                            },
+                            "isMailOnly": false,
+                            "deleted": false
+                        },
+                        "verification": null
+                    }
+            """;
+
+
+    @Autowired
+    @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
+    public ObjectMapper objectMapper;
+
+    @Test
+    public void testGetUserTechServicesResponseBindsWithoutAccountEnabledProperty() {
+        // Remove account enabled attribute from test JSON
+        String json = TEST_TECH_SERVICES_USER_RESPONSE.replace("\"accountEnabled\": true,", "");
+        // Ensure it still binds without exception with property missing
+        objectMapper.readValue(json, GetUserResponse.class);
+    }
+}

--- a/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/config/JacksonMapperIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/config/JacksonMapperIntegrationTest.java
@@ -52,4 +52,21 @@ public class JacksonMapperIntegrationTest extends BaseIntegrationTest {
         // Ensure it still binds without exception with property missing
         objectMapper.readValue(json, GetUserResponse.class);
     }
+
+    @Test
+    public void testGetUserTechServicesResponseBindsWithoutIsMailOnlyProperty() {
+        // Remove isMailOnly attribute from test JSON
+        String json = TEST_TECH_SERVICES_USER_RESPONSE.replace("\"isMailOnly\": false,", "");
+        // Ensure it still binds without exception with property missing
+        objectMapper.readValue(json, GetUserResponse.class);
+    }
+
+    @Test
+    public void testGetUserTechServicesResponseBindsWithOnlyDeleteProperty() {
+        // Test simple user json with only delete property.
+        String json = "{\"success\": true, \"user\": {\"deleted\":true}}";
+
+        // Ensure it still binds without exception with property missing
+        objectMapper.readValue(json, GetUserResponse.class);
+    }
 }

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/service/ExternalUserPollingService.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/service/ExternalUserPollingService.java
@@ -139,13 +139,16 @@ public class ExternalUserPollingService {
                     boolean isEnabledInSilas = entraUser.isEnabled();
 
                     // Update user fields if not deleted
-
-                    if (user.isAccountEnabled() && !isEnabledInSilas) {
-                        // user account enabled in entra, re-enabling in silas
-                        enableUserWithReason(user, entraUser);
-                    } else if (!user.isAccountEnabled() && isEnabledInSilas) {
-                        //user account has disabled reason in entra, disabling in silas
-                        disableUserWithReason(user, entraUser);
+                    if (user.getAccountEnabled() != null) {
+                        if (user.getAccountEnabled() && !isEnabledInSilas) {
+                            // user account enabled in entra, re-enabling in silas
+                            enableUserWithReason(user, entraUser);
+                        } else if (!user.getAccountEnabled() && isEnabledInSilas) {
+                            //user account has disabled reason in entra, disabling in silas
+                            disableUserWithReason(user, entraUser);
+                        }
+                    } else {
+                        log.warn("Could not update enabled status of user with ID {} when polling external users. Tech Services returned null for enabled status", entraUser.getId());
                     }
 
                     updateAccountActivationStatus(user, entraUser);

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/service/ExternalUserPollingService.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/service/ExternalUserPollingService.java
@@ -165,9 +165,12 @@ public class ExternalUserPollingService {
                         entraUser.setEmail(user.getEmail());
                     }
 
-                    if (user.isMailOnly() != entraUser.isMailOnly()) {
-                        entraUser.setMailOnly(user.isMailOnly());
+                    if (user.getIsMailOnly() != null) {
+                        if (user.getIsMailOnly() != entraUser.isMailOnly()) {
+                            entraUser.setMailOnly(user.getIsMailOnly());
+                        }
                     }
+
 
                     // Update Silas Status for the user
                     userService.refreshAndUpdatedUserProfilesStatus(entraUser.isEnabled(), entraUser.getInvitationStatus(), entraUser.getUserProfiles());

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/techservices/TechServicesUser.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/techservices/TechServicesUser.java
@@ -27,7 +27,7 @@ public class TechServicesUser implements Serializable {
     private String mail;
 
     @JsonProperty("accountEnabled")
-    private boolean accountEnabled;
+    private Boolean accountEnabled;
 
     @JsonProperty("createdDateTime")
     private LocalDateTime createdDateTime;

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/techservices/TechServicesUser.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/techservices/TechServicesUser.java
@@ -51,7 +51,7 @@ public class TechServicesUser implements Serializable {
     private CustomSecurityAttributes customSecurityAttributes;
 
     @JsonProperty("isMailOnly")
-    private boolean isMailOnly;
+    private Boolean isMailOnly;
 
     @JsonProperty("deleted")
     private boolean deleted;

--- a/src/main/resources/templates/user-audit/details.html
+++ b/src/main/resources/templates/user-audit/details.html
@@ -226,7 +226,7 @@
                             </div>
                             <div class="govuk-summary-card__content">
                                 <dl class="govuk-summary-list">
-                                    <div class="govuk-summary-list__row" th:if="${entraUser != null && !entraUser.accountEnabled}">
+                                    <div class="govuk-summary-list__row" th:if="${entraUser != null && entraUser.accountEnabled != null && !entraUser.accountEnabled}">
                                         <dt class="govuk-summary-list__key">Disable Reason</dt>
                                         <dd class="govuk-summary-list__value" th:if="${entraUser.customSecurityAttributes == null || entraUser.customSecurityAttributes.guestUserStatus == null || entraUser.customSecurityAttributes.guestUserStatus.disabledReason == null}">Unknown</dd>
                                         <dd class="govuk-summary-list__value" th:if="${entraUser.customSecurityAttributes != null && entraUser.customSecurityAttributes.guestUserStatus != null && entraUser.customSecurityAttributes.guestUserStatus.disabledReason != null}" th:text="${entraUserDisableReason}"></dd>


### PR DESCRIPTION
### Description :pencil:

When fetching user details from the Tech Services API, it was sometimes returning no value or a null value for the "accountEnabled" field. This caused an exception to be thrown on the SiLAS end. Adding some logic to handle this more gracefully.

---

### Changes Made :pencil:

- Changed accountEnabled field to boxed Boolean type to handle null.
- Updated polling logic to handle case where accountEnabled is null
- Added integration test to test json parsing when accountenabled is null.
- Updated some front end logic to ensure it can handle accountEnabled being null.

---

### Checklist :pencil:

- [X] I have added the relevant Liquibase changelog files for any entity changes
- [X] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [X] I have taken into account the application runs as 3 replicas in live environments
- [X] I have created any relevant documentation for this change
- [X] I have a corresponding JIRA ticket for this change 
- [X] I have added relevant unit & integration tests where applicable

---