### PR TITLE
STB-4433: Added logic to update user account status when fetched from entra in audit drilldown

### DIFF
--- a/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/UserAccountStatusRefreshIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/justice/laa/portal/landingpage/controller/UserAccountStatusRefreshIntegrationTest.java
@@ -1,0 +1,91 @@
+package uk.gov.justice.laa.portal.landingpage.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MvcResult;
+import uk.gov.justice.laa.portal.landingpage.entity.EntraUser;
+import uk.gov.justice.laa.portal.landingpage.service.TechServicesClient;
+import uk.gov.justice.laa.portal.landingpage.techservices.GetUserResponse;
+import uk.gov.justice.laa.portal.landingpage.techservices.TechServicesApiResponse;
+import uk.gov.justice.laa.portal.landingpage.techservices.TechServicesUser;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class UserAccountStatusRefreshIntegrationTest extends RoleBasedAccessIntegrationTest {
+
+    @MockitoBean
+    private TechServicesClient techServicesClient;
+
+    @Test
+    public void testUserEnabledStatusIsChangedToDisabledWhenEntraSaysDisabled() throws Exception {
+        EntraUser accessedUser = externalUsersNoRoles.getFirst();
+
+        // Setup Mock
+        when(techServicesClient.getUser(any())).thenReturn(buildGetUserResponse(false));
+
+        // Fetch audit user drilldown.
+        EntraUser loggedInUser = globalAdmins.getFirst();
+        auditUserDetailsGet(loggedInUser, accessedUser);
+
+        // Get latest user details from DB
+        accessedUser = entraUserRepository.findById(accessedUser.getId()).orElseThrow();
+        assertThat(accessedUser.isEnabled()).isFalse();
+
+        // Teardown
+        accessedUser.setEnabled(true);
+        entraUserRepository.save(accessedUser);
+    }
+
+    @Test
+    public void testUserEnabledStatusIsChangedToEnabledWhenEntraSaysEnabled() throws Exception {
+        EntraUser accessedUser = externalUsersNoRoles.getFirst();
+
+        // Disable accessed user in DB
+        accessedUser.setEnabled(false);
+        accessedUser = entraUserRepository.save(accessedUser);
+
+        // Setup Mock
+        when(techServicesClient.getUser(any())).thenReturn(buildGetUserResponse(true));
+
+        // Fetch audit user drilldown.
+        EntraUser loggedInUser = globalAdmins.getFirst();
+        auditUserDetailsGet(loggedInUser, accessedUser);
+
+        // Get latest user details from DB
+        accessedUser = entraUserRepository.findById(accessedUser.getId()).orElseThrow();
+        assertThat(accessedUser.isEnabled()).isTrue();
+    }
+
+    @Test
+    public void testUserEnabledStatusIsNotChangedWhenEntraMatchesSilas() throws Exception {
+        EntraUser accessedUser = externalUsersNoRoles.getFirst();
+
+        // Setup Mock
+        when(techServicesClient.getUser(any())).thenReturn(buildGetUserResponse(true));
+
+        // Fetch audit user drilldown.
+        EntraUser loggedInUser = globalAdmins.getFirst();
+        auditUserDetailsGet(loggedInUser, accessedUser);
+
+        // Get latest user details from DB
+        accessedUser = entraUserRepository.findById(accessedUser.getId()).orElseThrow();
+        assertThat(accessedUser.isEnabled()).isTrue();
+    }
+
+    private TechServicesApiResponse<GetUserResponse> buildGetUserResponse(boolean enabled) {
+        TechServicesUser techServicesUser = TechServicesUser.builder().accountEnabled(enabled).build();
+        GetUserResponse getUserResponse = GetUserResponse.builder().success(true).message("").user(techServicesUser).build();
+        return TechServicesApiResponse.success(getUserResponse);
+    }
+
+    private MvcResult auditUserDetailsGet(EntraUser loggedInUser, EntraUser accessedUser) throws Exception {
+        return mockMvc.perform(get(String.format("/admin/users/audit/%s?isEntraId=true", accessedUser.getId()))
+                .with(defaultOauth2Login(loggedInUser)))
+                .andExpect(status().isOk())
+                .andReturn();
+    }
+}

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/AuditController.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/controller/AuditController.java
@@ -42,6 +42,7 @@ import uk.gov.justice.laa.portal.landingpage.dto.AuditUserDto;
 import uk.gov.justice.laa.portal.landingpage.dto.CurrentUserDto;
 import uk.gov.justice.laa.portal.landingpage.dto.DeleteUserAttemptAuditEvent;
 import uk.gov.justice.laa.portal.landingpage.dto.DeleteUserSuccessAuditEvent;
