### PR TITLE
Stb 4381

### DIFF
--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/UserController.java
@@ -1035,7 +1035,8 @@ public class UserController {
                 }
             }
         } else {
-            log.error("No user attribute was present in request. User not added to model.");
+            log.warn("No user attribute was present in request. Redirecting to /admin/users.");
+            return "redirect:/admin/users";
         }
 
         model.addAttribute("isMultiFirmUser", isMultiFirmUser != null ? isMultiFirmUser : false);

--- a/src/main/resources/templates/add-user-created.html
+++ b/src/main/resources/templates/add-user-created.html
@@ -17,7 +17,7 @@
         <div class="govuk-!-width-two-thirds">
             <div class="govuk-panel govuk-panel--confirmation">
                 <h1 class="govuk-panel__title">User created</h1>
-                <div class="govuk-panel__body">
+                <div class="govuk-panel__body" th:if="${user != null}">
                     <span th:text="${user.firstName}"></span> <span th:text="${user.lastName}"></span> has been added
                 </div>
             </div>

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/UserControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/UserControllerTest.java
@@ -1274,8 +1274,7 @@ class UserControllerTest {
         HttpSession session = new MockHttpSession();
         ListAppender<ILoggingEvent> listAppender = LogMonitoring.addListAppenderToLogger(UserController.class);
         String view = userController.addUserCreated(model, session);
-        assertThat(model.getAttribute("user")).isNull();
-        assertThat(view).isEqualTo("add-user-created");
+        assertThat(view).isEqualTo("redirect:/admin/users");
         List<ILoggingEvent> logEvents = LogMonitoring.getLogsByLevel(listAppender, Level.ERROR);
         assertThat(logEvents).hasSize(1);
     }

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/UserControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/UserControllerTest.java
@@ -1275,7 +1275,7 @@ class UserControllerTest {
         ListAppender<ILoggingEvent> listAppender = LogMonitoring.addListAppenderToLogger(UserController.class);
         String view = userController.addUserCreated(model, session);
         assertThat(view).isEqualTo("redirect:/admin/users");
-        List<ILoggingEvent> logEvents = LogMonitoring.getLogsByLevel(listAppender, Level.ERROR);
+        List<ILoggingEvent> logEvents = LogMonitoring.getLogsByLevel(listAppender, Level.WARN);
         assertThat(logEvents).hasSize(1);
     }
 

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/UserControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/UserControllerTest.java
@@ -8420,4 +8420,43 @@ class UserControllerTest {
         }
 
     }
+
+    @Nested
+    class AddUserCreated {
+
+        @Test
+        void addUserCreated_whenUserInSession_returnsConfirmationView() {
+            // Given
+            MockHttpSession testSession = new MockHttpSession();
+            EntraUserDto user = new EntraUserDto();
+            user.setFirstName("Jane");
+            user.setLastName("Smith");
+            testSession.setAttribute("user", user);
+            testSession.setAttribute("isMultiFirmUser", false);
+
+            UserProfileDto userProfile = new UserProfileDto();
+            testSession.setAttribute("userProfile", userProfile);
+
+            // When
+            String view = userController.addUserCreated(model, testSession);
+
+            // Then
+            assertThat(view).isEqualTo("add-user-created");
+            assertThat(testSession.getAttribute("user")).isNull();
+            assertThat(testSession.getAttribute("userProfile")).isNull();
+            assertThat(testSession.getAttribute("isMultiFirmUser")).isNull();
+        }
+
+        @Test
+        void addUserCreated_whenNoUserInSession_redirectsToUsers() {
+            // Given
+            MockHttpSession testSession = new MockHttpSession();
+
+            // When
+            String view = userController.addUserCreated(model, testSession);
+
+            // Then
+            assertThat(view).isEqualTo("redirect:/admin/users");
+        }
+    }
 }


### PR DESCRIPTION
### Description :pencil:

When the GET `/admin/user/create/confirmation `endpoint was hit with no `user` in the HTTP session (e.g. page refresh after creation, direct navigation, or session expiry), the Thymeleaf template threw a `SpelEvaluationException` trying to read `user.firstName `on a null object.

---

### Changes Made :pencil:

This pull request improves the handling of the "add user created" flow by ensuring that users are redirected appropriately when required session data is missing, updating the confirmation view to prevent errors, and adding comprehensive tests to verify the new behavior.

**Improved session handling and user feedback**
- [`UserController.java`](diffhunk://#diff-1c3931784714b5992966f392b56dad9140ea42ba7303dfce45c2cb8533ed3885L1038-R1039): Now redirects to `/admin/users` with a warning when the user attribute is missing from the session, instead of just logging an error.
- [`add-user-created.html`](diffhunk://#diff-9d175ca477cf50e5b55ad685ab559a6608ce8752330c63c0040fcddfe9ad6a35L20-R20): Only displays the confirmation message if the `user` attribute is present, preventing potential template errors.

**Testing enhancements**
- [`UserControllerTest.java`](diffhunk://#diff-21057d4cac378b8df4513dea5fe6f79c549a4ccfaf968a2440e01349f6417183R8423-R8461): Added tests to verify that the confirmation view is shown when a user is present in the session and that a redirect occurs when the user is missing.

---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [ ] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [ ] I have a corresponding JIRA ticket for this change 
- [ ] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:

Please fill in.

---