### PR TITLE
STB-4269: add INVITE_SENT check to notification logic

### DIFF
--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/service/UserService.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/service/UserService.java
@@ -1006,8 +1006,9 @@ public class UserService {
                 .map(TechServicesUser.GuestUserStatus::getInvitationProgress);
         boolean accountEnabled = respUser.getAccountEnabled() == null || respUser.getAccountEnabled();
 
-        // AwaitingVerification users are handled by Entra/Technical Services.
-        if (invitationStatus.filter(status -> status == InvitationStatus.AWAITING_VERIFICATION).isPresent()) {
+        // AwaitingVerification and InviteSent users are handled by Entra/Technical Services.
+        if (invitationStatus.filter(status -> status == InvitationStatus.AWAITING_VERIFICATION || status ==
+                InvitationStatus.INVITE_SENT).isPresent()) {
             logger.info("User {} is awaiting verification. Activation email sent from Tech Services",
                     newUser.getEntraOid());
             syncUserStatus(respUser, newUser);

--- a/src/main/java/uk/gov/justice/laa/portal/landingpage/service/UserService.java
+++ b/src/main/java/uk/gov/justice/laa/portal/landingpage/service/UserService.java
@@ -1007,8 +1007,8 @@ public class UserService {
         boolean accountEnabled = respUser.getAccountEnabled() == null || respUser.getAccountEnabled();
 
         // AwaitingVerification and InviteSent users are handled by Entra/Technical Services.
-        if (invitationStatus.filter(status -> status == InvitationStatus.AWAITING_VERIFICATION || status ==
-                InvitationStatus.INVITE_SENT).isPresent()) {
+        if (invitationStatus.filter(status -> status == InvitationStatus.AWAITING_VERIFICATION || status
+                == InvitationStatus.INVITE_SENT).isPresent()) {
             logger.info("User {} is awaiting verification. Activation email sent from Tech Services",
                     newUser.getEntraOid());
             syncUserStatus(respUser, newUser);

--- a/src/test/java/uk/gov/justice/laa/portal/landingpage/service/UserServiceTest.java
+++ b/src/test/java/uk/gov/justice/laa/portal/landingpage/service/UserServiceTest.java
@@ -3536,6 +3536,57 @@ class UserServiceTest {
                     anyString(),
                     anyString());
         }
+
+        @Test
+        void createUser_existingUser_inviteSent_doesNotSendGovNotify() {
+            // Arrange
+            EntraUserDto user = new EntraUserDto();
+            user.setEmail("awaiting@example.com");
+            user.setFirstName("Alex");
+
+            when(mockEntraUserRepository.saveAndFlush(any(EntraUser.class)))
+                    .thenAnswer(i -> {
+                        EntraUser eu = i.getArgument(0);
+                        eu.setId(UUID.randomUUID());
+                        return eu;
+                    });
+
+            TechServicesUser respUser = TechServicesUser.builder()
+                    .id(UUID.randomUUID().toString())
+                    .email("awaiting@example.com")
+                    .accountEnabled(true)
+                    .customSecurityAttributes(
+                            TechServicesUser.CustomSecurityAttributes.builder()
+                                    .guestUserStatus(
+                                            TechServicesUser.GuestUserStatus.builder()
+                                                    .invitationProgress(InvitationStatus.INVITE_SENT)
+                                                    .build())
+                                    .build())
+                    .build();
+
+            TechServicesApiResponse<RegisterUserResponse> registerUserResponse =
+                    TechServicesApiResponse.success(
+                            RegisterUserResponse.builder()
+                                    .responseType(RegisterUserResponse.ResponseType.VERIFIED)
+                                    .user(respUser)
+                                    .build());
+
+            when(techServicesClient.registerNewUser(any(EntraUserDto.class)))
+                    .thenReturn(registerUserResponse);
+
+            FirmDto firmDto = FirmDto.builder()
+                    .name("Test Firm")
+                    .build();
+
+            // Act
+            userService.createUser(user, firmDto, false, "admin", false);
+
+            // Assert
+            verify(notificationService, never()).notifyExistingUser(
+                    any(),
+                    anyString(),
+                    anyString());
+        }
     }
 
     @Nested


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/STB-4269

### Description :pencil:

Please fill in.

---

### Changes Made :pencil:

- add INVITE_SENT check to logic, now checks if either AWAITING_VERIFICATION or INVITE_SENT when assessing if we send notification or allow TS to send re-activation email
- 
- 

---

### Checklist :pencil:

- [ ] I have added the relevant Liquibase changelog files for any entity changes
- [ ] I have added any new Environment Variables to the deployment template, deployment pipeline and GitHub Secrets.
- [ ] I have taken into account the application runs as 3 replicas in live environments
- [ ] I have created any relevant documentation for this change
- [ ] I have a corresponding JIRA ticket for this change 
- [x] I have added relevant unit & integration tests where applicable

---

### Additional Context :pencil:

Please fill in.

---