### PR TITLE
STB-4126 - Revert the logs so entra_oid from TS response is logged

### DIFF
--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/service/LiveTechServicesClient.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/service/LiveTechServicesClient.java
@@ -235,11 +235,11 @@ public class LiveTechServicesClient implements TechServicesClient {
                 if (response.getStatusCode().isSameCodeAs(HttpStatus.CREATED)) {
                     responseBody.setResponseType(RegisterUserResponse.ResponseType.CREATED);
                     logger.info("New User creation by Tech Services is successful for entra user: {} with security groups {} added",
-                            user.getId(), securityGroups);
+                            responseBody.getUser().getId(), securityGroups);
                     return TechServicesApiResponse.success(responseBody);
                 } else if (response.getStatusCode().isSameCodeAs(HttpStatus.OK)) {
                     responseBody.setResponseType(RegisterUserResponse.ResponseType.VERIFIED);
-                    logger.info("Tech Services request successful, user exists in Entra  for entra user: {}", user.getId());
+                    logger.info("Tech Services request successful, user exists in Entra  for entra user: {}", responseBody.getUser().getId());
                     return TechServicesApiResponse.success(responseBody);
                 } else {
                     logger.error("Error while sending new user creation request to Tech Services, for user entra oid: {}", user.getEntraOid());

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/service/LiveTechServicesClientTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/service/LiveTechServicesClientTest.java
@@ -711,7 +711,7 @@ public class LiveTechServicesClientTest {
         liveTechServicesClient.registerNewUser(user);
 
         assertLogMessage(Level.INFO, "Sending create new user request with security groups to tech services:");
-        assertLogMessage(Level.INFO, "New User creation by Tech Services is successful for entra user: id");
+        assertLogMessage(Level.INFO, "New User creation by Tech Services is successful for entra user: 12345678-1234-1234-1234-123456789012");
         verify(restClient, times(1)).post();
     }
 
@@ -775,7 +775,7 @@ public class LiveTechServicesClientTest {
         liveTechServicesClient.registerNewUser(user);
 
         assertLogMessage(Level.INFO, "Sending create new user request with security groups to tech services:");
-        assertLogMessage(Level.INFO, "Tech Services request successful, user exists in Entra  for entra user: id");
+        assertLogMessage(Level.INFO, "Tech Services request successful, user exists in Entra  for entra user: 12345678-1234-1234-1234-123456789012");
         verify(restClient, times(1)).post();
     }
 
@@ -814,7 +814,7 @@ public class LiveTechServicesClientTest {
         liveTechServicesClient.registerNewUser(user);
 
         assertLogMessage(Level.INFO, "Sending create new user request with security groups to tech services:");
-        assertLogMessage(Level.INFO, "New User creation by Tech Services is successful for entra user: id");
+        assertLogMessage(Level.INFO, "New User creation by Tech Services is successful for entra user: 12345678-1234-1234-1234-123456789012");
         verify(restClient, times(1)).post();
     }
 


### PR DESCRIPTION
### Description :pencil:

STB-4126 - Revert the logs so entra_oid from TS response is logged

---

### Changes Made :pencil:

- 
- 
- 

---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [ ] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [ ] I have a corresponding JIRA ticket for this change 
- [ ] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:

Please fill in.

---