### PR TITLE
STB-4269: Remove re-send activation email logic

### DIFF
--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/service/UserService.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/service/UserService.java
@@ -1001,7 +1001,7 @@ public class UserService {
         }
 
         InvitationStatus invitationStatus =
-                respUser.getCustomSecurityAttributes() != null  && respUser.getCustomSecurityAttributes().getGuestUserStatus() != null ?
+                respUser.getCustomSecurityAttributes() != null  && respUser.getCustomSecurityAttributes().getGuestUserStatus().getInvitationProgress() != null ?
                 respUser.getCustomSecurityAttributes().getGuestUserStatus().getInvitationProgress() : null;
         boolean accountEnabled = respUser.getAccountEnabled() == null || respUser.getAccountEnabled();
 

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/service/UserService.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/service/UserService.java
@@ -1007,7 +1007,7 @@ public class UserService {
         boolean accountEnabled = respUser.getAccountEnabled() == null || respUser.getAccountEnabled();
 
         // AwaitingVerification users are handled by Entra/Technical Services.
-        if (InvitationStatus.AWAITING_VERIFICATION.equals(invitationStatus)) {
+        if (invitationStatus.filter(status -> status == InvitationStatus.AWAITING_VERIFICATION).isPresent()) {
             logger.info("User {} is awaiting verification. Activation email sent from Tech Services",
                     newUser.getEntraOid());
             syncUserStatus(respUser, newUser);

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/service/UserService.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/service/UserService.java
@@ -1001,8 +1001,8 @@ public class UserService {
         }
 
         InvitationStatus invitationStatus =
-                respUser.getCustomSecurityAttributes() != null  && respUser.getCustomSecurityAttributes().getGuestUserStatus().getInvitationProgress() != null ?
-                respUser.getCustomSecurityAttributes().getGuestUserStatus().getInvitationProgress() : null;
+                respUser.getCustomSecurityAttributes() != null  && respUser.getCustomSecurityAttributes().getGuestUserStatus().getInvitationProgress() != null
+                        ? respUser.getCustomSecurityAttributes().getGuestUserStatus().getInvitationProgress() : null;
         boolean accountEnabled = respUser.getAccountEnabled() == null || respUser.getAccountEnabled();
 
         // AwaitingVerification users are handled by Entra/Technical Services.

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/service/UserService.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/service/UserService.java
@@ -1000,9 +1000,10 @@ public class UserService {
             return;
         }
 
-        InvitationStatus invitationStatus =
-                respUser.getCustomSecurityAttributes() != null  && respUser.getCustomSecurityAttributes().getGuestUserStatus().getInvitationProgress() != null
-                        ? respUser.getCustomSecurityAttributes().getGuestUserStatus().getInvitationProgress() : null;
+        Optional<InvitationStatus> invitationStatus = Optional.of(respUser)
+                .map(TechServicesUser::getCustomSecurityAttributes)
+                .map(TechServicesUser.CustomSecurityAttributes::getGuestUserStatus)
+                .map(TechServicesUser.GuestUserStatus::getInvitationProgress);
         boolean accountEnabled = respUser.getAccountEnabled() == null || respUser.getAccountEnabled();
 
         // AwaitingVerification users are handled by Entra/Technical Services.

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/service/UserService.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/service/UserService.java
@@ -993,48 +993,22 @@ public class UserService {
         }
     }
 
-    private void triggerResendActivation(EntraUser user) {
-        TechServicesApiResponse<SendUserVerificationEmailResponse> verificationResponse = techServicesClient.sendEmailVerification(mapper.map(user, EntraUserDto.class));
-        if (!verificationResponse.isSuccess()) {
-            logger.error("Failed to send verification email for user {}. Error: {}", user.getEntraOid(),
-                    verificationResponse.getError().getMessage()
-            );
-
-        }
-        logger.info("Resend activation email triggered for user: {}", user.getEntraOid());
-    }
-
     private void handleExistingUserScenario(TechServicesUser respUser, EntraUser newUser) {
 
         if (respUser == null) {
-            logger.error("Existing user response is null in handleExistingUserScenario for user: {}",
-                    newUser.getEntraOid());
+            logger.error("Existing user response is null in handleExistingUserScenario for user: {}", newUser.getEntraOid());
             return;
         }
 
-        String deleteReason = null;
-        String verificationStatus = null;
-        Boolean accountEnabled = true;
+        InvitationStatus invitationStatus = respUser.getCustomSecurityAttributes() != null ?
+                respUser.getCustomSecurityAttributes().getGuestUserStatus().getInvitationProgress() : null;
+        boolean accountEnabled = respUser.getAccountEnabled() == null || respUser.getAccountEnabled();
 
-        if (respUser != null) {
-            accountEnabled = respUser.getAccountEnabled() != null ? respUser.getAccountEnabled() : true;
-            if (respUser.getCustomSecurityAttributes() != null && respUser.getCustomSecurityAttributes().getGuestUserStatus() != null) {
-                deleteReason = respUser.getCustomSecurityAttributes().getGuestUserStatus().getDisabledReason();
-                if (respUser.getCustomSecurityAttributes().getGuestUserStatus().getInvitationProgress() != null) {
-                    verificationStatus = respUser.getCustomSecurityAttributes().getGuestUserStatus().getInvitationProgress().name();
-                }
-            }
-            if (respUser.getVerification() != null && respUser.getVerification().getStatus() != null) {
-                verificationStatus = respUser.getVerification().getStatus();
-            }
-        }
-
-        // Scenario: Never activated OR awaiting verification -> trigger resend activation
-        if ((deleteReason != null && "ExpiredInvitation".equalsIgnoreCase(deleteReason))
-                || (verificationStatus != null && InvitationStatus.AWAITING_VERIFICATION.toString().equalsIgnoreCase(verificationStatus))) {
-            logger.info("Triggering resend activation for user: {}", newUser.getEntraOid());
+        // AwaitingVerification users are handled by Entra/Technical Services.
+        if (InvitationStatus.AWAITING_VERIFICATION.equals(invitationStatus)) {
+            logger.info("User {} is awaiting verification. Activation email sent from Tech Services",
+                    newUser.getEntraOid());
             syncUserStatus(respUser, newUser);
-            triggerResendActivation(newUser);
             return;
         }
 

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/service/UserService.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/service/UserService.java
@@ -1000,7 +1000,8 @@ public class UserService {
             return;
         }
 
-        InvitationStatus invitationStatus = respUser.getCustomSecurityAttributes() != null ?
+        InvitationStatus invitationStatus =
+                respUser.getCustomSecurityAttributes() != null  && respUser.getCustomSecurityAttributes().getGuestUserStatus() != null ?
                 respUser.getCustomSecurityAttributes().getGuestUserStatus().getInvitationProgress() : null;
         boolean accountEnabled = respUser.getAccountEnabled() == null || respUser.getAccountEnabled();
 

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/service/UserServiceTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/service/UserServiceTest.java
@@ -3436,157 +3436,105 @@ class UserServiceTest {
         }
 
         @Test
-        void createUser_existingActiveUser_sendsGovNotify() {
+        void createUser_existingUser_notAwaitingVerification_sendsGovNotify() {
             // Arrange
             EntraUserDto user = new EntraUserDto();
             user.setEmail("existing@example.com");
             user.setFirstName("John");
-            user.setLastName("Smith");
 
-            when(mockEntraUserRepository.saveAndFlush(any(EntraUser.class))).thenAnswer(i -> {
-                EntraUser eu = i.getArgument(0);
-                eu.setId(UUID.randomUUID());
-                return eu;
-            });
+            when(mockEntraUserRepository.saveAndFlush(any(EntraUser.class)))
+                    .thenAnswer(i -> {
+                        EntraUser eu = i.getArgument(0);
+                        eu.setId(UUID.randomUUID());
+                        return eu;
+                    });
 
             TechServicesUser respUser = TechServicesUser.builder()
                     .id(UUID.randomUUID().toString())
                     .email("existing@example.com")
                     .accountEnabled(true)
+                    .customSecurityAttributes(
+                            TechServicesUser.CustomSecurityAttributes.builder()
+                                    .guestUserStatus(
+                                            TechServicesUser.GuestUserStatus.builder()
+                                                    .invitationProgress(InvitationStatus.VERIFICATION_SUCCESS)
+                                                    .build())
+                                    .build())
                     .build();
 
-            TechServicesApiResponse<RegisterUserResponse> registerUserResponse = TechServicesApiResponse
-                    .success(RegisterUserResponse.builder()
-                            .responseType(RegisterUserResponse.ResponseType.VERIFIED)
-                            .message("User already exists. Group memberships updated successfully.")
-                            .user(respUser).build());
-            when(techServicesClient.registerNewUser(any(EntraUserDto.class))).thenReturn(registerUserResponse);
+            TechServicesApiResponse<RegisterUserResponse> registerUserResponse =
+                    TechServicesApiResponse.success(
+                            RegisterUserResponse.builder()
+                                    .responseType(RegisterUserResponse.ResponseType.VERIFIED)
+                                    .user(respUser)
+                                    .build());
 
-            FirmDto firmDto = FirmDto.builder().name("Test Firm").build();
+            when(techServicesClient.registerNewUser(any(EntraUserDto.class)))
+                    .thenReturn(registerUserResponse);
+
+            FirmDto firmDto = FirmDto.builder()
+                    .name("Test Firm")
+                    .build();
 
             // Act
             userService.createUser(user, firmDto, false, "admin", false);
 
             // Assert
-            verify(notificationService, times(1)).notifyExistingUser(any(), eq("John"), eq("existing@example.com"));
-            verify(techServicesClient, never()).sendEmailVerification(any(EntraUserDto.class));
+            verify(notificationService).notifyExistingUser(
+                    any(),
+                    eq("John"),
+                    eq("existing@example.com"));
         }
 
         @Test
-        void createUser_expiredInvitation_triggersResendActivation() {
-            // Arrange
-            EntraUserDto user = new EntraUserDto();
-            user.setEmail("expired@example.com");
-            user.setFirstName("Jane");
-
-            when(mockEntraUserRepository.saveAndFlush(any(EntraUser.class))).thenAnswer(i -> {
-                EntraUser eu = i.getArgument(0);
-                eu.setId(UUID.randomUUID());
-                return eu;
-            });
-
-            TechServicesUser respUser = TechServicesUser.builder()
-                    .id(UUID.randomUUID().toString())
-                    .email("expired@example.com")
-                    .accountEnabled(false)
-                    .customSecurityAttributes(TechServicesUser.CustomSecurityAttributes.builder()
-                            .guestUserStatus(TechServicesUser.GuestUserStatus.builder()
-                                    .disabledReason("ExpiredInvitation").build()).build())
-                    .build();
-
-            TechServicesApiResponse<RegisterUserResponse> registerUserResponse = TechServicesApiResponse
-                    .success(RegisterUserResponse.builder()
-                            .responseType(RegisterUserResponse.ResponseType.VERIFIED)
-                            .message("User already exists")
-                            .user(respUser).build());
-            when(techServicesClient.registerNewUser(any(EntraUserDto.class))).thenReturn(registerUserResponse);
-            when(techServicesClient.sendEmailVerification(any(EntraUserDto.class)))
-                    .thenReturn(TechServicesApiResponse.success(SendUserVerificationEmailResponse.builder().success(true).message("sent").build()));
-
-            FirmDto firmDto = FirmDto.builder().name("Test Firm").build();
-
-            // Act
-            userService.createUser(user, firmDto, false, "admin", false);
-
-            // Assert
-            verify(techServicesClient, times(1)).sendEmailVerification(any(EntraUserDto.class));
-            verify(notificationService, never()).notifyExistingUser(any(), anyString(), anyString());
-        }
-
-        @Test
-        void createUser_awaitingVerification_triggersResendActivation() {
+        void createUser_existingUser_awaitingVerification_doesNotSendGovNotify() {
             // Arrange
             EntraUserDto user = new EntraUserDto();
             user.setEmail("awaiting@example.com");
             user.setFirstName("Alex");
 
-            when(mockEntraUserRepository.saveAndFlush(any(EntraUser.class))).thenAnswer(i -> {
-                EntraUser eu = i.getArgument(0);
-                eu.setId(UUID.randomUUID());
-                return eu;
-            });
+            when(mockEntraUserRepository.saveAndFlush(any(EntraUser.class)))
+                    .thenAnswer(i -> {
+                        EntraUser eu = i.getArgument(0);
+                        eu.setId(UUID.randomUUID());
+                        return eu;
+                    });
 
             TechServicesUser respUser = TechServicesUser.builder()
                     .id(UUID.randomUUID().toString())
                     .email("awaiting@example.com")
-                    .accountEnabled(false)
-                    .verification(TechServicesUser.VerificationStatus.builder()
-                            .status("AwaitingVerification").build())
-                    .build();
-
-            TechServicesApiResponse<RegisterUserResponse> registerUserResponse = TechServicesApiResponse
-                    .success(RegisterUserResponse.builder()
-                            .responseType(RegisterUserResponse.ResponseType.VERIFIED)
-                            .message("User already exists")
-                            .user(respUser)
-                            .build());
-            when(techServicesClient.registerNewUser(any(EntraUserDto.class))).thenReturn(registerUserResponse);
-            when(techServicesClient.sendEmailVerification(any(EntraUserDto.class)))
-                    .thenReturn(TechServicesApiResponse.success(SendUserVerificationEmailResponse.builder().success(true).message("sent").build()));
-
-            FirmDto firmDto = FirmDto.builder().name("Test Firm").build();
-
-            // Act
-            userService.createUser(user, firmDto, false, "admin", false);
-
-            // Assert
-            verify(techServicesClient, times(1)).sendEmailVerification(any(EntraUserDto.class));
-            verify(notificationService, never()).notifyExistingUser(any(), anyString(), anyString());
-        }
-
-        @Test
-        void createUser_newUser_doesNotSendNotifyOrResend() {
-            // Arrange
-            EntraUserDto user = new EntraUserDto();
-            user.setEmail("new@example.com");
-            user.setFirstName("New");
-
-            when(mockEntraUserRepository.saveAndFlush(any(EntraUser.class))).thenAnswer(i -> {
-                EntraUser eu = i.getArgument(0);
-                eu.setId(UUID.randomUUID());
-                return eu;
-            });
-
-            TechServicesUser createdUser = TechServicesUser.builder()
-                    .id(UUID.randomUUID().toString())
-                    .email("new@example.com")
                     .accountEnabled(true)
+                    .customSecurityAttributes(
+                            TechServicesUser.CustomSecurityAttributes.builder()
+                                    .guestUserStatus(
+                                            TechServicesUser.GuestUserStatus.builder()
+                                                    .invitationProgress(InvitationStatus.AWAITING_VERIFICATION)
+                                                    .build())
+                                    .build())
                     .build();
 
-            TechServicesApiResponse<RegisterUserResponse> registerUserResponse = TechServicesApiResponse
-                    .success(RegisterUserResponse.builder()
-                            .message("User created successfully")
-                            .user(createdUser).build());
-            when(techServicesClient.registerNewUser(any(EntraUserDto.class))).thenReturn(registerUserResponse);
+            TechServicesApiResponse<RegisterUserResponse> registerUserResponse =
+                    TechServicesApiResponse.success(
+                            RegisterUserResponse.builder()
+                                    .responseType(RegisterUserResponse.ResponseType.VERIFIED)
+                                    .user(respUser)
+                                    .build());
 
-            FirmDto firmDto = FirmDto.builder().name("Test Firm").build();
+            when(techServicesClient.registerNewUser(any(EntraUserDto.class)))
+                    .thenReturn(registerUserResponse);
+
+            FirmDto firmDto = FirmDto.builder()
+                    .name("Test Firm")
+                    .build();
 
             // Act
             userService.createUser(user, firmDto, false, "admin", false);
 
             // Assert
-            verify(notificationService, never()).notifyExistingUser(any(), anyString(), anyString());
-            verify(techServicesClient, never()).sendEmailVerification(any(EntraUserDto.class));
+            verify(notificationService, never()).notifyExistingUser(
+                    any(),
+                    anyString(),
+                    anyString());
         }
     }
 


### PR DESCRIPTION
### Description :pencil:

Second PR for story 4269, story has been updated to adjust logic

https://dsdmoj.atlassian.net/browse/STB-4269

---

### Changes Made :pencil:

- No longer checking for DisabledReason
- Notify email gets sent when Invitation Status != "AwaitingVerification"
- Refctor logic and simplify code
- Remove re-send activation email logic as tech services handles this

---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [x] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [x] I have a corresponding JIRA ticket for this change 
- [x] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:

Please fill in.

---