### PR TITLE
STB-4493 - Use the name returned from Entra response on user re-create

### DIFF
--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/service/UserService.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/service/UserService.java
@@ -958,6 +958,11 @@ public class UserService {
 
     @Transactional
     protected EntraUser syncUserStatus(TechServicesUser tsUser, EntraUser entraUser) {
+        // Populate details from Entra
+        entraUser.setEmail(tsUser.getEmail());
+        entraUser.setFirstName(tsUser.getGivenName());
+        entraUser.setLastName(tsUser.getSurname());
+
         updateAccountActivationStatus(tsUser, entraUser);
 
         if (tsUser.getIsMailOnly() != null) {

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/service/UserServiceTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/service/UserServiceTest.java
@@ -791,6 +791,38 @@ class UserServiceTest {
     }
 
     @Test
+    void recreateUserWithDifferentName() {
+        // assign role
+        TechServicesUser createdUser = new TechServicesUser();
+        createdUser.setId("id");
+        createdUser.setMail("test.user@email.com");
+        createdUser.setGivenName("New Name");
+        createdUser.setSurname("New Surname");
+        TechServicesApiResponse<RegisterUserResponse> registerUserResponse = TechServicesApiResponse
+                .success(RegisterUserResponse.builder().user(createdUser)
+                        .responseType(RegisterUserResponse.ResponseType.VERIFIED)
+                        .message("User created successfully. An email has been sent to the user with their activation code")
+                        .build());
+        when(techServicesClient.registerNewUser(any(EntraUserDto.class))).thenReturn(registerUserResponse);
+        when(techServicesClient.enableUser(any(EntraUserDto.class))).thenReturn(TechServicesApiResponse.success(null));
+        when(mockEntraUserRepository.saveAndFlush(any(EntraUser.class))).thenAnswer(returnsFirstArg());
+
+        EntraUserDto entraUserDto = new EntraUserDto();
+        entraUserDto.setFirstName("Test");
+        entraUserDto.setLastName("User");
+        entraUserDto.setEmail("test.user@email.com");
+        FirmDto firm = FirmDto.builder().name("Firm").build();
+        EntraUser result = userService.createUser(entraUserDto, firm, true, "admin", false);
+        assertThat(result).isNotNull();
+        assertThat(result.getFirstName()).isEqualTo("New Name");
+        assertThat(result.getLastName()).isEqualTo("New Surname");
+        assertThat(result.getUserProfiles()).isNotEmpty();
+        assertThat(result.getUserProfiles()).hasSize(1);
+        verify(mockEntraUserRepository, times(1)).saveAndFlush(any());
+        verify(techServicesClient, times(1)).registerNewUser(any(EntraUserDto.class));
+    }
+
+    @Test
     void getUserAppRolesByUserId_returnsRoleDetails_whenServicePrincipalAndRoleExist() {
         // Arrange
         UUID userProfileId = UUID.randomUUID();


### PR DESCRIPTION
### Description :pencil:

STB-4493 - Use the name returned from Entra response on user re-create

https://dsdmoj.atlassian.net/browse/STB-4493

---

### Changes Made :pencil:

- 
- 
- 

---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [ ] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [ ] I have a corresponding JIRA ticket for this change 
- [ ] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:

Please fill in.

---