+import uk.gov.justice.laa.portal.landingpage.dto.EntraUserDto;
 import uk.gov.justice.laa.portal.landingpage.dto.FirmDto;
 import uk.gov.justice.laa.portal.landingpage.dto.PaginatedAuditUsers;
 import uk.gov.justice.laa.portal.landingpage.entity.DeleteUserReason;
@@ -51,10 +52,12 @@ import uk.gov.justice.laa.portal.landingpage.entity.Permission;
 import uk.gov.justice.laa.portal.landingpage.forms.FirmSearchForm;
 import uk.gov.justice.laa.portal.landingpage.forms.UserTypeForm;
 import uk.gov.justice.laa.portal.landingpage.model.DeletedUser;
+import uk.gov.justice.laa.portal.landingpage.repository.EntraUserRepository;
 import uk.gov.justice.laa.portal.landingpage.service.AccessControlService;
 import uk.gov.justice.laa.portal.landingpage.service.AuditExportService;
 import uk.gov.justice.laa.portal.landingpage.service.AuditExportService.AuditCsvExport;
 import uk.gov.justice.laa.portal.landingpage.service.EventService;
+import uk.gov.justice.laa.portal.landingpage.service.ExternalUserPollingService;
 import uk.gov.justice.laa.portal.landingpage.service.FirmService;
 import uk.gov.justice.laa.portal.landingpage.service.LoginService;
 import uk.gov.justice.laa.portal.landingpage.service.TechServicesClient;
@@ -81,6 +84,8 @@ public class AuditController {
     private final AuthenticatedUser authenticatedUser;
     private final TechServicesClient techServicesClient;
     private final UserAccountStatusService userAccountStatusService;
+    private final ExternalUserPollingService externalUserPollingService;
+    private final EntraUserRepository entraUserRepository;
 
     @Value("${feature.flag.disable.user}")
     private boolean disableUserFeatureEnabled;
@@ -206,11 +211,30 @@ public class AuditController {
         TechServicesApiResponse<GetUserResponse> entraUserResponse = techServicesClient.getUser(userDetail.getEntraOid());
         if (entraUserResponse.isSuccess()) {
             TechServicesUser user = entraUserResponse.getData().getUser();
-            String disableUserReason = formatDisableUserReason(user);
 
             OffsetDateTime lastLoginTime = user.getLastSignIn() != null
                     ? OffsetDateTime.parse(user.getLastSignIn())
                     : null;
+
+            Optional<Boolean> optionalAccountEnabled = Optional.of(entraUserResponse)
+                    .map(TechServicesApiResponse::getData)
+                    .map(GetUserResponse::getUser)
+                    .map(TechServicesUser::getAccountEnabled);
+
+            if (optionalAccountEnabled.isPresent()) {
+                boolean accountEnabled = optionalAccountEnabled.get();
+                if (accountEnabled != userDetail.isEnabled()) {
+                    EntraUser entraUser = entraUserRepository.findById(UUID.fromString(userDetail.getUserId())).orElseThrow();
+                    if (accountEnabled) {
+                        externalUserPollingService.enableUserWithReason(user, entraUser);
+                    } else {
+                        externalUserPollingService.disableUserWithReason(user, entraUser);
+                    }
+                }
+                userDetail.setEnabled(accountEnabled);
+            }
+
+            String disableUserReason = formatDisableUserReason(user);
 
             model.addAttribute("lastLogin", lastLoginTime);
             model.addAttribute("entraUser", entraUserResponse.getData().getUser());

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/service/ExternalUserPollingService.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/service/ExternalUserPollingService.java
@@ -318,7 +318,7 @@ public class ExternalUserPollingService {
         return null;
     }
 
-    private void disableUserWithReason(TechServicesUser user, EntraUser entraUser) {
+    public void disableUserWithReason(TechServicesUser user, EntraUser entraUser) {
         try {
             entraUser.setEnabled(false);
             entraUser.setDisableType(DisableType.SYNC);
@@ -350,7 +350,7 @@ public class ExternalUserPollingService {
         }
     }
 
-    private void enableUserWithReason(TechServicesUser user, EntraUser entraUser) {
+    public void enableUserWithReason(TechServicesUser user, EntraUser entraUser) {
         try {
             entraUser.setEnabled(true);
             entraUserRepository.save(entraUser);

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/AuditControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/controller/AuditControllerTest.java
@@ -60,9 +60,11 @@ import uk.gov.justice.laa.portal.landingpage.entity.UserProfileSilasStatus;
 import uk.gov.justice.laa.portal.landingpage.entity.UserType;
 import uk.gov.justice.laa.portal.landingpage.forms.FirmSearchForm;
 import uk.gov.justice.laa.portal.landingpage.forms.UserTypeForm;
+import uk.gov.justice.laa.portal.landingpage.repository.EntraUserRepository;
 import uk.gov.justice.laa.portal.landingpage.service.AccessControlService;
 import uk.gov.justice.laa.portal.landingpage.service.AuditExportService;
 import uk.gov.justice.laa.portal.landingpage.service.EventService;
+import uk.gov.justice.laa.portal.landingpage.service.ExternalUserPollingService;
 import uk.gov.justice.laa.portal.landingpage.service.FirmService;
 import uk.gov.justice.laa.portal.landingpage.service.LoginService;
 import uk.gov.justice.laa.portal.landingpage.service.TechServicesClient;
@@ -109,6 +111,12 @@ class AuditControllerTest {
     @Mock
     private UserAccountStatusService userAccountStatusService;
 
+    @Mock
+    private ExternalUserPollingService externalUserPollingService;
+
+    @Mock
+    private EntraUserRepository entraUserRepository;
+
     private PaginatedAuditUsers mockPaginatedUsers;
     private List<AppRoleDto> mockSilasRoles;
     private Model model;
@@ -116,7 +124,8 @@ class AuditControllerTest {
     @BeforeEach
     void setUp() {
         auditController = new AuditController(userService, loginService, eventService, accessControlService,
-                auditExportService, firmService, authenticatedUser, techServicesClient, userAccountStatusService);
+                auditExportService, firmService, authenticatedUser, techServicesClient, userAccountStatusService, externalUserPollingService,
+                entraUserRepository);
         model = new ExtendedModelMap();
 
         // Setup mock audit users


### PR DESCRIPTION
### Description :pencil:

User details on the audit drilldown page can often look out of sync if the page fetches from entra after a user's account status has been changed and before the poller has ran. This PR adds some logic to dynamically update a user's account status if it is changed after pulling from entra.

---

### Changes Made :pencil:

- Added logic to change user account status after entra fetch.
- Added integration tests.

---

### Checklist :pencil:

- [X] I have added the relevant Liquibase changelog files for any entity changes
- [X] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [X] I have taken into account the application runs as 3 replicas in live environments
- [X] I have created any relevant documentation for this change
- [X] I have a corresponding JIRA ticket for this change 
- [X] I have added relevant unit & integration tests where applicable

---